### PR TITLE
♻️ refactor: retire develop branch references

### DIFF
--- a/.claude/commands/publish-check.md
+++ b/.claude/commands/publish-check.md
@@ -7,7 +7,8 @@
    `package.json`의 `"private"` 필드를 확인한다. `true`로 되어 있으면 `publish.yml`의
    "Publish to npm" 스텝이 자동으로 건너뛰어진다(`private`이 아닐 때만 실행). 실제
    npm 공개 배포를 시작하려면 `false`로 바꾸고 `publishConfig.access: "public"`을
-   추가해야 한다는 점을 보고한다.
+   추가해야 한다는 점을 보고한다. (최초 배포는 npm의 OIDC Trusted Publisher 등록
+   전이라 별도 부트스트랩이 필요 — 진행 시 안내한다.)
 
 2. **타입 체크**
 
@@ -26,25 +27,23 @@
    빌드 실패 시 오류 내용을 보고하고 중단한다. (`build` 스크립트가 내부적으로
    `check-types`를 다시 실행하므로 2번과 중복 실행되어도 정상이다.)
 
-4. **CHANGELOG.md `Unreleased` 상태 확인**
+4. **버전 상태 확인**
 
-   `CHANGELOG.md`의 `## [Unreleased]` 섹션을 확인한다.
-   - `<!-- next-bump: ... -->` 마커와 `### ` 하위 섹션이 없으면 경고: 다음 `main`
-     푸시에서 `promote-changelog.mjs`가 승격할 내용이 없음
-   - 마커가 있으면 예정된 bump 타입과 누적된 변경 항목을 요약해서 보고
+   ```bash
+   node -p "require('./package.json').version"
+   npm view @jbpark/live-editor version 2>/dev/null || echo "not published yet"
+   ```
 
-5. **package.json 버전 확인**
-   - `package.json`의 `version` 필드 출력
-   - npm 최신 버전과 비교: `npm view @jbpark/live-editor version 2>/dev/null || echo "not published yet"`
+   - `package.json` 버전이 npm 최신 버전보다 앞서 있으면, changesets의 "Version Packages" PR이 `main`에 이미 머지되어 버전을 승격시킨 상태 — 다음 `main` push 시 `publish.yml`이 자동으로 빌드/(공개 패키지면 퍼블리시)/태그한다.
+   - 두 버전이 같으면 아직 승격할 변경사항이 없다는 뜻(= `.changeset/*.md`가 없거나 아직 Version Packages PR이 머지 안 됨). `CHANGELOG.md` 최상단 섹션이 최신 버전과 일치하는지로도 확인 가능.
 
-6. **exports 필드 확인**
+5. **exports 필드 확인**
    - `package.json`의 `exports` 필드(`.`, `./utils`, `./utils/ast`, `./utils/tailwind`, `./style.css`)에
      새로 추가된 진입점이 누락되지 않았는지 확인
    - `src/index.ts` 및 관련 서브패스 파일들의 실제 export 목록과 대조
 
-7. **최종 요약**
+6. **최종 요약**
    통과/실패 항목을 표로 정리한다. `private: true`가 아직 남아 있으면 최우선 경고로 표시하고,
-   문제가 없으면 배포 흐름을 안내한다:
-   - `develop` 푸시 → `changelog-develop.yml`이 `CHANGELOG.md`의 `Unreleased`에 항목 누적
-   - `develop`이 `main`으로 머지 → `publish.yml`이 `Unreleased`를 버전으로 승격해 릴리스 PR 생성
-   - 릴리스 PR 머지 → 빌드 + 태그 생성 (+ `private`이 아니면 npm 배포)까지 자동 실행
+   문제가 없으면 배포 흐름을 안내한다: 별도 수동 퍼블리시 명령은 없다 — `main`에 changeset이
+   쌓이면 "Version Packages" PR이 열리고, 그 PR을 머지하면 `publish.yml`이 자동으로
+   빌드/(공개 패키지면 퍼블리시)/태그/GitHub Release까지 처리한다.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   lint-and-build:

--- a/README.ko.md
+++ b/README.ko.md
@@ -100,18 +100,18 @@ pnpm run preview
 
 ## 📦 버전 관리 & 배포
 
