### PR TITLE
fix: use function replacer to avoid $-pattern corruption

### DIFF
--- a/.changeset/pr-27.md
+++ b/.changeset/pr-27.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Prevent incorrect replacements in JSX placeholders by using function-based replacements to handle special characters.

--- a/src/components/Dnd/Panel/Items/index.tsx
+++ b/src/components/Dnd/Panel/Items/index.tsx
@@ -308,7 +308,9 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
     }
 
     for (const [placeholder, code] of jsxPlaceholders) {
-      nextValue = nextValue.replace(placeholder, code);
+      // 두 번째 인자가 문자열이면 $&, $$ 같은 특수 치환 패턴으로 해석되어
+      // code 안에 그런 문자가 있으면 결과가 깨진다 — 함수형 치환자로 방지.
+      nextValue = nextValue.replace(placeholder, () => code);
     }
 
     onChange?.(nextValue);

--- a/src/utils/ast/update.ts
+++ b/src/utils/ast/update.ts
@@ -251,7 +251,9 @@ export const update = (
     let result = unwrap(generateCode(ast));
 
     for (const [placeholder, original] of jsxPlaceholders) {
-      result = result.replace(placeholder, original);
+      // 두 번째 인자가 문자열이면 $&, $$ 같은 특수 치환 패턴으로 해석되어
+      // original 안에 그런 문자가 있으면 결과가 깨진다 — 함수형 치환자로 방지.
+      result = result.replace(placeholder, () => original);
     }
 
     return result;


### PR DESCRIPTION
## Summary
- `update.ts`, `Dnd/Panel/Items/index.tsx`의 placeholder 치환 로직이 `result.replace(placeholder, original)` 형태로 문자열을 두 번째 인자로 넘기고 있었음
- `String.prototype.replace`는 문자열 두 번째 인자를 `$&`, `$$`, `` $` ``, `$'` 같은 특수 치환 패턴으로 해석하므로, richtext/innerHTML/jsx 바인딩 값에 그런 문자가 섞이면 결과가 조용히 깨짐
- 재현: `node -e "console.log('{ph}'.replace('{ph}', 'Price: \$& off'))"` → `"Price: {ph} off"` (기대값과 다름)
- 같은 파일군의 `tree.ts`는 이미 함수형 치환자를 쓰고 있어 문제가 없었음 — `update.ts`/`Items.tsx`만 누락된 것으로 보여 동일하게 `.replace(placeholder, () => value)`로 통일

## Test plan
- [x] `pnpm check-types` 통과
- [x] `pnpm lint` 통과
- [x] `pnpm build` 통과
- [x] Node로 `$`-패턴 치환 동작 자체를 직접 재현/검증 (수정 전후 비교)