### PR TITLE
🐛 fix(build): remove unbundle mode to stop vendoring node_modules into dist

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   treeshake: true,
-  unbundle: true,
   inlineOnly: [
     /^@babel\//,
     /^@codemirror\//,


### PR DESCRIPTION
## Summary
Pre-first-publish build check found `dist/` contained 733 files / 6.4MB unpacked, including a full mirrored copy of ~44 third-party dependencies under `dist/node_modules/.pnpm/...`.

## Root cause
`tsdown.config.ts` had `unbundle: true` (maps to rolldown's `preserveModules`), which mirrors the entire input module graph 1:1 into output files — including modules pulled in via `inlineOnly`. Since those modules resolve from `node_modules`, their mirrored output path reproduces the original `node_modules/.pnpm/<pkg>/...` structure instead of being merged into the bundle.

This package only exposes 4 grouped entry points (`.`, `./utils`, `./utils/ast`, `./utils/tailwind`) with no per-component subpath exports, so `unbundle`'s per-module output granularity wasn't providing any real tree-shaking benefit to consumers.

## Fix
Remove `unbundle: true`. Inlined deps now bundle normally into a handful of chunks per entry.

## Result
- `dist/`: 733 files (6.4MB) → 22 files (6.3MB, same code, no more per-module node_modules mirroring)
- `npm publish --dry-run` tarball: 733 files → 22 files
- `pnpm check-types`, `pnpm lint`, `pnpm test` (49 tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)