### PR TITLE
feat(pages): add a project intro page at "/"

### DIFF
--- a/.changeset/pr-60.md
+++ b/.changeset/pr-60.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add a project intro page at "/" with the title, tagline, highlights, and links to the editor/GitHub/npm. The interactive editor moved from "/" to "/editor".

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,13 +5,14 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import './index.css';
 
 import App from './App';
-import { Playground, Preview } from './pages';
+import { Intro, Playground, Preview } from './pages';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<App />} />
+        <Route path="/" element={<Intro />} />
+        <Route path="/editor" element={<App />} />
         <Route path="/preview" element={<Preview />} />
         <Route path="/playground" element={<Playground />} />
       </Routes>

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,2 +1,3 @@
+export { default as Intro } from './intro';
 export { default as Playground } from './playground';
 export { default as Preview } from './preview';

--- a/src/pages/intro/index.tsx
+++ b/src/pages/intro/index.tsx
@@ -1,0 +1,68 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Button, Space, Typography } from '@jbpark/ui-kit';
+import { ExternalLink, Github } from 'lucide-react';
+
+const HIGHLIGHTS = [
+  'Real-time canvas edits sync back to source code via AST transforms',
+  'Drag-and-drop builder with an interactive property panel',
+  'Isolated iframe preview for DOM/CSS separation',
+];
+
+const Intro = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6">
+      <Space
+        orientation="vertical"
+        align="center"
+        size="large"
+        className="max-w-2xl text-center"
+      >
+        <Typography.Title level={1}>Live Editor</Typography.Title>
+        <Typography.Paragraph className="text-lg text-gray-500">
+          An interactive editor for building UIs with real-time preview and
+          drag-and-drop.
+        </Typography.Paragraph>
+        <ul className="space-y-2 text-left text-gray-600">
+          {HIGHLIGHTS.map(highlight => (
+            <li key={highlight}>• {highlight}</li>
+          ))}
+        </ul>
+        <Space size="middle">
+          <Button
+            type="primary"
+            size="large"
+            onClick={() => navigate('/editor')}
+          >
+            Open Editor
+          </Button>
+          <Button
+            size="large"
+            icon={<Github />}
+            onClick={() =>
+              window.open('https://github.com/pjb0811/live-editor', '_blank')
+            }
+          >
+            GitHub
+          </Button>
+          <Button
+            size="large"
+            icon={<ExternalLink />}
+            onClick={() =>
+              window.open(
+                'https://www.npmjs.com/package/@jbpark/live-editor',
+                '_blank',
+              )
+            }
+          >
+            npm
+          </Button>
+        </Space>
+      </Space>
+    </div>
+  );
+};
+
+export default Intro;


### PR DESCRIPTION
## Summary
- Add a simple intro page (`src/pages/intro`) with the project title, tagline, highlights, and links to the editor/GitHub/npm
- Move the interactive editor from `/` to `/editor` so first-time visitors land on context before the drag-and-drop UI
- `/preview` and `/playground` stay unchanged

## Test plan
- [x] `vitest run`
- [x] `tsc -b`
- [x] `eslint`
- [x] Confirmed `/` and `/editor` both resolve correctly on the local dev server