### PR TITLE
fix(value): handle string/numeric object keys in evaluateLiteral

### DIFF
--- a/.changeset/pr-54.md
+++ b/.changeset/pr-54.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Fix evaluateLiteral to correctly parse JSON-stringified object keys, fixing data loss when moving or editing items in the Children panel.

--- a/src/utils/ast/value.test.ts
+++ b/src/utils/ast/value.test.ts
@@ -34,6 +34,14 @@ describe('parseValue', () => {
     expect(parseValue('{a: 1, b: "x"}')).toEqual({ a: 1, b: 'x' });
   });
 
+  it('round-trips JSON.stringify output (string-literal keys) without losing properties', () => {
+    const original = [
+      { tagName: 'div', attributes: { id: 'x' }, children: [] },
+    ];
+
+    expect(parseValue(JSON.stringify(original))).toEqual(original);
+  });
+
   it('parses an array literal string into a real array', () => {
     expect(parseValue('[1, "x", true]')).toEqual([1, 'x', true]);
   });

--- a/src/utils/ast/value.ts
+++ b/src/utils/ast/value.ts
@@ -28,7 +28,7 @@ const dedent = (str: string): string => {
 // 실제 JS 값으로 변환한다. 함수 호출, 변수 참조 등 리터럴이 아닌 표현식은
 // 평가하지 않고 undefined를 반환한다 — 사용자 코드는 iframe 안에서만 실행한다는
 // 이 저장소의 원칙(AGENTS.md)을 이 패널 UI(메인 문서에서 렌더링됨)에서도 지키기 위함.
-const evaluateLiteral = (node: t.Node): unknown => {
+export const evaluateLiteral = (node: t.Node): unknown => {
   if (t.isStringLiteral(node)) {
     return node.value;
   }
@@ -75,10 +75,25 @@ const evaluateLiteral = (node: t.Node): unknown => {
     const result: Record<string, unknown> = {};
 
     for (const prop of node.properties) {
-      if (!t.isObjectProperty(prop) || !t.isIdentifier(prop.key)) {
+      if (!t.isObjectProperty(prop)) {
         continue;
       }
-      result[prop.key.name] = evaluateLiteral(prop.value);
+
+      let key: string | null = null;
+
+      if (t.isIdentifier(prop.key)) {
+        key = prop.key.name;
+      } else if (t.isStringLiteral(prop.key)) {
+        key = prop.key.value;
+      } else if (t.isNumericLiteral(prop.key)) {
+        key = String(prop.key.value);
+      }
+
+      if (key === null) {
+        continue;
+      }
+
+      result[key] = evaluateLiteral(prop.value);
     }
 
     return result;


### PR DESCRIPTION
## Summary
- Fix `evaluateLiteral` to accept `StringLiteral`/`NumericLiteral` object keys in addition to `Identifier`, so `JSON.stringify` output (which always quotes keys) round-trips correctly instead of collapsing every property into an empty object
- Export `evaluateLiteral` so other modules can reuse it instead of re-implementing literal evaluation
- This was the root cause of an editor bug: reordering/repositioning a Children-panel item wiped its content and eventually emptied the whole container, because the JSON round-trip through this function silently dropped every property

## Test plan
- [x] Added a regression test covering the `JSON.stringify` round-trip case
- [x] `vitest run`
- [x] `tsc -b`
- [x] `eslint`