### PR TITLE
🔖 chore(release): patch bump to move past blocked npm version 1.0.0

### DIFF
--- a/.changeset/patch-release-1-0-1.md
+++ b/.changeset/patch-release-1-0-1.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+No functional changes. Bump past `1.0.0`, which npm permanently refuses to accept (a previously-unpublished exact version number cannot be republished).


### PR DESCRIPTION
## Summary
- `npm publish` for `1.0.0` failed with `Cannot publish over previously published version "1.0.0"` — npm permanently blocks republishing an exact version number that was previously published and unpublished, even though it no longer shows up in the registry.
- No functional changes; adds a patch changeset so the next Version Packages PR bumps `1.0.0` → `1.0.1`, which npm will actually accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)