### PR TITLE
refactor(binding): parse binding config via Zod instead of manual AST walking

### DIFF
--- a/.changeset/pr-55.md
+++ b/.changeset/pr-55.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Refactor the data-binding config parser to validate/normalize via Zod schemas instead of manually walking Babel AST nodes field by field, and derive the allowed binding type list from a single source of truth shared with the type definitions.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "lucide-react": "^0.562.0",
     "react-router-dom": "^7.12.0",
     "tailwindcss": "^4.1.13",
-    "uuid": "^12.0.0"
+    "uuid": "^12.0.0",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "prettier": "^3.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       uuid:
         specifier: ^12.0.0
         version: 12.0.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.1
@@ -4344,8 +4347,8 @@ packages:
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
-  zod@4.3.5:
-    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -7322,8 +7325,8 @@ snapshots:
       '@babel/parser': 7.28.6
       eslint: 9.39.2(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.5
-      zod-validation-error: 4.0.2(zod@4.3.5)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -8657,10 +8660,10 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.3.5):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.5
+      zod: 4.4.3
 
   zod@3.22.4: {}
 
-  zod@4.3.5: {}
+  zod@4.4.3: {}

--- a/src/utils/ast/binding.test.ts
+++ b/src/utils/ast/binding.test.ts
@@ -82,6 +82,23 @@ describe('parseBinding', () => {
     });
   });
 
