### PR TITLE
🐛 fix: stop misdetecting plain JS as TypeScript

### DIFF
--- a/.changeset/pr-75.md
+++ b/.changeset/pr-75.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fix false-positive TypeScript detection for ES module import and export aliasing syntax.

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -19,6 +19,8 @@ export const REGEX = {
   COMMENT: /\{\s*\/\*[\s\S]*?\*\/\s*\}/g,
   SECTION: /<section[\s\S]*?<\/section>/g,
   DATA_NAME: /data-name=["']([^"']+)["']/,
+  MODULE_IMPORT_EXPORT_LINE:
+    /^\s*(?:import|export)\b[^\n]*\bfrom\s+['"][^'"]*['"];?\s*$/gm,
 } as const;
 
 export const TS_PATTERNS = [

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// utils/index.ts imports @jbpark/ui-kit for baseModules, which pulls in its
+// CSS — stub both out since detectTypeScript doesn't touch either.
+vi.mock('@jbpark/ui-kit', () => ({}));
+vi.mock('@jbpark/ui-kit/utils', () => ({}));
+
+const { detectTypeScript } = await import('./index');
+
+describe('detectTypeScript', () => {
+  it('does not flag the default template as TypeScript', () => {
+    const code = `
+import * as ui from 'ui-kit';
+import { cn } from 'ui-kit/utils';
+
+const App = () => {
+  return (
+    <main id="app-container"></main>
+  )
+}
+
+export default App;
+`;
+    expect(detectTypeScript(code)).toBe(false);
+  });
+
+  it('does not flag a named import alias as TypeScript', () => {
+    const code = `
+import { Foo as Bar } from 'ui-kit';
+const App = () => <Bar />;
+export default App;
+`;
+    expect(detectTypeScript(code)).toBe(false);
+  });
+
+  it('does not flag an `export * as` re-export as TypeScript', () => {
+    const code = `
+export * as ns from 'ui-kit';
+const App = () => <div />;
+export default App;
+`;
+    expect(detectTypeScript(code)).toBe(false);
+  });
+
+  it('flags a real `interface` declaration as TypeScript', () => {
+    const code = `
+interface Props { name: string }
+const App = (props: Props) => <div>{props.name}</div>;
+export default App;
+`;
+    expect(detectTypeScript(code)).toBe(true);
+  });
+
+  it('flags a real `type` alias as TypeScript', () => {
+    const code = `
+type Foo = { name: string };
+const App = () => <div>hi</div>;
+export default App;
+`;
+    expect(detectTypeScript(code)).toBe(true);
+  });
+
+  it('flags a real `as` type assertion as TypeScript', () => {
+    const code = `
+const App = () => {
+  const x = (window as any).foo;
+  return <div>{x}</div>;
+};
+export default App;
+`;
+    expect(detectTypeScript(code)).toBe(true);
+  });
+
+  it('flags a real `enum` declaration as TypeScript', () => {
+    const code = `
+enum Color { Red, Blue }
+const App = () => <div>{Color.Red}</div>;
+export default App;
+`;
+    expect(detectTypeScript(code)).toBe(true);
+  });
+
+  it('flags an optional parameter as TypeScript', () => {
+    const code = `
+const App = (props?: { name: string }) => <div>{props?.name}</div>;
+export default App;
+`;
+    expect(detectTypeScript(code)).toBe(true);
+  });
+
+  it('still detects a real `as` assertion on an exported line', () => {
+    const code = `
+import * as ui from 'ui-kit';
+export const x = (5 as unknown) as string;
+const App = () => <div>{x}</div>;
+export default App;
+`;
+    expect(detectTypeScript(code)).toBe(true);
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -120,7 +120,14 @@ export const transformCode = (code: string): string => {
 };
 
 export const detectTypeScript = (code: string): boolean => {
-  return TS_PATTERNS.some(pattern => pattern.test(code));
+  // Strip `import`/`export ... from '...'` lines first — aliasing via `as`
+  // (`import * as ui from 'ui-kit'`, `import { Foo as Bar } from '...'`) is
+  // plain ES module syntax, not a TypeScript signal, but it otherwise
+  // matches the `as\s+\w+` pattern below and made every piece of code look
+  // like TypeScript.
+  const withoutModuleLines = code.replace(REGEX.MODULE_IMPORT_EXPORT_LINE, '');
+
+  return TS_PATTERNS.some(pattern => pattern.test(withoutModuleLines));
 };
 
 const compileModule = (


### PR DESCRIPTION
## Root cause
`import * as ui from '...'` (and named import/export aliases like `{ Foo as Bar }`) always matched the `as\s+\w+` TypeScript pattern, so `detectTypeScript` returned `true` for nearly every piece of code — even the plain default template — sending it through the full TypeScript compiler unnecessarily on every compile.

## Fix
Strip `import`/`export ... from '...'` lines before testing against `TS_PATTERNS`, since that aliasing is plain ES module syntax, not a TypeScript signal. Real `as` assertions elsewhere in the code (even on an exported line) still correctly detect as TypeScript.

## Verification
Added `src/utils/index.test.ts` covering both the false-positive fixes (default template, named import alias, `export * as` re-export) and real TypeScript detection cases (interface, type alias, `as` assertion, enum, optional param, and an `as` assertion on an exported line). `pnpm lint` / `pnpm check-types` / `pnpm test` (124/124) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)