### PR TITLE
chore(config): allow trycloudflare.com hosts in vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,4 +15,7 @@ export default defineConfig({
   define: {
     'process.env': {},
   },
+  server: {
+    allowedHosts: ['.trycloudflare.com'],
+  },
 });


### PR DESCRIPTION
## Summary
- Add `server.allowedHosts` for `.trycloudflare.com` so Vite's dev-server host check doesn't block requests proxied through a cloudflared quick tunnel (used for previewing on mobile)

## Test plan
- [x] `tsc -b`
- [x] `eslint`
- [x] Confirmed a cloudflared tunnel URL returns 200 instead of Vite's blocked-host 403