### PR TITLE
✨ feat(app): add viewport-size toggle for responsive preview

### DIFF
--- a/.changeset/pr-52.md
+++ b/.changeset/pr-52.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add viewport presets and custom width input for responsive design in the editor.

--- a/.changeset/responsive-preview.md
+++ b/.changeset/responsive-preview.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add a viewport-size toggle (Desktop/Tablet/Mobile presets + custom width input) to the demo app's toolbar, resolving #35. Applied by composing `frame.style.width` on the existing `Live.Preview`/`Live.Dnd` `frame` prop — no changes to `Frame`/`IFrame` themselves.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,12 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import {
+  DesktopOutlined,
   EyeOutlined,
+  MobileOutlined,
   RedoOutlined,
   SaveOutlined,
+  TabletOutlined,
   UndoOutlined,
 } from '@ant-design/icons';
 import {
@@ -12,7 +15,15 @@ import {
   useHistoryState,
   useLocalStorage,
 } from '@jbpark/use-hooks';
-import { Button, Flex, Radio, Space, Splitter, message } from 'antd';
+import {
+  Button,
+  Flex,
+  InputNumber,
+  Radio,
+  Space,
+  Splitter,
+  message,
+} from 'antd';
 
 import './App.css';
 
@@ -23,6 +34,13 @@ const options = [
   { label: 'Drag & Drop', value: 'dnd' },
   { label: 'Editor', value: 'editor' },
 ];
+
+// `null` means no width constraint (fills the panel, i.e. "Desktop").
+const VIEWPORT_PRESETS = [
+  { label: <DesktopOutlined />, value: null, title: 'Desktop (full width)' },
+  { label: <TabletOutlined />, value: 768, title: 'Tablet (768px)' },
+  { label: <MobileOutlined />, value: 375, title: 'Mobile (375px)' },
+] as const;
 
 const App = () => {
   const [savedValue, setSavedValue] = useLocalStorage(
@@ -40,10 +58,24 @@ const App = () => {
     canRedo,
   } = useHistoryState(value);
   const [type, setType] = useState<'dnd' | 'editor'>('editor');
+  const [viewportWidth, setViewportWidth] = useState<number | null>(null);
 
   const navigate = useNavigate();
 
   const editable = type === 'editor';
+
+  const previewFrame = {
+    mode: 'iframe' as const,
+    syncStyle: true,
+    scripts: ['/js/tailwindcss.js'],
+    style: viewportWidth
+      ? {
+          width: viewportWidth,
+          margin: '0 auto',
+          border: '1px solid #d9d9d9',
+        }
+      : undefined,
+  };
 
   // Commit to undo/redo history only after edits settle, so rapid typing in
   // the raw editor doesn't create a history entry per keystroke.
@@ -102,6 +134,31 @@ const App = () => {
               buttonStyle="solid"
               onChange={e => setType(e.target.value)}
             />
+            <Radio.Group
+              size="small"
+              value={viewportWidth}
+              optionType="button"
+              buttonStyle="solid"
+              onChange={e => setViewportWidth(e.target.value)}
+            >
+              {VIEWPORT_PRESETS.map(preset => (
+                <Radio.Button
+                  key={preset.title}
+                  value={preset.value}
+                  title={preset.title}
+                >
+                  {preset.label}
+                </Radio.Button>
+              ))}
+            </Radio.Group>
+            <InputNumber
+              size="small"
+              min={200}
+              max={2560}
+              placeholder="Custom width"
+              value={viewportWidth}
+              onChange={value => setViewportWidth(value)}
+            />
             <Button
               icon={<UndoOutlined />}
               disabled={!canUndo}
@@ -142,15 +199,8 @@ const App = () => {
                   max="80%"
                   collapsible
                 >
-                  <div className="h-full overflow-hidden p-2">
-                    <Live.Preview
-                      showError
-                      frame={{
-                        mode: 'iframe',
-                        syncStyle: true,
-                        scripts: ['/js/tailwindcss.js'],
-                      }}
-                    />
+                  <div className="h-full overflow-auto p-2">
+                    <Live.Preview showError frame={previewFrame} />
                   </div>
                 </Splitter.Panel>
                 <Splitter.Panel collapsible>
@@ -159,11 +209,7 @@ const App = () => {
               </Splitter>
             ) : (
               <Live.Dnd
-                frame={{
-                  mode: 'iframe',
-                  syncStyle: true,
-                  scripts: ['/js/tailwindcss.js'],
-                }}
+                frame={previewFrame}
                 value={value}
                 onChange={setValue}
               />


### PR DESCRIPTION
## Summary
Resolves #35.

- Add a viewport-size toggle to the demo toolbar: Desktop/Tablet/Mobile preset buttons (`Radio.Group`, matching the existing Drag & Drop / Editor mode toggle's style) plus a custom width `InputNumber`.
- Composes with the existing `frame.style` prop already accepted by `Live.Preview`/`Live.Dnd` — sets `width` + centers it + adds a device-frame border — rather than changing `Frame`/`IFrame`. Only `style.width` is set, so `IFrame`'s `autoHeight` sizing logic is untouched, matching the issue's "no structural changes" guidance.
- The two previously-duplicated (and identical) inline `frame` objects for the editor-mode `Live.Preview` and dnd-mode `Live.Dnd` branches are consolidated into one `previewFrame` shared by both, so the toggle affects both modes.
- Changed the editor-mode preview wrapper from `overflow-hidden` to `overflow-auto` so a centered, narrower device frame with taller content stays scrollable instead of being clipped.

## Test plan
- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm test` (80/80, unrelated to this change but re-run for safety)
- [x] `pnpm build` (library) and `pnpm build:demo` (Vite demo app) both succeed
- [ ] Manual click-through in the browser (not verified in this environment — no browser available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)