### PR TITLE
chore(config): add SPA rewrite to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm run build:demo",
   "outputDirectory": "dist-demo",
-  "installCommand": "pnpm install"
+  "installCommand": "pnpm install",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## Summary
- Add a catch-all rewrite to `/index.html` so direct/hard navigation to client-side routes (`/editor`, `/preview`, `/playground`) doesn't 404 on Vercel
- Found while investigating the Dnd responsive layout bug: navigating straight to `/editor` returned a Vercel 404 (`DEPLOYMENT_NOT_FOUND`-style page) instead of the app, since there was no fallback rewrite for unknown paths

## Test plan
- [x] Matches the same pattern already used in `use-hooks`' `vercel.json`