### PR TITLE
🐛 fix: add delete button to properties panel

### DIFF
--- a/.changeset/pr-74.md
+++ b/.changeset/pr-74.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add a delete button to the drag-and-drop panel to allow removing sections directly from the editor.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -352,6 +352,7 @@ const Dnd = ({
             <Panel
               item={sections.find(s => s.id === selectedId)}
               onChange={onChange}
+              onDelete={onDelete}
             />
           </div>
           <Button
@@ -384,6 +385,7 @@ const Dnd = ({
             <Panel
               item={sections.find(s => s.id === selectedId)}
               onChange={onChange}
+              onDelete={onDelete}
             />
           </Drawer>
         </div>

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 
-import { Toast, Typography } from '@jbpark/ui-kit';
+import { Button, Toast, Typography } from '@jbpark/ui-kit';
+import { Trash } from 'lucide-react';
 
 import type { Section } from '~/types';
 import { cn } from '~/utils';
@@ -11,9 +12,10 @@ import Node from './node';
 interface Props {
   item?: Section;
   onChange?: (next: Partial<Section>) => void;
+  onDelete?: (id: string) => void;
 }
 
-const Panel = ({ item, onChange }: Props) => {
+const Panel = ({ item, onChange, onDelete }: Props) => {
   const { dataAttrNodes, updatedCode, parseError } = useMemo(() => {
     if (!item?.code) {
       return { dataAttrNodes: [], updatedCode: '', parseError: false };
@@ -65,9 +67,14 @@ const Panel = ({ item, onChange }: Props) => {
         //
       )}
     >
-      <Typography.Title className="text-lg font-semibold">
-        {item.name}
-      </Typography.Title>
+      <div className="flex items-center justify-between">
+        <Typography.Title className="text-lg font-semibold">
+          {item.name}
+        </Typography.Title>
+        {onDelete && (
+          <Button danger icon={<Trash />} onClick={() => onDelete(item.id)} />
+        )}
+      </div>
       {!dataAttrNodes.length && (
         <Typography.Text className="text-xs text-gray-400">
           No editable elements.


### PR DESCRIPTION
## Root cause
Sortable's own delete button only appears when a section is selected, but on mobile that's also when the Properties drawer opens as a bottom sheet, which covers it — leaving no way to delete a section on mobile.

## Fix
Add a delete button next to the title in the properties panel itself, wired to the existing `onDelete` handler, so it's reachable from both the mobile drawer and the desktop sidebar.

## Verification
`pnpm lint` / `pnpm check-types` / `pnpm test` (115/115) all pass. Manually verified on a real device via a tunneled dev server (Drag & Drop mode → add a component → tap it to open Properties → delete button works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)