### PR TITLE
feat(types): type data-binding attributes as BindingItem[]

### DIFF
--- a/.changeset/pr-65.md
+++ b/.changeset/pr-65.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Type the `data-binding` JSX attribute as `BindingItem[]`, giving editor autocomplete and compile-time errors while authoring binding configs instead of silent runtime failures.

--- a/src/types/data-attributes.d.ts
+++ b/src/types/data-attributes.d.ts
@@ -1,0 +1,14 @@
+import type { BindingItem } from '~/utils/ast/types';
+
+// Authored `data-binding` attributes are plain array literals parsed
+// statically out of the JSX source text (see src/utils/ast/binding.ts) — they
+// are never actually evaluated as React props at runtime. This augmentation
+// only exists to give editors/tsc real autocomplete and type-checking while
+// authoring them (e.g. in src/pages/playground/index.tsx), instead of the
+// default permissive `data-*` attribute typing that accepts anything.
+declare module 'react' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- must match the merged interface's type param name
+  interface HTMLAttributes<T> {
+    'data-binding'?: BindingItem[];
+  }
+}


### PR DESCRIPTION
## Summary
- Add `src/types/data-attributes.d.ts`, augmenting React's `HTMLAttributes` to type the `data-binding` JSX attribute as `BindingItem[]` instead of the default permissive `data-*` typing that accepts anything
- Gives real editor autocomplete and compile-time errors while authoring binding configs (e.g. `src/pages/playground/index.tsx`) — a typo'd field name now fails `tsc` instead of silently getting dropped at runtime by the Zod-based parser

## Test plan
- [x] `vitest run`, `tsc -b`, `eslint`
- [x] Deliberately introduced a `label` -> `lable` typo and confirmed `tsc` caught it, then reverted