### PR TITLE
fix(css): fix Tailwind cascade order between own CSS and ui-kit's

### DIFF
--- a/.changeset/pr-62.md
+++ b/.changeset/pr-62.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Fix a CSS cascade-order bug that permanently hid the Dnd builder's palette/properties columns on desktop, regardless of viewport width. Also fixes the underlying `.prettierrc` import-sort regex that was silently undoing the fix on every format run.

--- a/.prettierrc
+++ b/.prettierrc
@@ -10,7 +10,7 @@
     "^next(.*)",
     "<THIRD_PARTY_MODULES>",
     "^~/(.*)$",
-    "^./*.*.(c|le|sc)ss",
+    "^\\.{1,2}/.*\\.(css|less|scss)$",
     "^[./]"
   ],
   "importOrderSeparation": true,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
-import './index.css';
 import '@jbpark/ui-kit/style.css';
+
+import './index.css';
 
 import Context from './components/context';
 import LiveDnd from './components/dnd';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,6 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
-import './index.css';
-
 import App from './App';
 import { Intro, Playground, Preview } from './pages';
 


### PR DESCRIPTION
## Summary
- Swap the CSS import order in `src/index.tsx` so `@jbpark/ui-kit/style.css` loads before `./index.css` — both are independently-compiled Tailwind builds, and ui-kit's unconditional `.hidden{display:none}` utility was landing after live-editor's own `@media(min-width:48rem){.md:block{...}}` rule in the concatenated stylesheet, permanently winning the cascade regardless of viewport width and hiding the Dnd builder's palette/properties columns even on desktop
- Remove the redundant direct `./index.css` import in `main.tsx` (already pulled in transitively via `App` → `index.tsx`)
- Fix the unescaped regex in `.prettierrc`'s `importOrder` (`"^./*.*.(c|le|sc)ss"`) that matched ANY path ending in css/less/scss — including bare package specifiers like `@jbpark/ui-kit/style.css` — not just relative stylesheet imports. This was silently re-sorting the two CSS imports back to the broken order on every `prettier --write` / pre-commit run.

## Test plan
- [x] `vitest run`, `tsc -b`, `eslint`
- [x] Local production build (`build:demo`) + verified compiled CSS ordering directly
- [x] Verified live via Chrome (screenshot) on the tunneled dev build — Drag & Drop mode now shows the 3-column desktop layout at 1280px width