### PR TITLE
chore: mark package public and set publishConfig.access

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@jbpark/live-editor",
-  "private": true,
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.1.0",
   "type": "module",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Prep step for the first real npm publish of `@jbpark/live-editor`.

- Flip `private: true` → `false` — this is the flag `.github/workflows/publish.yml`'s "Publish to npm" step checks; it's currently a no-op regardless of version bumps
- Add `publishConfig.access: "public"`, matching the existing `@jbpark/use-hooks` package — required for a scoped (`@jbpark/*`) package to publish publicly instead of defaulting to a private/paid-org package

## Not done here (separate, manual steps)

- Merging this alone does **not** trigger a publish — the already-open Version Packages PR (#26) merging afterward is what actually runs `npm publish` in CI for the first time
- Before that CI-driven publish can work, a one-time **manual** first publish (`npm login` + `npm publish --access public`) is needed, since npm's Trusted Publisher (OIDC) can only be configured on a package that already exists on the registry — same bootstrap `ui-kit`/`use-hooks` presumably went through
- After the manual first publish, a Trusted Publisher (GitHub Actions, repo `live-editor`, workflow `publish.yml`) needs to be registered on npmjs.com for `@jbpark/live-editor`'s package settings

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds