### PR TITLE
feat: use @jbpark/use-hooks's useLocalStorage for manual save

### DIFF
--- a/.changeset/pr-39.md
+++ b/.changeset/pr-39.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Introduce useLocalStorage hook for managing saved values, enhancing state persistence.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,11 @@ import {
   SaveOutlined,
   UndoOutlined,
 } from '@ant-design/icons';
-import { useDebounce, useHistoryState } from '@jbpark/use-hooks';
+import {
+  useDebounce,
+  useHistoryState,
+  useLocalStorage,
+} from '@jbpark/use-hooks';
 import { Button, Flex, Radio, Space, Splitter, message } from 'antd';
 
 import './App.css';
@@ -21,9 +25,12 @@ const options = [
 ];
 
 const App = () => {
-  const [value, setValue] = useState(
-    () => localStorage.getItem(STORAGE_KEY) || DEFAULT_TEMPLATE,
+  const [savedValue, setSavedValue] = useLocalStorage(
+    STORAGE_KEY,
+    DEFAULT_TEMPLATE,
   );
+
+  const [value, setValue] = useState(savedValue);
   const {
     value: historyValue,
     setValue: commitHistory,
@@ -109,7 +116,7 @@ const App = () => {
               icon={<SaveOutlined />}
               type="primary"
               onClick={() => {
-                localStorage.setItem(STORAGE_KEY, value);
+                setSavedValue(value);
                 message.success('Code saved successfully');
               }}
             />


### PR DESCRIPTION
## Summary

- `src/App.tsx`: replace raw `localStorage.getItem`/`setItem` calls with `@jbpark/use-hooks`'s `useLocalStorage` hook, consistent with the recent `useHistoryState`/`useDebounce` adoption in this repo
- Save stays **manual**: only the Save button click calls `setSavedValue(value)`. The live editing `value` state is seeded once from the persisted value on mount but isn't reactively resynced from it — so `useLocalStorage`'s cross-tab `storage` event sync can't yank in-progress edits mid-session if another tab saves

## Note on one behavior difference

`useLocalStorage`'s own mount effect writes the initial value to `localStorage` if the key doesn't exist yet. So on a first-ever visit (empty localStorage), `DEFAULT_TEMPLATE` now gets persisted once automatically before any manual save — previously nothing was written until the user explicitly clicked Save. Flagging since it's a real (if low-impact) behavior change.

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 49/49 passing
- [x] `pnpm build` succeeds
- [ ] Could not verify interactively in a real browser in this environment (none available) — worth a manual check that Save/reload still round-trips correctly