### PR TITLE
refactor(ast): replace regex-based section parser with Babel AST

### DIFF
--- a/.changeset/pr-78.md
+++ b/.changeset/pr-78.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add support for parsing and manipulating JSX documents, including extracting sections, replacing sections, and generating section previews.

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -15,10 +15,6 @@ export const DATA_ATTR = {
 export const REGEX = {
   NUMBER: /^\d+(\.\d+)?$/,
   BOOLEAN_OR_NULL: /^(true|false|null|undefined)$/,
-  CONTAINER: /(<main[^>]*id=["']app-container["'][^>]*>)([\s\S]*?)(<\/main>)/m,
-  COMMENT: /\{\s*\/\*[\s\S]*?\*\/\s*\}/g,
-  SECTION: /<section[\s\S]*?<\/section>/g,
-  DATA_NAME: /data-name=["']([^"']+)["']/,
   MODULE_IMPORT_EXPORT_LINE:
     /^\s*(?:import|export)\b[^\n]*\bfrom\s+['"][^'"]*['"];?\s*$/gm,
 } as const;

--- a/src/utils/ast/document.test.ts
+++ b/src/utils/ast/document.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  generateDocumentCode,
+  generateSectionPreview,
+  getSections,
+  parseDocument,
+  replaceDocumentSections,
+} from './document';
+
+const FULL_CODE = `
+import * as ui from 'ui-kit';
+
+const App = () => {
+  return (
+    <main id="app-container">
+      <section data-name="Hero"><h1>Hero</h1></section>
+      <section data-name="Features"><p>Features</p></section>
+    </main>
+  )
+}
+
+export default App;
+`;
+
+const EMPTY_CODE = `
+const App = () => {
+  return (
+    <main id="app-container"></main>
+  )
+}
+
+export default App;
+`;
+
+describe('parseDocument', () => {
+  it('locates the app-container element', () => {
+    const doc = parseDocument(FULL_CODE);
+
+    expect(doc?.container).toBeDefined();
+  });
+
+  it('returns undefined when no app-container exists', () => {
+    const doc = parseDocument(`<main id="other"></main>`);
+
+    expect(doc).toBeUndefined();
+  });
+
+  it('returns undefined for unparsable code instead of throwing', () => {
+    expect(() => parseDocument('<main id="app-container">')).not.toThrow();
+    expect(parseDocument('<main id="app-container">')).toBeUndefined();
+  });
+});
+
+describe('getSections', () => {
+  it('extracts each top-level <section> in document order', () => {
+    const doc = parseDocument(FULL_CODE)!;
+    const sections = getSections(doc);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0]).toMatchObject({ id: '0', name: 'Hero' });
+    expect(sections[1]).toMatchObject({ id: '1', name: 'Features' });
+    expect(sections[0]!.code).toContain('<h1>Hero</h1>');
+  });
+
+  it('falls back to a positional name when data-name is missing', () => {
+    const doc = parseDocument(`
+      const App = () => (
+        <main id="app-container">
+          <section><p>x</p></section>
+        </main>
+      );
+    `)!;
+
+    expect(getSections(doc)[0]!.name).toBe('1번째 컴포넌트');
+  });
+
+  it('returns an empty list for an empty container', () => {
+    const doc = parseDocument(EMPTY_CODE)!;
+
+    expect(getSections(doc)).toEqual([]);
+  });
+
+  it('ignores non-section children of the container', () => {
+    const doc = parseDocument(`
+      const App = () => (
+        <main id="app-container">
+          <div>not a section</div>
+          <section data-name="Real"><p>x</p></section>
+        </main>
+      );
+    `)!;
+
+    expect(getSections(doc)).toHaveLength(1);
+    expect(getSections(doc)[0]!.name).toBe('Real');
+  });
+});
+
+describe('replaceDocumentSections', () => {
+  it('replaces the container content with the given sections, in order', () => {
+    const next = replaceDocumentSections(FULL_CODE, [
+      `<section data-name="About"><p>About</p></section>`,
+    ]);
+
+    const sections = getSections(parseDocument(next)!);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0]!.name).toBe('About');
+  });
+
+  it('preserves non-section children of the container', () => {
+    const codeWithComment = `
+      const App = () => (
+        <main id="app-container">
+          {/* keep me */}
+          <section data-name="Hero"><h1>Hero</h1></section>
+        </main>
+      );
+    `;
+
+    const next = replaceDocumentSections(codeWithComment, [
+      `<section data-name="Hero2"><h1>Hero2</h1></section>
+`,
+    ]);
+
+    expect(next).toContain('keep me');
+    expect(getSections(parseDocument(next)!)[0]!.name).toBe('Hero2');
+  });
+
+  it('returns the original code unchanged when it fails to parse', () => {
+    const broken = '<main id="app-container">';
+
+    expect(replaceDocumentSections(broken, ['<section />'])).toBe(broken);
+  });
+
+  it('skips section strings that fail to parse instead of throwing', () => {
+    const next = replaceDocumentSections(FULL_CODE, [
+      '<section data-name="Good"><p>Good</p></section>',
+      '<not-jsx',
+    ]);
+
+    expect(getSections(parseDocument(next)!)).toHaveLength(1);
+  });
+});
+
+describe('generateSectionPreview', () => {
+  it('produces a document whose container holds only the given section', () => {
+    const preview = generateSectionPreview(
+      FULL_CODE,
+      `<section data-name="Solo"><p>Solo</p></section>`,
+    );
+
+    const sections = getSections(parseDocument(preview)!);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0]!.name).toBe('Solo');
+  });
+
+  it('returns fullCode unchanged when the section fails to parse', () => {
+    expect(generateSectionPreview(FULL_CODE, '<not-jsx')).toBe(FULL_CODE);
+  });
+
+  it('returns fullCode unchanged when fullCode fails to parse', () => {
+    const broken = '<main id="app-container">';
+
+    expect(generateSectionPreview(broken, '<section />')).toBe(broken);
+  });
+});
+
+describe('generateDocumentCode', () => {
+  it('regenerates code that still contains the surrounding module scaffold', () => {
+    const doc = parseDocument(FULL_CODE)!;
+    const code = generateDocumentCode(doc);
+
+    expect(code).toContain("import * as ui from 'ui-kit'");
+    expect(code).toContain('export default App');
+  });
+});

