### PR TITLE
feat: add undo/redo, adopt @jbpark/use-hooks for debounce

### DIFF
--- a/.changeset/pr-37.md
+++ b/.changeset/pr-37.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add undo and redo functionality to the editor with keyboard shortcuts and buttons.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@jbpark/ui-kit": "^2.3.4",
+    "@jbpark/use-hooks": "^2.4.0",
     "@tailwindcss/vite": "^4.1.13",
     "@tiptap/core": "^3.22.5",
     "@tiptap/extension-placeholder": "^3.22.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@jbpark/ui-kit':
         specifier: ^2.3.4
         version: 2.3.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(gsap@3.14.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@jbpark/use-hooks':
+        specifier: ^2.4.0
+        version: 2.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.1.18(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
@@ -685,8 +688,8 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@jbpark/use-hooks@2.1.0':
-    resolution: {integrity: sha512-/rgfrPG3zT74OFA/snZOJbBtgTiTDP0Naq/xWUNzTJGnyto7ssNCq9zTsGVeTVEqa3TYnUe/CS3bWoJ4WzCeBg==}
+  '@jbpark/use-hooks@2.4.0':
+    resolution: {integrity: sha512-nKo/TGmtqTVV3HC0Q7z1wV2jmtUdDuQ6feIsTjpJKVN1PUBVQEDsIUhSMu8AzuDgwcdBXQ+P+gNRKh0eEAy2SQ==}
     peerDependencies:
       react: ^19.1.1
       react-dom: ^19.1.1
@@ -4946,7 +4949,7 @@ snapshots:
   '@jbpark/ui-kit@2.3.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(gsap@3.14.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@gsap/react': 2.1.2(gsap@3.14.2)(react@19.2.3)
-      '@jbpark/use-hooks': 2.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@jbpark/use-hooks': 2.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4977,7 +4980,7 @@ snapshots:
       - '@types/react-dom'
       - gsap
 
-  '@jbpark/use-hooks@2.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@jbpark/use-hooks@2.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { EyeOutlined, SaveOutlined } from '@ant-design/icons';
+import {
+  EyeOutlined,
+  RedoOutlined,
+  SaveOutlined,
+  UndoOutlined,
+} from '@ant-design/icons';
+import { useDebounce, useHistoryState } from '@jbpark/use-hooks';
 import { Button, Flex, Radio, Space, Splitter, message } from 'antd';
 
 import './App.css';
@@ -18,11 +24,63 @@ const App = () => {
   const [value, setValue] = useState(
     () => localStorage.getItem(STORAGE_KEY) || DEFAULT_TEMPLATE,
   );
+  const {
+    value: historyValue,
+    setValue: commitHistory,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+  } = useHistoryState(value);
   const [type, setType] = useState<'dnd' | 'editor'>('editor');
 
   const navigate = useNavigate();
 
   const editable = type === 'editor';
+
+  // Commit to undo/redo history only after edits settle, so rapid typing in
+  // the raw editor doesn't create a history entry per keystroke.
+  useDebounce(
+    () => {
+      commitHistory(value);
+    },
+    { delay: 500 },
+    [value],
+  );
+
+  // Reflect undo/redo (or the debounced commit above catching up) back into
+  // the editable value.
+  useEffect(() => {
+    setValue(historyValue);
+  }, [historyValue]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const isMod = e.metaKey || e.ctrlKey;
+
+      if (!isMod || e.key.toLowerCase() !== 'z') {
+        return;
+      }
+
+      const target = e.target as HTMLElement | null;
+
+      if (target?.closest('.cm-editor')) {
+        // Let CodeMirror's own text-level undo/redo handle this instead.
+        return;
+      }
+
+      e.preventDefault();
+
+      if (e.shiftKey) {
+        redo();
+      } else {
+        undo();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [undo, redo]);
 
   return (
     <>
@@ -36,6 +94,16 @@ const App = () => {
               optionType="button"
               buttonStyle="solid"
               onChange={e => setType(e.target.value)}
+            />
+            <Button
+              icon={<UndoOutlined />}
+              disabled={!canUndo}
+              onClick={undo}
+            />
+            <Button
+              icon={<RedoOutlined />}
+              disabled={!canRedo}
+              onClick={redo}
             />
             <Button
               icon={<SaveOutlined />}

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
-import { useDebounce } from 'react-use';
+
+import { useDebounce } from '@jbpark/use-hooks';
 
 import { useError, usePreview } from '~/components/Context/states';
 import { DEFAULT_TEMPLATE } from '~/enums';
@@ -49,7 +50,7 @@ const Editor = ({
     () => {
       setCode(value);
     },
-    debounce,
+    { delay: debounce },
     [value],
   );
 


### PR DESCRIPTION
## Summary

Closes #31 (undo/redo).

- Added `@jbpark/use-hooks` dependency, uses its new `useHistoryState` hook to give the demo app (`src/App.tsx`) undo/redo over the edited `value`
- Undo/Redo toolbar buttons (disabled per `canUndo`/`canRedo`) + `Ctrl/Cmd+Z` / `Ctrl/Cmd+Shift+Z` shortcuts
- History commits are debounced (500ms) off live `value` changes so rapid typing in the raw code editor doesn't create a history entry per keystroke; undo/redo write back into `value` so both Editor and Dnd modes reflect it
- The keyboard shortcut handler skips when focus is inside `.cm-editor`, so CodeMirror's own internal text-level undo/redo (bound via its default keymap) isn't fought over by the app-level handler
- Replaced `react-use`'s `useDebounce` in `src/components/Editor/index.tsx` with `@jbpark/use-hooks`'s `useDebounce` — `react-use` was only ever a transitive, undeclared dependency (relied on via this repo's `shamefully-hoist`), so this also removes that reliance

## Note on one intentional behavior difference

`@jbpark/use-hooks`'s `useDebounce` invokes immediately on first mount rather than waiting out the initial delay (unlike `react-use`'s version, which always delays, even on mount). Practical effect: the preview no longer shows stale/default content for the first `debounce` ms (1000ms default) after the Editor mounts — seems like a strict improvement, but flagging it since it's a real behavior change from before.

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 49/49 passing
- [x] `pnpm build` succeeds
- [ ] Could not verify interactively in a real browser in this environment (none available) — worth a manual click-through (Undo/Redo buttons, keyboard shortcuts, editor debounce, CodeMirror's own undo still working while focused) before/after merge