### PR TITLE
feat: add min/max/pattern/required validation for bindings

### DIFF
--- a/.changeset/pr-40.md
+++ b/.changeset/pr-40.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add validation for binding values with min, max, pattern, and required constraints in the Field component.

--- a/src/components/Dnd/Panel/Field/index.tsx
+++ b/src/components/Dnd/Panel/Field/index.tsx
@@ -1,11 +1,15 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Checkbox, ColorPicker, Input, Select } from '@jbpark/ui-kit';
 
 import CoreEditor from '~/components/Editor/Core';
 import TiptapEditor from '~/components/Editor/Tiptap';
 import { BINDING_PROP } from '~/enums';
-import { type BindingItem, parseValue } from '~/utils/ast';
+import {
+  type BindingItem,
+  parseValue,
+  validateBindingValue,
+} from '~/utils/ast';
 
 import Children from '../Children';
 import Items from '../Items';
@@ -42,6 +46,8 @@ const Field = ({ binding, id, value, onChange }: Props) => {
   const parsedValue = useMemo(() => {
     return parseValue(value);
   }, [value]);
+
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   if (
     binding.property === 'items' ||
@@ -228,12 +234,57 @@ const Field = ({ binding, id, value, onChange }: Props) => {
 
   if (typeof parsedValue === 'number') {
     return (
-      <Input
-        type="number"
-        defaultValue={stringValue}
-        placeholder="Enter a numeric value"
+      <div>
+        <Input
+          type="number"
+          defaultValue={stringValue}
+          placeholder="Enter a numeric value"
+          onBlur={e => {
+            const next = e.target.value.trim();
+            const result = validateBindingValue(
+              binding,
+              next ? Number(next) : '',
+            );
+
+            if (!result.valid) {
+              setValidationError(result.message ?? 'Invalid value.');
+              return;
+            }
+
+            setValidationError(null);
+
+            if (next && next !== value) {
+              onChange?.({
+                id,
+                label: binding.label,
+                value: next,
+              });
+            }
+          }}
+        />
+        {validationError && (
+          <p className="mt-1 text-xs text-red-500">{validationError}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Input.TextArea
+        defaultValue={value}
+        placeholder="Enter a value"
         onBlur={e => {
           const next = e.target.value.trim();
+          const result = validateBindingValue(binding, next);
+
+          if (!result.valid) {
+            setValidationError(result.message ?? 'Invalid value.');
+            return;
+          }
+
+          setValidationError(null);
+
           if (next && next !== value) {
             onChange?.({
               id,
@@ -243,24 +294,10 @@ const Field = ({ binding, id, value, onChange }: Props) => {
           }
         }}
       />
-    );
-  }
-
-  return (
-    <Input.TextArea
-      defaultValue={value}
-      placeholder="Enter a value"
-      onBlur={e => {
-        const next = e.target.value.trim();
-        if (next && next !== value) {
-          onChange?.({
-            id,
-            label: binding.label,
-            value: next,
-          });
-        }
-      }}
-    />
+      {validationError && (
+        <p className="mt-1 text-xs text-red-500">{validationError}</p>
+      )}
+    </div>
   );
 };
 

--- a/src/utils/ast/binding.test.ts
+++ b/src/utils/ast/binding.test.ts
@@ -70,6 +70,33 @@ describe('parseBinding', () => {
     });
   });
 
+  it('extracts min/max/pattern/required constraints when present', () => {
+    const result = parseBinding(
+      "[{label: 'Age', property: 'data-age', type: 'number', min: 0, max: 120, pattern: '^[0-9]+$', required: true}]",
+    );
+
+    expect(result).toEqual([
+      {
+        label: 'Age',
+        property: 'data-age',
+        type: 'number',
+        min: 0,
+        max: 120,
+        pattern: '^[0-9]+$',
+        required: true,
+      },
+    ]);
+  });
+
+  it('omits min/max/pattern/required fields entirely when not authored', () => {
+    const result = parseBinding("[{label: 'Title', property: 'innerText'}]");
+
+    expect(result[0]).not.toHaveProperty('min');
+    expect(result[0]).not.toHaveProperty('max');
+    expect(result[0]).not.toHaveProperty('pattern');
+    expect(result[0]).not.toHaveProperty('required');
+  });
+
   it('returns an empty array without throwing for malformed binding syntax', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {

--- a/src/utils/ast/binding.ts
+++ b/src/utils/ast/binding.ts
@@ -213,6 +213,56 @@ export const parseBinding = (bindingValue: string | null): BindingItem[] => {
                 }
               }
 
+              const minProp = element.properties.find(
+                p =>
+                  t.isObjectProperty(p) &&
+                  t.isIdentifier(p.key) &&
+                  p.key.name === 'min' &&
+                  t.isNumericLiteral(p.value),
+              ) as t.ObjectProperty | undefined;
+
+              if (minProp) {
+                binding.min = (minProp.value as t.NumericLiteral).value;
+              }
+
+              const maxProp = element.properties.find(
+                p =>
+                  t.isObjectProperty(p) &&
+                  t.isIdentifier(p.key) &&
+                  p.key.name === 'max' &&
+                  t.isNumericLiteral(p.value),
+              ) as t.ObjectProperty | undefined;
+
+              if (maxProp) {
+                binding.max = (maxProp.value as t.NumericLiteral).value;
+              }
+
+              const patternProp = element.properties.find(
+                p =>
+                  t.isObjectProperty(p) &&
+                  t.isIdentifier(p.key) &&
+                  p.key.name === 'pattern' &&
+                  t.isStringLiteral(p.value),
+              ) as t.ObjectProperty | undefined;
+
+              if (patternProp) {
+                binding.pattern = (patternProp.value as t.StringLiteral).value;
+              }
+
+              const requiredProp = element.properties.find(
+                p =>
+                  t.isObjectProperty(p) &&
+                  t.isIdentifier(p.key) &&
+                  p.key.name === 'required' &&
+                  t.isBooleanLiteral(p.value),
+              ) as t.ObjectProperty | undefined;
+
+              if (requiredProp) {
+                binding.required = (
+                  requiredProp.value as t.BooleanLiteral
+                ).value;
+              }
+
               return binding;
             }
           }

--- a/src/utils/ast/index.ts
+++ b/src/utils/ast/index.ts
@@ -23,3 +23,5 @@ export { generateCode } from './helpers';
 export { clearExtractCache, extract } from './extract';
 export { bulkUpdate, update } from './update';
 export { clone, fillIds, replaceIds } from './tree';
+export type { ValidationResult } from './validate';
+export { validateBindingValue } from './validate';

--- a/src/utils/ast/types.ts
+++ b/src/utils/ast/types.ts
@@ -51,6 +51,10 @@ export interface BindingItem {
   type?: BindingType;
   options?: BindingOption[];
   render?: BindingRenderMap;
+  min?: number;
+  max?: number;
+  pattern?: string;
+  required?: boolean;
 }
 
 export type NodeValueType =

--- a/src/utils/ast/validate.test.ts
+++ b/src/utils/ast/validate.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BindingItem } from './types';
+import { validateBindingValue } from './validate';
+
+const makeBinding = (overrides: Partial<BindingItem> = {}): BindingItem => ({
+  label: 'Test',
+  property: 'test',
+  ...overrides,
+});
+
+describe('validateBindingValue', () => {
+  it('is valid when no constraints are set', () => {
+    expect(validateBindingValue(makeBinding(), 'anything')).toEqual({
+      valid: true,
+    });
+  });
+
+  it('is valid for an empty value when not required', () => {
+    expect(validateBindingValue(makeBinding(), '')).toEqual({ valid: true });
+    expect(validateBindingValue(makeBinding(), null)).toEqual({
+      valid: true,
+    });
+    expect(validateBindingValue(makeBinding(), undefined)).toEqual({
+      valid: true,
+    });
+  });
+
+  it('fails for an empty value when required', () => {
+    const result = validateBindingValue(makeBinding({ required: true }), '');
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toBeTruthy();
+  });
+
+  it('passes required when a non-empty value is present', () => {
+    expect(
+      validateBindingValue(makeBinding({ required: true }), 'hello'),
+    ).toEqual({ valid: true });
+  });
+
+  it('fails when a number is below min', () => {
+    const result = validateBindingValue(makeBinding({ min: 10 }), 5);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('10');
+  });
+
+  it('fails when a number is above max', () => {
+    const result = validateBindingValue(makeBinding({ max: 100 }), 150);
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('100');
+  });
+
+  it('passes when a number is within min/max bounds', () => {
+    expect(validateBindingValue(makeBinding({ min: 0, max: 10 }), 5)).toEqual({
+      valid: true,
+    });
+  });
+
+  it('fails when a string does not match the pattern', () => {
+    const result = validateBindingValue(
+      makeBinding({ pattern: '^[0-9]+$' }),
+      'abc',
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('passes when a string matches the pattern', () => {
+    expect(
+      validateBindingValue(makeBinding({ pattern: '^[0-9]+$' }), '12345'),
+    ).toEqual({ valid: true });
+  });
+
+  it('treats a malformed pattern as non-blocking rather than throwing', () => {
+    const result = validateBindingValue(
+      makeBinding({ pattern: '(unclosed' }),
+      'anything',
+    );
+
+    expect(() =>
+      validateBindingValue(makeBinding({ pattern: '(unclosed' }), 'anything'),
+    ).not.toThrow();
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('does not apply min/max to non-number values', () => {
+    expect(
+      validateBindingValue(makeBinding({ min: 10, max: 20 }), 'not-a-number'),
+    ).toEqual({ valid: true });
+  });
+
+  it('does not apply pattern to non-string values', () => {
+    expect(
+      validateBindingValue(makeBinding({ pattern: '^[0-9]+$' }), 42),
+    ).toEqual({ valid: true });
+  });
+});

--- a/src/utils/ast/validate.ts
+++ b/src/utils/ast/validate.ts
@@ -1,0 +1,52 @@
+import type { BindingItem } from './types';
+
+export interface ValidationResult {
+  valid: boolean;
+  message?: string;
+}
+
+const VALID: ValidationResult = { valid: true };
+
+export const validateBindingValue = (
+  binding: BindingItem,
+  value: unknown,
+): ValidationResult => {
+  const isEmpty = value === '' || value === null || value === undefined;
+
+  if (isEmpty) {
+    if (binding.required) {
+      return { valid: false, message: 'This field is required.' };
+    }
+    return VALID;
+  }
+
+  if (typeof value === 'number') {
+    if (binding.min !== undefined && value < binding.min) {
+      return { valid: false, message: `Must be at least ${binding.min}.` };
+    }
+    if (binding.max !== undefined && value > binding.max) {
+      return { valid: false, message: `Must be at most ${binding.max}.` };
+    }
+  }
+
+  if (typeof value === 'string' && binding.pattern) {
+    let regex: RegExp;
+
+    try {
+      regex = new RegExp(binding.pattern);
+    } catch {
+      // Malformed pattern authored on the binding itself — don't block the
+      // user's input for an authoring mistake that isn't theirs to fix.
+      return VALID;
+    }
+
+    if (!regex.test(value)) {
+      return {
+        valid: false,
+        message: 'Value does not match the required format.',
+      };
+    }
+  }
+
+  return VALID;
+};


### PR DESCRIPTION
## Summary

Closes #32.

- `src/utils/ast/types.ts`: add optional `min`/`max`/`pattern`/`required` fields to `BindingItem`
- `src/utils/ast/binding.ts`: `parseBinding` now extracts these from authored `data-binding` entries, mirroring the existing `label`/`property`/`type` extraction pattern
- `src/utils/ast/validate.ts` (new): `validateBindingValue(binding, value)` — pure function checking required/min/max/pattern, returning `{ valid, message? }`. A malformed authored pattern is treated as non-blocking rather than thrown, since that's an authoring mistake, not the editor's to surface as a hard failure
- `src/components/Dnd/Panel/Field/index.tsx`: wire validation into the number-input and text/textarea branches — runs on blur, before `parseValue`/codegen ever sees the value; shows an inline error message and skips the `onChange` commit when invalid, instead of only failing later at preview runtime via `Error/Guard`

## Scope

This covers the top-level `BindingItem` editor widgets (the common case). Nested `BindingRenderLeaf` (used for array-item properties in `Items/index.tsx`) isn't extended here, kept out to limit scope — can be a follow-up if needed.

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 63/63 passing (added `validate.test.ts`, 12 cases; extended `binding.test.ts`, 2 cases)
- [x] `pnpm build` succeeds
- [ ] Could not verify interactively in a real browser in this environment (none available) — worth a manual check that an invalid min/max/pattern/required entry actually shows the inline error and blocks the commit