--- a/src/utils/ast/document.ts
+++ b/src/utils/ast/document.ts
@@ -1,0 +1,137 @@
+import { parse, parseExpression } from '@babel/parser';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+
+import type { Section } from '../../types';
+import { generateCode } from './helpers';
+
+const APP_CONTAINER_ID = 'app-container';
+const SECTION_TAG = 'section';
+const DATA_NAME_ATTR = 'data-name';
+
+export interface DocumentTree {
+  ast: t.File;
+  container: t.JSXElement;
+}
+
+const getTagName = (element: t.JSXElement): string => {
+  const name = element.openingElement.name;
+  return t.isJSXIdentifier(name) ? name.name : '';
+};
+
+const getAttrValue = (
+  element: t.JSXElement,
+  attrName: string,
+): string | undefined => {
+  const attr = element.openingElement.attributes.find(
+    (a): a is t.JSXAttribute =>
+      t.isJSXAttribute(a) &&
+      t.isJSXIdentifier(a.name) &&
+      a.name.name === attrName,
+  );
+
+  return attr && t.isStringLiteral(attr.value) ? attr.value.value : undefined;
+};
+
+const isSectionElement = (node: t.Node): node is t.JSXElement =>
+  t.isJSXElement(node) && getTagName(node) === SECTION_TAG;
+
+const isBlankJSXText = (node: t.Node): boolean =>
+  t.isJSXText(node) && !node.value.trim();
+
+const findContainer = (ast: t.File): t.JSXElement | undefined => {
+  let container: t.JSXElement | undefined;
+
+  traverse(ast, {
+    JSXElement(path) {
+      if (getAttrValue(path.node, 'id') === APP_CONTAINER_ID) {
+        container = path.node;
+        path.stop();
+      }
+    },
+  });
+
+  return container;
+};
+
+// Parses the whole source once into a single Babel AST — the shared "document
+// tree" that section-level (this file) and field-level (extract.ts/update.ts)
+// operations both read/write via @babel/* instead of the previous regex-based
+// section slicing living in a separate, conflicting parser.
+export const parseDocument = (code: string): DocumentTree | undefined => {
+  try {
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['jsx', 'typescript'],
+    });
+
+    const container = findContainer(ast);
+
+    return container ? { ast, container } : undefined;
+  } catch (e) {
+    console.warn('⚠️ Failed to parse document', e);
+    return undefined;
+  }
+};
+
+export const getSections = (doc: DocumentTree): Section[] =>
+  doc.container.children.filter(isSectionElement).map((node, index) => ({
+    id: `${index}`,
+    name: getAttrValue(node, DATA_NAME_ATTR) || `${index + 1}번째 컴포넌트`,
+    code: generateCode(node),
+  }));
+
+export const generateDocumentCode = (doc: DocumentTree): string =>
+  generateCode(doc.ast);
+
+const parseSectionNode = (code: string): t.JSXElement | undefined => {
+  try {
+    const expr = parseExpression(code, {
+      plugins: ['jsx', 'typescript'],
+    });
+
+    return t.isJSXElement(expr) ? expr : undefined;
+  } catch (e) {
+    console.warn('⚠️ Failed to parse section', e);
+    return undefined;
+  }
+};
+
+export const replaceDocumentSections = (
+  fullCode: string,
+  sectionCodes: string[],
+): string => {
+  const doc = parseDocument(fullCode);
+
+  if (!doc) {
+    return fullCode;
+  }
+
+  const nextSections = sectionCodes
+    .map(parseSectionNode)
+    .filter((node): node is t.JSXElement => Boolean(node));
+
+  const preserved = doc.container.children.filter(
+    child => !isSectionElement(child) && !isBlankJSXText(child),
+  );
+
+  doc.container.children = [...nextSections, ...preserved];
+
+  return generateDocumentCode(doc);
+};
+
+export const generateSectionPreview = (
+  fullCode: string,
+  sectionCode: string,
+): string => {
+  const doc = parseDocument(fullCode);
+  const sectionNode = parseSectionNode(sectionCode);
+
+  if (!doc || !sectionNode) {
+    return fullCode;
+  }
+
+  doc.container.children = [sectionNode];
+
+  return generateDocumentCode(doc);
+};

