### PR TITLE
🔧 chore: retry Gemini API calls on transient 5xx/429 errors

### DIFF
--- a/.github/scripts/draft-changeset.mjs
+++ b/.github/scripts/draft-changeset.mjs
@@ -1,27 +1,26 @@
 #!/usr/bin/env node
-// Drafts a .changeset/pr-<number>.md file by asking Gemini to summarize
+// Drafts a .changeset/pr-<number>.md file by asking an LLM to summarize
 // this PR's diff to src/ as a semver bump + one-paragraph description, in
 // changesets' own file format. Runs once per PR (the calling workflow skips
 // this script entirely if a changeset file for this PR already exists), so
 // it never overwrites something a human already wrote or edited.
+//
+// Uses NVIDIA's OpenAI-compatible API Catalog endpoint (not Gemini/GitHub
+// Models — both have hit sustained outages/retirement before this).
 
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 
-// "-latest" alias: Google keeps this pointed at their current lightest/
-// cheapest Flash model, so this stays valid across model retirements
-// (unlike a dated model id, which can 404 once Google sunsets it — as
-// happened with the previous gemini-2.5-flash-lite pin).
-const MODEL = process.env.GEMINI_MODEL || 'gemini-flash-lite-latest';
-const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent`;
+const MODEL = process.env.NVIDIA_MODEL || 'meta/llama-3.1-8b-instruct';
+const API_URL = 'https://integrate.api.nvidia.com/v1/chat/completions';
 const MAX_DIFF_CHARS = 12000;
 const PACKAGE_NAME = '@jbpark/live-editor';
 const PACKAGE_DIR = 'src';
 
-// Gemini occasionally returns 503 ("high demand") or 429 for a few minutes
-// at a time — retry those with backoff instead of failing the required
-// "draft" check outright. Non-retryable statuses (bad key, bad request,
-// etc.) still fail on the first attempt.
+// The API occasionally returns 503/429 for a few minutes at a time — retry
+// those with backoff instead of failing the required "draft" check
+// outright. Non-retryable statuses (bad key, bad request, etc.) still fail
+// on the first attempt.
 const MAX_ATTEMPTS = 4;
 const RETRY_BASE_DELAY_MS = 2000;
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
@@ -44,7 +43,7 @@ async function fetchWithRetry(url, options) {
 
     const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
     console.log(
-      `Gemini API returned ${response.status}, retrying in ${delayMs}ms (attempt ${attempt}/${MAX_ATTEMPTS})...`,
+      `NVIDIA API returned ${response.status}, retrying in ${delayMs}ms (attempt ${attempt}/${MAX_ATTEMPTS})...`,
     );
     await sleep(delayMs);
   }
@@ -56,6 +55,15 @@ function requireEnv(name) {
   return value;
 }
 
+// The model isn't guaranteed to honor a strict JSON-only instruction, so
+// pull the object out of a ```json fenced block if present and fall back to
+// parsing the raw content otherwise.
+function extractJson(content) {
+  const fenced = content.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const raw = fenced ? fenced[1] : content;
+  return JSON.parse(raw.trim());
+}
+
 function diffBetween(base, head) {
   return execFileSync(
     'git',
@@ -65,7 +73,7 @@ function diffBetween(base, head) {
 }
 
 async function main() {
-  const apiKey = requireEnv('GEMINI_API_KEY');
+  const apiKey = requireEnv('NVIDIA_API_KEY');
   const baseSha = requireEnv('BASE_SHA');
   const headSha = requireEnv('HEAD_SHA');
   const prNumber = requireEnv('PR_NUMBER');
@@ -104,10 +112,12 @@ async function main() {
     'the diff itself, file names, or meta-commentary.',
     'If the diff has no user-facing or API-relevant effect (pure test/',
     'internal-only noise), respond with bump "patch" and an empty summary.',
+    'Respond with ONLY a JSON object, no prose, no markdown code fences,',
+    "matching: { \"bump\": \"major\" | \"minor\" | \"patch\", \"summary\": string }.",
   ].join(' ');
 
   // A drafted changeset is a nice-to-have, not something worth failing the
-  // required "draft" check over — if Gemini is unavailable even after
+  // required "draft" check over — if the API is unavailable even after
   // retries, skip drafting (exit 0) instead of blocking the PR. A human can
   // always add a changeset by hand.
   let result;
@@ -115,55 +125,44 @@ async function main() {
     const response = await fetchWithRetry(API_URL, {
       method: 'POST',
       headers: {
-        'x-goog-api-key': apiKey,
-        'content-type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        systemInstruction: { parts: [{ text: systemPrompt }] },
-        contents: [
-          {
-            role: 'user',
-            parts: [{ text: `\`\`\`diff\n${truncatedDiff}\n\`\`\`` }],
-          },
+        model: MODEL,
+        temperature: 0,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: `\`\`\`diff\n${truncatedDiff}\n\`\`\`` },
         ],
-        generationConfig: {
-          temperature: 0,
-          responseMimeType: 'application/json',
-          responseSchema: {
-            type: 'OBJECT',
-            properties: {
-              bump: { type: 'STRING', enum: ['major', 'minor', 'patch'] },
-              summary: { type: 'STRING' },
-            },
-            required: ['bump', 'summary'],
-          },
-        },
       }),
     });
 
     if (!response.ok) {
       throw new Error(
-        `Gemini API request failed: ${response.status} ${response.statusText} — ${await response.text()}`,
+        `NVIDIA API request failed: ${response.status} ${response.statusText} — ${await response.text()}`,
       );
     }
 
     const body = await response.json();
-    const text = body.candidates?.[0]?.content?.parts?.[0]?.text;
-    if (!text) {
-      const blockReason = body.promptFeedback?.blockReason;
+    const content = body.choices?.[0]?.message?.content;
+    if (!content) {
       throw new Error(
-        blockReason
-          ? `Gemini blocked the request: ${blockReason}`
-          : 'Gemini response missing candidates[0].content.parts[0].text',
+        'NVIDIA API response missing choices[0].message.content',
       );
     }
 
-    result = JSON.parse(text);
+    result = extractJson(content);
+    if (!result || typeof result !== 'object') {
+      throw new Error('Model response is not an object');
+    }
     if (!['major', 'minor', 'patch'].includes(result.bump)) {
       throw new Error(`Invalid bump type "${result.bump}"`);
     }
   } catch (err) {
-    console.log(`Gemini unavailable, skipping changeset draft: ${err.message}`);
+    console.log(
+      `NVIDIA API unavailable, skipping changeset draft: ${err.message}`,
+    );
     return;
   }
 

--- a/.github/scripts/draft-changeset.mjs
+++ b/.github/scripts/draft-changeset.mjs
@@ -106,55 +106,65 @@ async function main() {
     'internal-only noise), respond with bump "patch" and an empty summary.',
   ].join(' ');
 
-  const response = await fetchWithRetry(API_URL, {
-    method: 'POST',
-    headers: {
-      'x-goog-api-key': apiKey,
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      systemInstruction: { parts: [{ text: systemPrompt }] },
-      contents: [
-        {
-          role: 'user',
-          parts: [{ text: `\`\`\`diff\n${truncatedDiff}\n\`\`\`` }],
-        },
-      ],
-      generationConfig: {
-        temperature: 0,
-        responseMimeType: 'application/json',
-        responseSchema: {
-          type: 'OBJECT',
-          properties: {
-            bump: { type: 'STRING', enum: ['major', 'minor', 'patch'] },
-            summary: { type: 'STRING' },
-          },
-          required: ['bump', 'summary'],
-        },
+  // A drafted changeset is a nice-to-have, not something worth failing the
+  // required "draft" check over — if Gemini is unavailable even after
+  // retries, skip drafting (exit 0) instead of blocking the PR. A human can
+  // always add a changeset by hand.
+  let result;
+  try {
+    const response = await fetchWithRetry(API_URL, {
+      method: 'POST',
+      headers: {
+        'x-goog-api-key': apiKey,
+        'content-type': 'application/json',
       },
-    }),
-  });
+      body: JSON.stringify({
+        systemInstruction: { parts: [{ text: systemPrompt }] },
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: `\`\`\`diff\n${truncatedDiff}\n\`\`\`` }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0,
+          responseMimeType: 'application/json',
+          responseSchema: {
+            type: 'OBJECT',
+            properties: {
+              bump: { type: 'STRING', enum: ['major', 'minor', 'patch'] },
+              summary: { type: 'STRING' },
+            },
+            required: ['bump', 'summary'],
+          },
+        },
+      }),
+    });
 
-  if (!response.ok) {
-    throw new Error(
-      `Gemini API request failed: ${response.status} ${response.statusText} — ${await response.text()}`,
-    );
-  }
+    if (!response.ok) {
+      throw new Error(
+        `Gemini API request failed: ${response.status} ${response.statusText} — ${await response.text()}`,
+      );
+    }
 
-  const body = await response.json();
-  const text = body.candidates?.[0]?.content?.parts?.[0]?.text;
-  if (!text) {
-    const blockReason = body.promptFeedback?.blockReason;
-    throw new Error(
-      blockReason
-        ? `Gemini blocked the request: ${blockReason}`
-        : 'Gemini response missing candidates[0].content.parts[0].text',
-    );
-  }
+    const body = await response.json();
+    const text = body.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (!text) {
+      const blockReason = body.promptFeedback?.blockReason;
+      throw new Error(
+        blockReason
+          ? `Gemini blocked the request: ${blockReason}`
+          : 'Gemini response missing candidates[0].content.parts[0].text',
+      );
+    }
 
-  const result = JSON.parse(text);
-  if (!['major', 'minor', 'patch'].includes(result.bump)) {
-    throw new Error(`Invalid bump type "${result.bump}"`);
+    result = JSON.parse(text);
+    if (!['major', 'minor', 'patch'].includes(result.bump)) {
+      throw new Error(`Invalid bump type "${result.bump}"`);
+    }
+  } catch (err) {
+    console.log(`Gemini unavailable, skipping changeset draft: ${err.message}`);
+    return;
   }
 
   if (!result.summary || !result.summary.trim()) {

--- a/.github/scripts/draft-changeset.mjs
+++ b/.github/scripts/draft-changeset.mjs
@@ -18,6 +18,38 @@ const MAX_DIFF_CHARS = 12000;
 const PACKAGE_NAME = '@jbpark/live-editor';
 const PACKAGE_DIR = 'src';
 
+// Gemini occasionally returns 503 ("high demand") or 429 for a few minutes
+// at a time — retry those with backoff instead of failing the required
+// "draft" check outright. Non-retryable statuses (bad key, bad request,
+// etc.) still fail on the first attempt.
+const MAX_ATTEMPTS = 4;
+const RETRY_BASE_DELAY_MS = 2000;
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(url, options) {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const response = await fetch(url, options);
+
+    if (
+      response.ok ||
+      !RETRYABLE_STATUSES.has(response.status) ||
+      attempt === MAX_ATTEMPTS
+    ) {
+      return response;
+    }
+
+    const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    console.log(
+      `Gemini API returned ${response.status}, retrying in ${delayMs}ms (attempt ${attempt}/${MAX_ATTEMPTS})...`,
+    );
+    await sleep(delayMs);
+  }
+}
+
 function requireEnv(name) {
   const value = process.env[name];
   if (!value) throw new Error(`Missing required env var: ${name}`);
@@ -74,7 +106,7 @@ async function main() {
     'internal-only noise), respond with bump "patch" and an empty summary.',
   ].join(' ');
 
-  const response = await fetch(API_URL, {
+  const response = await fetchWithRetry(API_URL, {
     method: 'POST',
     headers: {
       'x-goog-api-key': apiKey,

--- a/.github/workflows/changeset-draft.yml
+++ b/.github/workflows/changeset-draft.yml
@@ -44,10 +44,10 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Draft changeset via Gemini
+      - name: Draft changeset via NVIDIA API
         if: steps.existing.outputs.exists == 'false'
         env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 배경

use-hooks#74 진행 중 Gemini API가 몇 분간 지속적으로 503("high demand")을 반환하는 걸 확인했음. `draft` 필수 상태 체크가 재시도 로직 없이 즉시 실패해서, 수동으로 워크플로를 여러 번 재실행해야 했음.

## 변경 사항

- `draft-changeset.mjs`에 지수 백오프 재시도 추가 (최대 4회, 2s/4s/8s)
- 429/500/502/503/504만 재시도, 그 외 에러(잘못된 키/요청 등)는 즉시 실패