### PR TITLE
chore(viewport): remove viewport preset controls

### DIFF
--- a/.changeset/pr-53.md
+++ b/.changeset/pr-53.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Remove the Desktop/Tablet/Mobile viewport-size preset toggle and custom width input from the editor toolbar.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,9 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import {
-  DesktopOutlined,
   EyeOutlined,
-  MobileOutlined,
   RedoOutlined,
   SaveOutlined,
-  TabletOutlined,
   UndoOutlined,
 } from '@ant-design/icons';
 import {
@@ -15,15 +12,7 @@ import {
   useHistoryState,
   useLocalStorage,
 } from '@jbpark/use-hooks';
-import {
-  Button,
-  Flex,
-  InputNumber,
-  Radio,
-  Space,
-  Splitter,
-  message,
-} from 'antd';
+import { Button, Flex, Radio, Space, Splitter, message } from 'antd';
 
 import './App.css';
 
@@ -34,13 +23,6 @@ const options = [
   { label: 'Drag & Drop', value: 'dnd' },
   { label: 'Editor', value: 'editor' },
 ];
-
-// `null` means no width constraint (fills the panel, i.e. "Desktop").
-const VIEWPORT_PRESETS = [
-  { label: <DesktopOutlined />, value: null, title: 'Desktop (full width)' },
-  { label: <TabletOutlined />, value: 768, title: 'Tablet (768px)' },
-  { label: <MobileOutlined />, value: 375, title: 'Mobile (375px)' },
-] as const;
 
 const App = () => {
   const [savedValue, setSavedValue] = useLocalStorage(
@@ -58,7 +40,6 @@ const App = () => {
     canRedo,
   } = useHistoryState(value);
   const [type, setType] = useState<'dnd' | 'editor'>('editor');
-  const [viewportWidth, setViewportWidth] = useState<number | null>(null);
 
   const navigate = useNavigate();
 
@@ -68,13 +49,6 @@ const App = () => {
     mode: 'iframe' as const,
     syncStyle: true,
     scripts: ['/js/tailwindcss.js'],
-    style: viewportWidth
-      ? {
-          width: viewportWidth,
-          margin: '0 auto',
-          border: '1px solid #d9d9d9',
-        }
-      : undefined,
   };
 
   // Commit to undo/redo history only after edits settle, so rapid typing in
@@ -133,31 +107,6 @@ const App = () => {
               optionType="button"
               buttonStyle="solid"
               onChange={e => setType(e.target.value)}
-            />
-            <Radio.Group
-              size="small"
-              value={viewportWidth}
-              optionType="button"
-              buttonStyle="solid"
-              onChange={e => setViewportWidth(e.target.value)}
-            >
-              {VIEWPORT_PRESETS.map(preset => (
-                <Radio.Button
-                  key={preset.title}
-                  value={preset.value}
-                  title={preset.title}
-                >
-                  {preset.label}
-                </Radio.Button>
-              ))}
-            </Radio.Group>
-            <InputNumber
-              size="small"
-              min={200}
-              max={2560}
-              placeholder="Custom width"
-              value={viewportWidth}
-              onChange={value => setViewportWidth(value)}
             />
             <Button
               icon={<UndoOutlined />}


### PR DESCRIPTION
## Summary
- Remove the Desktop/Tablet/Mobile viewport-width preset toolbar (radio group + custom-width input) from the demo `App.tsx`

## Test plan
- [x] `tsc -b`
- [x] `eslint`