### PR TITLE
fix: stop evaluating panel field values with new Function

### DIFF
--- a/.changeset/pr-25.md
+++ b/.changeset/pr-25.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Introduce evaluateLiteral function to convert AST nodes to pure literal values without executing code, enhancing the handling of object and array expressions.

--- a/src/utils/ast/value.ts
+++ b/src/utils/ast/value.ts
@@ -24,6 +24,69 @@ const dedent = (str: string): string => {
     : lines.map(line => line.slice(indent)).join('\n');
 };
 
+// AST 노드를 코드 실행(new Function/eval) 없이 순수 리터럴 구조만 재귀적으로
+// 실제 JS 값으로 변환한다. 함수 호출, 변수 참조 등 리터럴이 아닌 표현식은
+// 평가하지 않고 undefined를 반환한다 — 사용자 코드는 iframe 안에서만 실행한다는
+// 이 저장소의 원칙(AGENTS.md)을 이 패널 UI(메인 문서에서 렌더링됨)에서도 지키기 위함.
+const evaluateLiteral = (node: t.Node): unknown => {
+  if (t.isStringLiteral(node)) {
+    return node.value;
+  }
+
+  if (t.isNumericLiteral(node)) {
+    return node.value;
+  }
+
+  if (t.isBooleanLiteral(node)) {
+    return node.value;
+  }
+
+  if (t.isNullLiteral(node)) {
+    return null;
+  }
+
+  if (t.isIdentifier(node) && node.name === 'undefined') {
+    return undefined;
+  }
+
+  if (
+    t.isUnaryExpression(node) &&
+    node.operator === '-' &&
+    t.isNumericLiteral(node.argument)
+  ) {
+    return -node.argument.value;
+  }
+
+  if (t.isTemplateLiteral(node) && node.expressions.length === 0) {
+    return node.quasis[0]?.value.cooked ?? node.quasis[0]?.value.raw ?? '';
+  }
+
+  if (t.isJSXElement(node) || t.isJSXFragment(node)) {
+    return generateCode(node);
+  }
+
+  if (t.isArrayExpression(node)) {
+    return node.elements.map(element =>
+      element ? evaluateLiteral(element) : null,
+    );
+  }
+
+  if (t.isObjectExpression(node)) {
+    const result: Record<string, unknown> = {};
+
+    for (const prop of node.properties) {
+      if (!t.isObjectProperty(prop) || !t.isIdentifier(prop.key)) {
+        continue;
+      }
+      result[prop.key.name] = evaluateLiteral(prop.value);
+    }
+
+    return result;
+  }
+
+  return undefined;
+};
+
 export const parseValue = (value: unknown): unknown => {
   if (typeof value !== 'string') {
     return value;
@@ -59,35 +122,18 @@ export const parseValue = (value: unknown): unknown => {
     (trimmed.startsWith('[') && trimmed.endsWith(']'))
   ) {
     try {
-      return new Function(`return (${trimmed})`)();
-    } catch {
-      try {
-        const ast = parseExpression(trimmed, {
-          plugins: ['jsx', 'typescript'],
-        });
+      const ast = parseExpression(trimmed, {
+        plugins: ['jsx', 'typescript'],
+      });
 
-        if (t.isObjectExpression(ast)) {
-          const result: Record<string, unknown> = {};
-
-          for (const prop of ast.properties) {
-            if (!t.isObjectProperty(prop) || !t.isIdentifier(prop.key)) {
-              continue;
-            }
-            if (t.isJSXElement(prop.value) || t.isJSXFragment(prop.value)) {
-              result[prop.key.name] = generateCode(prop.value);
-              continue;
-            }
-            result[prop.key.name] = extractNodeValue(prop.value).value;
-          }
-
-          return result;
-        }
-      } catch {
-        /* ignore */
+      if (t.isObjectExpression(ast) || t.isArrayExpression(ast)) {
+        return evaluateLiteral(ast);
       }
-
-      return value;
+    } catch {
+      /* ignore */
     }
+
+    return value;
   }
 
   return value;


### PR DESCRIPTION
## Summary
- `Dnd/Panel/Field`, `Dnd/Panel/Items`가 사용하는 `parseValue()`가 `new Function('return (' + trimmed + ')')()`로 프로퍼티 패널에 입력된 객체/배열 리터럴 텍스트를 **메인 문서(iframe 밖)에서 직접 실행**하고 있었음
- `AGENTS.md`의 "사용자 코드 직접 실행 금지 — 반드시 compile() 통해 캐시 후 iframe 내부에서만 실행" 원칙 위반
- `new Function` 호출을 제거하고, Babel AST를 재귀 순회해 리터럴 구조(문자열/숫자/불리언/null/배열/객체/JSX)만 실제 값으로 변환하는 `evaluateLiteral()`로 교체. 함수 호출·변수 참조 등 리터럴이 아닌 표현식은 실행하지 않고 무시함(undefined)

## Test plan
- [x] `pnpm check-types` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과
- [x] `tsx`로 직접 재현: 중첩 객체/배열 리터럴이 기존과 동일하게 실제 값으로 파싱됨을 확인
- [x] 동일한 방법으로 `{ x: (globalThis.__pwned = true) }` 같은 악성 페이로드가 더 이상 실행되지 않음을 확인 (`__pwned` 그대로 `false`)