### PR TITLE
🔖 chore(release): bump version to 1.0.3, skipping npm-blocked 1.0.0-1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.1",
+  "version": "1.0.3",
   "type": "module",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- `npm publish` kept failing with `Cannot publish over previously published version` for both `1.0.0` and `1.0.1`.
- Root cause found via the registry API (`registry.npmjs.org/@jbpark%2flive-editor`): its `time` object has entries for `1.0.0`/`1.0.1`/`1.0.2` dated `2026-01-11` — about six months before this project's actual first publish (`0.1.0` on `2026-07-27`). Those three version numbers were published-then-unpublished under the same package name in an unrelated earlier project/experiment, and npm permanently blocks reusing an exact unpublished version number for a given package.
- This is **not** a Trusted Publisher / GitHub Actions misconfiguration — OIDC auth succeeds and the workflow reaches the real registry `PUT` every time (confirmed in the failing run logs: provenance gets signed and submitted before the `400` comes back).
- Fix: bump straight to `1.0.3` (the next number with no history), bypassing the changesets patch-bump flow for this one jump since a normal patch changeset would only compute `1.0.1 → 1.0.2`, which is itself still blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)