### PR TITLE
feat(app): make the Editor-mode Splitter responsive

### DIFF
--- a/.changeset/pr-64.md
+++ b/.changeset/pr-64.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Make the Editor-mode Preview/CodeMirror Splitter responsive: it now stacks vertically on mobile instead of staying side-by-side.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   useDebounce,
   useHistoryState,
   useLocalStorage,
+  useResponsiveSize,
 } from '@jbpark/use-hooks';
 import { Button, Flex, Radio, Space, Splitter, message } from 'antd';
 
@@ -40,6 +41,9 @@ const App = () => {
     canRedo,
   } = useHistoryState(value);
   const [type, setType] = useState<'dnd' | 'editor'>('editor');
+
+  const { breakpoint } = useResponsiveSize();
+  const isMobile = breakpoint.current === 'xs' || breakpoint.current === 'sm';
 
   const navigate = useNavigate();
 
@@ -141,7 +145,7 @@ const App = () => {
         >
           <Live>
             {editable ? (
-              <Splitter>
+              <Splitter layout={isMobile ? 'vertical' : 'horizontal'}>
                 <Splitter.Panel
                   defaultSize="50%"
                   min="20%"


### PR DESCRIPTION
## Summary
- Stack the Preview/CodeMirror Splitter panels vertically on mobile (breakpoint xs/sm) instead of side-by-side, using antd Splitter's `layout` prop
- Detect mobile via use-hooks' `useResponsiveSize`, the same hook already used in the Dnd builder's responsive layout

## Test plan
- [x] `vitest run`, `tsc -b`, `eslint`
- [x] Verified live via Chrome at 1280px (side-by-side) and 390px (stacked)