### PR TITLE
add test coverage for extract.ts and update.ts

### DIFF
--- a/src/utils/ast/extract.test.ts
+++ b/src/utils/ast/extract.test.ts
@@ -1,0 +1,232 @@
+import * as t from '@babel/types';
+import { describe, expect, it } from 'vitest';
+
+import { clearExtractCache, extract, nodeToJSX } from './extract';
+import type { DataAttrNode } from './types';
+
+describe('extract', () => {
+  it('returns an empty array for code with no data attributes', () => {
+    expect(extract('<div>Hello</div>')).toEqual([]);
+  });
+
+  it('extracts a single element and its full field set', () => {
+    const [node] = extract(
+      `<div data-id="a" data-binding="[{label:'Text',property:'innerText'}]">Hello</div>`,
+    );
+
+    expect(node).toMatchObject({
+      tagName: 'div',
+      textContent: 'Hello',
+      bindings: [{ label: 'Text', property: 'innerText' }],
+    });
+    expect(node!.dataAttributes).toEqual([
+      { name: 'data-id', value: 'a', isStringLiteral: true },
+      {
+        name: 'data-binding',
+        value: "[{label:'Text',property:'innerText'}]",
+        isStringLiteral: true,
+      },
+    ]);
+    expect(node!.loc).toBeDefined();
+  });
+
+  it('extracts sibling top-level elements independently', () => {
+    const results = extract(`
+      <div data-id="a" data-binding="[{label:'A',property:'innerText'}]">A</div>
+      <div data-id="b" data-binding="[{label:'B',property:'innerText'}]">B</div>
+    `);
+
+    expect(results).toHaveLength(2);
+    expect(results.map(r => r.tagName)).toEqual(['div', 'div']);
+    expect(results[0]!.textContent).toBe('A');
+    expect(results[1]!.textContent).toBe('B');
+  });
+
+  it('does not treat a malformed data-binding value as fatal', () => {
+    const [node] = extract(
+      `<div data-id="a" data-binding="not valid js">x</div>`,
+    );
+
+    expect(node!.bindings).toEqual([]);
+  });
+
+  it('resolves member-expression tag names (e.g. ui.Button)', () => {
+    const [node] = extract(
+      `<ui.Button data-id="a" data-binding="[{label:'Label',property:'label'}]">Click</ui.Button>`,
+    );
+
+    expect(node!.tagName).toBe('ui.Button');
+  });
+
+  it('records rawChildren from generated child code when an innerHTML binding is present', () => {
+    const [node] = extract(
+      `<span data-id="a" data-binding="[{label:'Html',property:'innerHTML'}]"><b>bold</b> text</span>`,
+    );
+
+    expect(node!.rawChildren).toContain('<b>bold</b>');
+    expect(node!.rawChildren).toContain('text');
+  });
+
+  it('wraps each data-children element in a data-item wrapper, and does not duplicate it at the top level', () => {
+    const results = extract(`
+      <div data-id="a" data-binding="[{label:'Kids',property:'children'}]">
+        <p data-id="inner" data-binding="[{label:'P',property:'innerText'}]">child text</p>
+        <span>plain child, no data attrs</span>
+      </div>
+    `);
+
+    // Only the top-level "a" element is recorded — the children were pulled
+    // into its `children` array, not emitted as separate top-level entries.
+    expect(results).toHaveLength(1);
+
+    const [parent] = results;
+    expect(parent!.children).toHaveLength(2);
+
+    const [wrappedP, wrappedSpan] = parent!.children!;
+    expect(wrappedP!.tagName).toBe('div');
+    expect(wrappedP!.attributes).toEqual([
+      { name: 'data-item', value: 'true' },
+    ]);
+    expect(wrappedP!.children).toHaveLength(1);
+    expect(wrappedP!.children![0]).toMatchObject({
+      tagName: 'p',
+      textContent: 'child text',
+      bindings: [{ label: 'P', property: 'innerText' }],
+    });
+
+    // A plain child with no data-* attributes is still wrapped, but its own
+    // extracted entry carries no bindings.
+    expect(wrappedSpan!.children).toHaveLength(1);
+    expect(wrappedSpan!.children![0]).toMatchObject({
+      tagName: 'span',
+      bindings: [],
+    });
+  });
+
+  it('recurses into nested data-children regions', () => {
+    const results = extract(`
+      <div data-id="outer" data-binding="[{label:'Outer',property:'children'}]">
+        <div data-id="mid" data-binding="[{label:'Mid',property:'children'}]">
+          <em data-id="deep" data-binding="[{label:'Deep',property:'innerText'}]">deep text</em>
+        </div>
+      </div>
+    `);
+
+    expect(results).toHaveLength(1);
+
+    const mid = results[0]!.children![0]!.children![0]!;
+    expect(mid.tagName).toBe('div');
+
+    const deep = mid.children![0]!.children![0]!;
+    expect(deep).toMatchObject({ tagName: 'em', textContent: 'deep text' });
+  });
+
+  it('wraps a JSX fragment inside a data-children region as an isFragment node', () => {
+    const results = extract(`
+      <div data-id="a" data-binding="[{label:'Kids',property:'children'}]">
+        <>
+          <p data-id="p1" data-binding="[{label:'P1',property:'innerText'}]">one</p>
+          <p data-id="p2" data-binding="[{label:'P2',property:'innerText'}]">two</p>
+        </>
+      </div>
+    `);
+
+    const [fragmentChild] = results[0]!.children!;
+    expect(fragmentChild!.isFragment).toBe(true);
+    expect(fragmentChild!.tagName).toBe('');
+    expect(fragmentChild!.children).toHaveLength(2);
+  });
+
+  it('marks JSX elements inside an items array binding as processed so they are not also emitted at the top level', () => {
+    const results = extract(`
+      <ul
+        data-id="list"
+        data-binding="[{label:'Items',property:'items',type:'array'}]"
+        items={[
+          { node: <li data-id="item-1" data-binding="[{label:'T',property:'innerText'}]">one</li> },
+        ]}
+      >
+      </ul>
+    `);
+
+    // Only the <ul> itself is recorded — the <li> living inside the items
+    // array literal is not independently walked by traverse().
+    expect(results).toHaveLength(1);
+    expect(results[0]!.tagName).toBe('ul');
+  });
+
+  it('caches results by raw source string, and clearExtractCache() invalidates the cache', () => {
+    clearExtractCache();
+    const code = `<div data-id="a" data-binding="[{label:'A',property:'innerText'}]">A</div>`;
+
+    const first = extract(code);
+    const second = extract(code);
+    expect(second).toBe(first);
+
+    clearExtractCache();
+    const third = extract(code);
+    expect(third).not.toBe(first);
+    expect(third).toEqual(first);
+  });
+});
+
+describe('nodeToJSX', () => {
+  const makeNode = (overrides: Partial<DataAttrNode> = {}): DataAttrNode => ({
+    tagName: 'div',
+    attributes: [],
+    dataAttributes: [],
+    textContent: '',
+    ...overrides,
+  });
+
+  it('builds a JSX element with attributes and text content', () => {
+    const node = makeNode({
+      tagName: 'span',
+      attributes: [{ name: 'className', value: 'foo', isStringLiteral: true }],
+      textContent: 'hi',
+    });
+
+    const jsx = nodeToJSX(node);
+    expect(jsx).not.toBeNull();
+    expect(t.isJSXElement(jsx)).toBe(true);
+  });
+
+  it('builds a JSX fragment for isFragment nodes', () => {
+    const node = makeNode({
+      isFragment: true,
+      tagName: '',
+      children: [makeNode({ tagName: 'span', textContent: 'child' })],
+    });
+
+    const jsx = nodeToJSX(node);
+    expect(t.isJSXFragment(jsx)).toBe(true);
+  });
+
+  it('unwraps a data-item wrapper div to its single child', () => {
+    const wrapper = makeNode({
+      tagName: 'div',
+      dataAttributes: [{ name: 'data-item', value: 'true' }],
+      children: [makeNode({ tagName: 'p', textContent: 'inner' })],
+    });
+
+    const jsx = nodeToJSX(wrapper);
+    expect(jsx).not.toBeNull();
+    expect(
+      t.isJSXElement(jsx) && t.isJSXIdentifier(jsx.openingElement.name),
+    ).toBe(true);
+    expect(
+      t.isJSXElement(jsx) &&
+        t.isJSXIdentifier(jsx.openingElement.name) &&
+        jsx.openingElement.name.name,
+    ).toBe('p');
+  });
+
+  it('returns null for a data-item wrapper with no children', () => {
+    const wrapper = makeNode({
+      tagName: 'div',
+      dataAttributes: [{ name: 'data-item', value: 'true' }],
+    });
+
+    expect(nodeToJSX(wrapper)).toBeNull();
+  });
+});

