### PR TITLE
🐛 fix: decode saved code with useLocalStorage on preview page

### DIFF
--- a/.changeset/pr-73.md
+++ b/.changeset/pr-73.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Improve state synchronization in the preview page by utilizing the local storage hook for persistent code viewing.

--- a/src/pages/preview/index.tsx
+++ b/src/pages/preview/index.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from 'react';
+import { useLocalStorage } from '@jbpark/use-hooks';
 
 import Live from '~/.';
 import { STORAGE_KEY } from '~/constants';
 
 const PreviewPage = () => {
-  const code = useMemo(() => localStorage.getItem(STORAGE_KEY), []);
+  const [code] = useLocalStorage(STORAGE_KEY, '');
 
   if (!code) {
     return <div className="p-6 text-gray-500">No saved code found.</div>;


### PR DESCRIPTION
## Root cause
The preview page read `localStorage.getItem(STORAGE_KEY)` directly, but the editor page saves through `@jbpark/use-hooks`' `useLocalStorage`, which `JSON.stringify`s on write. So the preview page was always compiling a JSON-encoded string (quotes + escaped newlines) instead of the real code — which happens to be syntactically valid JS as a single string-literal statement, so it silently produced zero exports and always showed "Component not found", regardless of what was actually saved.

## Fix
Switch the preview page to the same `useLocalStorage` hook the editor page already uses, so both sides share one encode/decode path instead of drifting apart again later.

## Verification
Reproduced and confirmed the fix via headless Chrome (CDP) — before the fix, a fresh page load of `/preview` always showed "Component not found" (even for the plain unmodified default template); after the fix, saved code renders correctly. `pnpm lint` / `pnpm check-types` / `pnpm test` (115/115) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)