### PR TITLE
🐛 fix(vercel): serve the vite demo app instead of the npm library bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-demo
 dist-ssr
 *.local
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "scripts": {
     "dev": "vite",
     "build": "pnpm check-types && tsdown",
+    "build:demo": "vite build --outDir dist-demo",
     "check-types": "tsc -b",
     "lint": "eslint .",
     "test": "vitest run",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm run build:demo",
+  "outputDirectory": "dist-demo",
+  "installCommand": "pnpm install"
+}


### PR DESCRIPTION
## Summary
- Vercel's main-domain deployment was showing raw bundled source instead of the demo app.
- Root cause: the repo's `build` script (`tsc -b && tsdown`) builds the **npm library** (`dist/index.mjs`, no `index.html`) — Vercel was running that by default (zero-config), so the root domain served the library bundle with nothing to render it.
- The actual demo app (`index.html` + `src/main.tsx` + `src/App.tsx`, built via `vite build`) was never wired into any deploy.
- Fix: added `build:demo` script (`vite build --outDir dist-demo`) and a `vercel.json` pointing Vercel's `buildCommand`/`outputDirectory` at it, without touching the existing `build` script (still used by CI/publish for the npm package).
- GitHub Pages deploy (`docs-deploy.yml`) is intentionally untouched — out of scope for this change.

## Test plan
- [x] `pnpm run build:demo` — produces `dist-demo/index.html` referencing the built JS/CSS assets
- [x] `vite preview --outDir dist-demo` — root path serves the real `index.html`/app shell, not raw bundle source
- [ ] Vercel redeploy after merge (needs dashboard/CLI access outside this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)