--- a/src/utils/ast/update.test.ts
+++ b/src/utils/ast/update.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { bulkUpdate, update } from './update';
+
+const CODE = `
+<div data-id="a" data-binding="[{label:'Text',property:'innerText'}]">old text</div>
+<span data-id="b" data-binding="[{label:'Html',property:'innerHTML'}]"><i>old</i></span>
+<p data-id="c" data-binding="[{label:'Rich',property:'innerHTML',type:'richtext'}]">old rich</p>
+<ul data-id="d" data-binding="[{label:'Kids',property:'children'}]"><li>x</li></ul>
+<Icon data-id="e" data-binding="[{label:'Node',property:'icon',type:'jsx'}]" icon={<Old />} />
+<input data-id="f" data-binding="[{label:'Placeholder',property:'placeholder'}]" placeholder="old" />
+<input data-id="g" data-binding="[{label:'Count',property:'count'}]" count={1} />
+`;
+
+describe('update', () => {
+  it('replaces innerText content', () => {
+    const result = update(CODE, 'a', 'Text', 'new text');
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('>new text<');
+    expect(result.code).not.toContain('old text');
+  });
+
+  it('injects raw HTML as literal children for a plain innerHTML binding, unescaped', () => {
+    const result = update(CODE, 'b', 'Html', '<b>new & "quoted"</b>');
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('<span data-id="b"');
+    expect(result.code).toContain('<b>new & "quoted"</b>');
+    // The raw value must land as literal markup, not inside a {} expression.
+    expect(result.code).not.toContain('{<b>new');
+  });
+
+  it('sets dangerouslySetInnerHTML for a richtext binding', () => {
+    const result = update(CODE, 'c', 'Rich', 'new <em>rich</em>');
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('dangerouslySetInnerHTML');
+    expect(result.code).toContain('new <em>rich</em>');
+    // richtext clears any prior JSX children instead of leaving old markup behind.
+    expect(result.code).not.toContain('old rich');
+  });
+
+  it('adds dangerouslySetInnerHTML when the attribute did not previously exist', () => {
+    const code = `<p data-id="x" data-binding="[{label:'Rich',property:'innerHTML',type:'richtext'}]">plain</p>`;
+    const result = update(code, 'x', 'Rich', 'injected');
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('dangerouslySetInnerHTML={{');
+    expect(result.code).toContain('__html: "injected"');
+  });
+
+  it('replaces children from a JSON-encoded DataAttrNode array', () => {
+    const value = JSON.stringify([
+      {
+        tagName: 'li',
+        attributes: [],
+        dataAttributes: [],
+        textContent: 'y',
+      },
+    ]);
+
+    const result = update(CODE, 'd', 'Kids', value);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('<li>y</li>');
+    expect(result.code).not.toContain('<li>x</li>');
+  });
+
+  it('fails gracefully when the children value is not valid JSON', () => {
+    const result = update(CODE, 'd', 'Kids', 'not json');
+
+    expect(result.success).toBe(false);
+    expect(result.code).toBe(CODE);
+  });
+
+  it('injects a jsx-type attribute value as an expression, preserving its own JSX syntax', () => {
+    const result = update(
+      CODE,
+      'e',
+      'Node',
+      '<NewIcon size={5 > 2 ? 1 : 2} />',
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('icon={<NewIcon size={5 > 2 ? 1 : 2} />}');
+  });
+
+  it('updates a plain string attribute', () => {
+    const result = update(CODE, 'f', 'Placeholder', 'new placeholder');
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('placeholder="new placeholder"');
+  });
+
+  it('updates a plain attribute with a numeric expression value', () => {
+    const result = update(CODE, 'g', 'Count', '42');
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('count={42}');
+  });
+
+  it('returns success: false and the original code when the data-id is not found', () => {
+    const result = update(CODE, 'does-not-exist', 'Text', 'nope');
+
+    expect(result).toEqual({ code: CODE, success: false });
+  });
+
+  it('returns success: false and the original code when the label does not match any binding', () => {
+    const result = update(CODE, 'a', 'NoSuchLabel', 'nope');
+
+    expect(result).toEqual({ code: CODE, success: false });
+  });
+});
+
+describe('bulkUpdate', () => {
+  it('applies every entry in order and reports overall success', () => {
+    const result = bulkUpdate(CODE, [
+      { dataId: 'a', label: 'Text', value: 'bulk text' },
+      { dataId: 'f', label: 'Placeholder', value: 'bulk placeholder' },
+      { dataId: 'e', label: 'Node', value: '<Bulk />' },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('>bulk text<');
+    expect(result.code).toContain('placeholder="bulk placeholder"');
+    expect(result.code).toContain('icon={<Bulk />}');
+  });
+
+  it('reports success: false if any entry fails, while still applying the ones that succeed', () => {
+    const result = bulkUpdate(CODE, [
+      { dataId: 'a', label: 'Text', value: 'bulk text' },
+      { dataId: 'missing', label: 'Text', value: 'nope' },
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.code).toContain('>bulk text<');
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for `src/utils/ast/extract.ts` and `update.ts`, the two largest and most complex files in the AST module — both had zero tests. Follow-up to #69 (the simplification refactor).

## Changes

- `extract.test.ts`: single/multiple top-level nodes, malformed `data-binding`, member-expression tag names, `innerHTML` `rawChildren`, `data-children` wrapping (nested regions, fragment children, plain non-data-attr children), `items`-array element de-duplication against the top-level `traverse()`, source-keyed caching + `clearExtractCache()`, and `nodeToJSX()` including the `data-item` wrapper unwrap/empty cases
- `update.test.ts`: every binding kind (`innerText`, `innerHTML`, `richtext` incl. adding a missing `dangerouslySetInnerHTML` attribute, `children` incl. invalid-JSON failure, `jsx`-type attribute, plain string/numeric attribute), missing-id/missing-label failure cases, and `bulkUpdate`'s all-succeed/partial-failure behavior

## Type of Change

- [x] ✅ test — test addition

## Scope

- [x] AST transform (`src/utils/ast`)

## Validation

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`

## Checklist

- [x] Commit messages follow gitmoji + conventional-commit style
- [x] No unrelated changes included