+  it('drops a nested render leaf with an unrecognized type instead of keeping it as-is', () => {
+    const result = parseBinding(`
+      [{
+        label: 'Items',
+        property: 'items',
+        render: {
+          icon: { type: 'string', property: 'innerText' },
+          bogus: { type: 'not-a-real-type', property: 'innerText' }
+        }
+      }]
+    `);
+
+    expect(result[0]!.render).toEqual({
+      icon: { type: 'string', property: 'innerText' },
+    });
+  });
+
   it('extracts min/max/pattern/required constraints when present', () => {
     const result = parseBinding(
       "[{label: 'Age', property: 'data-age', type: 'number', min: 0, max: 120, pattern: '^[0-9]+$', required: true}]",
@@ -107,6 +124,57 @@ describe('parseBinding', () => {
     expect(result[0]).not.toHaveProperty('max');
     expect(result[0]).not.toHaveProperty('pattern');
     expect(result[0]).not.toHaveProperty('required');
+  });
+
+  it('drops individually malformed options while keeping the valid ones', () => {
+    const result = parseBinding(`
+      [{
+        label: 'Size',
+        property: 'size',
+        options: [
+          { label: 'small', value: 'small' },
+          { label: 'no-value' },
+          { label: 'large', value: 'large' }
+        ]
+      }]
+    `);
+
+    expect(result[0]!.options).toEqual([
+      { label: 'small', value: 'small' },
+      { label: 'large', value: 'large' },
+    ]);
+  });
+
+  it('omits the options field entirely when no option is valid', () => {
+    const result = parseBinding(`
+      [{
+        label: 'Size',
+        property: 'size',
+        options: [{ label: 'no-value' }]
+      }]
+    `);
+
+    expect(result[0]).not.toHaveProperty('options');
+  });
+
+  it('skips non-object entries in the top-level binding array', () => {
+    const result = parseBinding(
+      "[1, 'x', {label: 'Title', property: 'innerText'}]",
+    );
+
+    expect(result).toEqual([{ label: 'Title', property: 'innerText' }]);
+  });
+
+  it('drops an item that has no label', () => {
+    const result = parseBinding("[{property: 'innerText'}]");
+
+    expect(result).toEqual([]);
+  });
+
+  it('drops an item that has neither a property nor a richtext type', () => {
+    const result = parseBinding("[{label: 'Title'}]");
+
+    expect(result).toEqual([]);
   });
 
   it('returns an empty array without throwing for malformed binding syntax', () => {

--- a/src/utils/ast/binding.ts
+++ b/src/utils/ast/binding.ts
@@ -1,84 +1,77 @@
 import { parseExpression } from '@babel/parser';
 import * as t from '@babel/types';
+import { z } from 'zod';
 
 import { BINDING_PROP, DATA_ATTR } from '../../enums';
-import type {
-  BindingItem,
-  BindingOption,
-  BindingRenderLeaf,
-  BindingRenderMap,
-  BindingType,
-  DataAttrNode,
+import {
+  BINDING_TYPES,
+  type BindingItem,
+  type BindingOption,
+  type BindingRenderMap,
+  type DataAttrNode,
 } from './types';
+import { evaluateLiteral, parseArrayExpression } from './value';
 
-const parseRenderObject = (
-  node: t.ObjectExpression,
-): BindingRenderMap | null => {
+const bindingTypeSchema = z.enum(BINDING_TYPES);
+
+const bindingOptionSchema = z.object({
+  label: z.string(),
+  value: z.string(),
+});
+
+const bindingRenderLeafSchema = z.object({
+  type: bindingTypeSchema,
+  property: z.string().optional(),
+});
+
+const rawBindingItemSchema = z.object({
+  label: z.string(),
+  property: z.string().optional(),
+  type: bindingTypeSchema.optional(),
+  options: z.array(bindingOptionSchema).optional(),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  pattern: z.string().optional(),
+  required: z.boolean().optional(),
+});
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+// A render map entry is either a "leaf" (has its own `type`) or a nested
+// map of further entries — recurse into whichever it looks like, and drop
+// anything that matches neither instead of failing the whole map.
+const sanitizeRenderMap = (value: unknown): BindingRenderMap | undefined => {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
   const map: BindingRenderMap = {};
 
-  node.properties.forEach(prop => {
-    if (
-      !t.isObjectProperty(prop) ||
-      !t.isIdentifier(prop.key) ||
-      !t.isObjectExpression(prop.value)
-    ) {
-      return;
+  for (const [key, raw] of Object.entries(value)) {
+    if (!isPlainObject(raw)) {
+      continue;
     }
 
-    const key = prop.key.name;
+    if ('type' in raw) {
+      const leaf = bindingRenderLeafSchema.safeParse(raw);
 
-    const typeProp = prop.value.properties.find(
-      p =>
-        t.isObjectProperty(p) &&
-        t.isIdentifier(p.key) &&
-        p.key.name === 'type' &&
-        t.isStringLiteral(p.value),
-    ) as t.ObjectProperty | undefined;
-
-    if (typeProp) {
-      const leaf: BindingRenderLeaf = {
-        type: (typeProp.value as t.StringLiteral).value as BindingType,
-      };
-
-      const propertyProp = prop.value.properties.find(
-        p =>
-          t.isObjectProperty(p) &&
-          t.isIdentifier(p.key) &&
-          p.key.name === 'property' &&
-          t.isStringLiteral(p.value),
-      ) as t.ObjectProperty | undefined;
-
-      if (propertyProp) {
-        leaf.property = (propertyProp.value as t.StringLiteral).value;
+      if (leaf.success) {
+        const render = sanitizeRenderMap(raw.render);
+        map[key] = render ? { ...leaf.data, render } : leaf.data;
       }
-
-      const renderProp = prop.value.properties.find(
-        p =>
-          t.isObjectProperty(p) &&
-          t.isIdentifier(p.key) &&
-          p.key.name === 'render' &&
-          t.isObjectExpression(p.value),
-      ) as t.ObjectProperty | undefined;
-
-      if (renderProp) {
-        const nested = parseRenderObject(
-          renderProp.value as t.ObjectExpression,
-        );
-        if (nested) {
-          leaf.render = nested;
-        }
-      }
-
-      map[key] = leaf;
-    } else {
-      const nested = parseRenderObject(prop.value);
-      if (nested) {
-        map[key] = nested;
-      }
+      continue;
     }
-  });
 
-  return Object.keys(map).length > 0 ? map : null;
+    const nested = sanitizeRenderMap(raw);
+
+    if (nested) {
+      map[key] = nested;
+    }
+  }
+
+  return Object.keys(map).length > 0 ? map : undefined;
 };
 
 export const parseBinding = (bindingValue: string | null): BindingItem[] => {
@@ -86,199 +79,75 @@ export const parseBinding = (bindingValue: string | null): BindingItem[] => {
     return [];
   }
 
-  try {
-    const ast = parseExpression(bindingValue, {
-      plugins: ['jsx', 'typescript'],
-    });
+  const ast = parseArrayExpression(bindingValue);
 
-    if (t.isArrayExpression(ast)) {
-      return ast.elements
-        .map(element => {
-          if (t.isObjectExpression(element)) {
-            const labelProp = element.properties.find(
-              p =>
-                t.isObjectProperty(p) &&
-                t.isIdentifier(p.key) &&
-                p.key.name === 'label' &&
-                t.isStringLiteral(p.value),
-            ) as t.ObjectProperty | undefined;
-
-            const propertyProp = element.properties.find(
-              p =>
-                t.isObjectProperty(p) &&
-                t.isIdentifier(p.key) &&
-                p.key.name === 'property' &&
-                t.isStringLiteral(p.value),
-            ) as t.ObjectProperty | undefined;
-
-            const optionsProp = element.properties.find(
-              p =>
-                t.isObjectProperty(p) &&
-                t.isIdentifier(p.key) &&
-                p.key.name === 'options' &&
-                t.isArrayExpression(p.value),
-            ) as t.ObjectProperty | undefined;
-
-            const typePropEarly = element.properties.find(
-              p =>
-                t.isObjectProperty(p) &&
-                t.isIdentifier(p.key) &&
-                p.key.name === 'type' &&
-                t.isStringLiteral(p.value),
-            ) as t.ObjectProperty | undefined;
-
-            const earlyTypeValue = typePropEarly
-              ? (typePropEarly.value as t.StringLiteral).value
-              : undefined;
-
-            const isRichtext = earlyTypeValue === 'richtext';
-
-            if (labelProp && (propertyProp || isRichtext)) {
-              const binding: BindingItem = {
-                label: (labelProp.value as t.StringLiteral).value,
-                property: propertyProp
-                  ? (propertyProp.value as t.StringLiteral).value
-                  : BINDING_PROP.INNER_HTML,
-              };
-
-              const typeProp = typePropEarly;
-
-              if (typeProp) {
-                const typeValue = (typeProp.value as t.StringLiteral).value;
-                if (
-                  [
-                    'array',
-                    'object',
-                    'string',
-                    'number',
-                    'boolean',
-                    'color',
-                    'jsx',
-                    'richtext',
-                    'date',
-                    'url',
-                    'icon-picker',
-                    'asset-picker',
-                  ].includes(typeValue)
-                ) {
-                  binding.type = typeValue as BindingType;
-                }
-              }
-
-              const renderProp = element.properties.find(
-                p =>
-                  t.isObjectProperty(p) &&
-                  t.isIdentifier(p.key) &&
-                  p.key.name === 'render' &&
-                  t.isObjectExpression(p.value),
-              ) as t.ObjectProperty | undefined;
-
-              if (renderProp && t.isObjectExpression(renderProp.value)) {
-                const renderMap = parseRenderObject(renderProp.value);
-
-                if (renderMap) {
-                  binding.render = renderMap;
-                }
-              }
-
-              if (optionsProp && t.isArrayExpression(optionsProp.value)) {
-                const options = optionsProp.value.elements
-                  .map(el => {
-                    if (t.isObjectExpression(el)) {
-                      const labelProp = el.properties.find(
-                        p =>
-                          t.isObjectProperty(p) &&
-                          t.isIdentifier(p.key) &&
-                          p.key.name === 'label' &&
-                          t.isStringLiteral(p.value),
-                      ) as t.ObjectProperty | undefined;
-
-                      const valueProp = el.properties.find(
-                        p =>
-                          t.isObjectProperty(p) &&
-                          t.isIdentifier(p.key) &&
-                          p.key.name === 'value' &&
-                          t.isStringLiteral(p.value),
-                      ) as t.ObjectProperty | undefined;
-
-                      if (labelProp && valueProp) {
-                        return {
-                          label: (labelProp.value as t.StringLiteral).value,
-                          value: (valueProp.value as t.StringLiteral).value,
-                        };
-                      }
-                    }
-                    return null;
-                  })
-                  .filter((item): item is BindingOption => item !== null);
-
-                if (options.length > 0) {
-                  binding.options = options;
-                }
-              }
-
-              const minProp = element.properties.find(
-                p =>
-                  t.isObjectProperty(p) &&
-                  t.isIdentifier(p.key) &&
-                  p.key.name === 'min' &&
-                  t.isNumericLiteral(p.value),
-              ) as t.ObjectProperty | undefined;
-
-              if (minProp) {
-                binding.min = (minProp.value as t.NumericLiteral).value;
-              }
-
-              const maxProp = element.properties.find(
-                p =>
-                  t.isObjectProperty(p) &&
-                  t.isIdentifier(p.key) &&
-                  p.key.name === 'max' &&
-                  t.isNumericLiteral(p.value),
-              ) as t.ObjectProperty | undefined;
-
-              if (maxProp) {
-                binding.max = (maxProp.value as t.NumericLiteral).value;
-              }
-
-              const patternProp = element.properties.find(
-                p =>
-                  t.isObjectProperty(p) &&
-                  t.isIdentifier(p.key) &&
-                  p.key.name === 'pattern' &&
-                  t.isStringLiteral(p.value),
-              ) as t.ObjectProperty | undefined;
-
-              if (patternProp) {
-                binding.pattern = (patternProp.value as t.StringLiteral).value;
-              }
-
-              const requiredProp = element.properties.find(
-                p =>
-                  t.isObjectProperty(p) &&
-                  t.isIdentifier(p.key) &&
-                  p.key.name === 'required' &&
-                  t.isBooleanLiteral(p.value),
-              ) as t.ObjectProperty | undefined;
-
-              if (requiredProp) {
-                binding.required = (
-                  requiredProp.value as t.BooleanLiteral
-                ).value;
-              }
-
-              return binding;
-            }
-          }
-          return null;
-        })
-        .filter((item): item is BindingItem => item !== null);
-    }
-  } catch (error) {
-    console.error('❌ Binding parsing error:', error);
+  if (!ast) {
+    return [];
   }
 
-  return [];
+  const raw = evaluateLiteral(ast);
+
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const items: BindingItem[] = [];
+
+  for (const rawItem of raw) {
+    if (!isPlainObject(rawItem)) {
+      continue;
+    }
+
+    // Drop an unrecognized `type` instead of rejecting the whole item — an
+    // authored binding with a typo'd/future type string still works as an
+    // untyped field rather than disappearing entirely.
+    const sanitizedType = bindingTypeSchema.safeParse(rawItem.type);
+
+    // Drop individually malformed options instead of rejecting the whole
+    // item — a select field with 3 valid options and 1 malformed one should
+    // still work with the 3 valid ones.
+    const sanitizedOptions = Array.isArray(rawItem.options)
+      ? rawItem.options
+          .map(option => {
+            const parsed = bindingOptionSchema.safeParse(option);
+            return parsed.success ? parsed.data : null;
+          })
+          .filter((option): option is BindingOption => option !== null)
+      : undefined;
+
+    const parsed = rawBindingItemSchema.safeParse({
+      ...rawItem,
+      type: sanitizedType.success ? sanitizedType.data : undefined,
+      options: sanitizedOptions?.length ? sanitizedOptions : undefined,
+    });
+
+    if (!parsed.success) {
+      continue;
+    }
+
+    const { label, property, type, options, min, max, pattern, required } =
+      parsed.data;
+
+    if (property === undefined && type !== 'richtext') {
+      continue;
+    }
+
+    const render = sanitizeRenderMap(rawItem.render);
+
+    items.push({
+      label,
+      property: property ?? BINDING_PROP.INNER_HTML,
+      ...(type !== undefined && { type }),
+      ...(options?.length && { options }),
+      ...(render && { render }),
+      ...(min !== undefined && { min }),
+      ...(max !== undefined && { max }),
+      ...(pattern !== undefined && { pattern }),
+      ...(required !== undefined && { required }),
+    });
+  }
+
+  return items;
 };
 
 export const getCurrentValue = (

--- a/src/utils/ast/types.ts
+++ b/src/utils/ast/types.ts
@@ -25,19 +25,22 @@ export interface BindingOption {
   value: string;
 }
 
-export type BindingType =
-  | 'array'
-  | 'object'
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'color'
-  | 'jsx'
-  | 'richtext'
-  | 'date'
-  | 'url'
-  | 'icon-picker'
-  | 'asset-picker';
+export const BINDING_TYPES = [
+  'array',
+  'object',
+  'string',
+  'number',
+  'boolean',
+  'color',
+  'jsx',
+  'richtext',
+  'date',
+  'url',
+  'icon-picker',
+  'asset-picker',
+] as const;
+
+export type BindingType = (typeof BINDING_TYPES)[number];
 
 export interface BindingRenderLeaf {
   type: BindingType;


### PR DESCRIPTION
## Summary
- Rewrite `parseBinding` to evaluate the `data-binding` literal to a plain value (reusing `evaluateLiteral`) and validate/normalize it with Zod schemas, replacing ~250 lines of repetitive `t.isObjectProperty`/`t.isIdentifier`/`t.isStringLiteral` matching per field
- Preserve existing lenient behavior: unrecognized `type` strings and individually malformed `options` entries are dropped without rejecting the whole binding item
- Derive `BindingType` from a new `BINDING_TYPES` const array in `types.ts` instead of a hand-written union, so it's the single source of truth shared with the Zod enum
- Consistency fix: nested render-leaf `type` values are now validated against the same allowed list as the top-level `type` (previously only the top-level `type` was checked)
- Add `zod` as a dependency

**Base branch note:** this stacks on `fix/binding-value-string-literal-keys` because it depends on that branch's `evaluateLiteral` export. Merge the fix PR first, then retarget/merge this one into `main`.

## Test plan
- [x] Added regression tests: dropping malformed options while keeping valid ones, omitting `options` when none are valid, skipping non-object array entries, dropping items with no label or no property/richtext type, dropping a render leaf with an unrecognized type
- [x] `vitest run`
- [x] `tsc -b`
- [x] `eslint`