-이 프로젝트는 `develop` → `main` 브랜치 흐름과 AI 기반 자동 릴리스 노트를 사용합니다 — 수동 changeset 파일이 없습니다:
+배포는 [changesets](https://github.com/changesets/changesets)로 완전히 자동화되어 있습니다:
 
-- **기능 브랜치**는 `develop`으로 머지합니다.
-- `develop`에 푸시할 때마다 워크플로우가 diff를 분석해 `CHANGELOG.md`의 `## [Unreleased]` 섹션에 항목을 추가합니다 (아직 버전은 올리지 않음).
-- `develop`이 `main`으로 머지되면 그 `Unreleased` 섹션에 버전과 날짜가 확정되고 `package.json` 버전도 함께 올라간 뒤, 릴리스 PR로 열립니다.
-- 릴리스 PR을 머지하면 빌드, 태그 생성, (이 패키지가 공개로 전환되면) npm 배포가 실행됩니다.
+- `main`으로 향하는 PR마다 AI가 변경 내용을 요약한 changeset 파일을 초안으로 작성합니다.
+- `main`에 changeset들이 쌓이면 "Version Packages" PR이 `package.json`의 버전을 승격시키고 `CHANGELOG.md`를 정리합니다.
+- 이 PR을 머지하면 빌드, 태그 생성, (이 패키지가 공개로 전환되면) npm 배포가 실행됩니다.
 
 CI 워크플로우:
 
-- `changelog-develop.yml`: `develop` 푸시마다 AI가 생성한 changelog 항목을 추가
-- `publish.yml`: `Unreleased`를 릴리스 PR로 승격하고, 머지 시 빌드/배포/태그 실행
-- `release.yml`: 태그 푸시 시 GitHub Release 생성 (예: `v1.2.3`)
+- `changeset-draft.yml`: `main` 대상 PR이 열리거나 갱신될 때 AI가 changeset 초안을 작성
+- `version.yml`: changeset이 쌓이면 "Version Packages" PR을 열거나 갱신
+- `publish.yml`: `main` 머지 시 버전이 미태그 상태면 빌드/(공개 패키지면 배포)/태그/GitHub Release 생성
+- `release.yml`: 기존 태그에 대한 GitHub Release를 수동(`workflow_dispatch`)으로 재생성하는 백업 유틸리티
 - `docs-deploy.yml`: 빌드 후 `dist/`를 GitHub Pages에 배포
 
 참고: GitHub Pages 사용 시 저장소 설정에서 Pages Source를 "GitHub Actions"로 지정하세요. 저장소 서브경로로 배포한다면 `vite.config.ts`의 `base` 값을 경로에 맞게 설정해야 합니다.

--- a/README.md
+++ b/README.md
@@ -100,18 +100,18 @@ pnpm run preview
 
 ## 📦 Versioning & Release
 
-This project uses a `develop` → `main` branch flow with automated, AI-assisted release notes — no manual changeset files:
+Releases are fully automated via [changesets](https://github.com/changesets/changesets):
 
-- **Feature branches** merge into `develop`.
-- On every push to `develop`, a workflow analyzes the diff and appends bullet points to the `## [Unreleased]` section of `CHANGELOG.md` (no version bump yet).
-- When `develop` is merged into `main`, that `Unreleased` section is stamped with a version + date and `package.json` is bumped to match, opened as a release PR.
-- Merging the release PR builds, tags the release, and (once this package is made public) publishes to npm.
+- Each PR against `main` gets an AI-drafted changeset file describing its change.
+- Once changesets accumulate on `main`, a "Version Packages" PR bumps `package.json`'s version and consolidates `CHANGELOG.md`.
+- Merging that PR builds, tags the release, and (once this package is made public) publishes to npm.
 
 CI workflows:
 
-- `changelog-develop.yml`: Appends AI-generated changelog bullets on every `develop` push.
-- `publish.yml`: Promotes `Unreleased` into a release PR, then builds/publishes/tags on merge.
-- `release.yml`: Creates GitHub Releases on tag push (e.g., `v1.2.3`).
+- `changeset-draft.yml`: Drafts an AI-generated changeset on PR open/sync against `main`.
+- `version.yml`: Opens/updates the "Version Packages" PR once changesets accumulate.
+- `publish.yml`: Builds/(publishes if public)/tags/creates the GitHub Release on merge to `main` when the version is untagged.
+- `release.yml`: Manual `workflow_dispatch` fallback to (re)create a GitHub Release for an existing tag.
 - `docs-deploy.yml`: Builds and deploys `dist/` to GitHub Pages.
 
 Note: For GitHub Pages, set the repository Pages source to “GitHub Actions”. If deploying under a repo subpath, configure `base` in `vite.config.ts` accordingly.


### PR DESCRIPTION
## Summary
- `ci.yml`: drop `develop` from push/pull_request triggers
- Update `README.md`, `README.ko.md`, `.claude/commands/publish-check.md` to describe the current main-only changesets release flow instead of the old develop → main sync

`develop` branch itself will be deleted as a separate step after this merges (safe to delete: fully synced into main by PR #18, no unique commits).

## Test plan
- [x] `pnpm run lint` — clean
- [x] `tsc -b` — 0 errors
- [x] `pnpm run build` — succeeds
- [ ] CI passes