--- a/src/utils/ast/index.ts
+++ b/src/utils/ast/index.ts
@@ -21,6 +21,14 @@ export {
 } from './value';
 export { generateCode } from './helpers';
 export { clearExtractCache, extract } from './extract';
+export type { DocumentTree } from './document';
+export {
+  generateDocumentCode,
+  generateSectionPreview,
+  getSections,
+  parseDocument,
+  replaceDocumentSections,
+} from './document';
 export { bulkUpdate, update } from './update';
 export { clone, fillIds, replaceIds } from './tree';
 export type { ValidationResult } from './validate';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,12 @@ import type * as TS from 'typescript';
 import type { Module, Section } from '~/types';
 
 import { CONFIG, REGEX, TS_PATTERNS } from '../constants';
+import {
+  generateSectionPreview,
+  getSections,
+  parseDocument,
+  replaceDocumentSections,
+} from './ast/document';
 
 const ts = await import('typescript');
 
@@ -186,51 +192,17 @@ const compileModule = (
 };
 
 export const extractSections = (code: string): Section[] => {
-  const cleanCode = code.replace(REGEX.COMMENT, '');
-  const matches = [...cleanCode.matchAll(REGEX.SECTION)];
+  const doc = parseDocument(code);
 
-  return matches.map((m, i) => {
-    const sectionCode = m[0];
-
-    const dataNameMatch = sectionCode.match(REGEX.DATA_NAME);
-
-    return {
-      code: sectionCode,
-      id: `${i}`,
-      name: dataNameMatch?.[1] || `${i + 1}번째 컴포넌트`,
-    };
-  });
+  return doc ? getSections(doc) : [];
 };
 
 export const replaceSections = (code: string, sections: string[]): string => {
-  const comments = [...code.matchAll(REGEX.COMMENT)].map(match => match[0]);
-
-  const cleanCode = code.replace(REGEX.SECTION, '');
-  const match = cleanCode.match(REGEX.CONTAINER);
-
-  if (match) {
-    const [, openTag, , closeTag] = match;
-    const allContent = [...sections, ...comments].join('\n');
-
-    return cleanCode.replace(
-      REGEX.CONTAINER,
-      `${openTag}\n${allContent}\n${closeTag}`,
-    );
-  }
-
-  return code;
+  return replaceDocumentSections(code, sections);
 };
 
 export const generateSection = (code: string, fullCode: string) => {
-  const match = fullCode.match(REGEX.CONTAINER);
-
-  if (!match) {
-    return fullCode;
-  }
-
-  const [, openTag, , closeTag] = match;
-
-  return fullCode.replace(REGEX.CONTAINER, `${openTag}\n${code}\n${closeTag}`);
+  return generateSectionPreview(fullCode, code);
 };
 
 const scriptCache = new Map<string, string>();


### PR DESCRIPTION
## Summary
- add `src/utils/ast/document.ts`: parse the whole document once into a Babel AST, locate `app-container`, and derive/replace/preview `<section>` children via AST traversal instead of `REGEX.CONTAINER/SECTION/DATA_NAME/COMMENT`
- `utils/index.ts`'s `extractSections`/`replaceSections`/`generateSection` now delegate to `document.ts` — public signatures unchanged, so `dnd.tsx`, `renderer.tsx`, and `panel.tsx` need no changes
- `constants/index.ts`: drop the now-unused `REGEX.CONTAINER/SECTION/DATA_NAME/COMMENT` entries (`NUMBER`/`BOOLEAN_OR_NULL`/`MODULE_IMPORT_EXPORT_LINE` kept)

Part of the "unify parser + incremental codegen" architecture work (issue #76), Stage 1 of 3 — this stage removes the regex-vs-AST parser conflict for section-level parsing. Stage 2 (cache consolidation) and Stage 3 (Proxy/Immer incremental codegen) follow as separate PRs.

## Test plan
- [x] `document.test.ts` (15 cases): section extraction/ordering, missing data-name fallback, parse-failure fallback, non-section child preservation, single-section preview generation
- [x] full suite (139 tests), typecheck, lint all pass
- [x] manually verified in a running dev instance: edited code to two sections → live preview renders both → Drag & Drop tab shows both sections → deleted one → remaining code regenerated correctly