### PR TITLE
refactor(utils): extract shared bounded-cache helper

### DIFF
--- a/.changeset/pr-79.md
+++ b/.changeset/pr-79.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Added bounded caching to improve performance by limiting the number of cached items and evicting the oldest entry when the limit is reached.

--- a/src/utils/ast/extract.ts
+++ b/src/utils/ast/extract.ts
@@ -4,6 +4,7 @@ import * as t from '@babel/types';
 import { nanoid } from 'nanoid';
 
 import { BINDING_PROP, CONFIG, DATA_ATTR } from '../../constants';
+import { createBoundedCache } from '../cache';
 import { parseBinding } from './binding';
 import { attrValue, generateCode, wrap } from './helpers';
 import type { Attribute, BindingItem, DataAttrNode } from './types';
@@ -82,7 +83,9 @@ const parseJSXName = (
   return expr;
 };
 
-const extractCache = new Map<string, DataAttrNode[]>();
+const extractCache = createBoundedCache<string, DataAttrNode[]>(
+  CONFIG.CACHE_LIMIT,
+);
 
 const extractAttributes = (
   attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[],
@@ -471,13 +474,6 @@ export function extract(raw: string): DataAttrNode[] {
   }
 
   const results = parseToNodes(raw);
-
-  if (extractCache.size >= CONFIG.CACHE_LIMIT) {
-    const firstKey = extractCache.keys().next().value;
-    if (firstKey) {
-      extractCache.delete(firstKey);
-    }
-  }
 
   extractCache.set(raw, results);
 

--- a/src/utils/cache.test.ts
+++ b/src/utils/cache.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createBoundedCache } from './cache';
+
+describe('createBoundedCache', () => {
+  it('stores and retrieves values', () => {
+    const cache = createBoundedCache<string, number>(3);
+
+    cache.set('a', 1);
+
+    expect(cache.has('a')).toBe(true);
+    expect(cache.get('a')).toBe(1);
+    expect(cache.size).toBe(1);
+  });
+
+  it('evicts the oldest entry once the limit is reached', () => {
+    const cache = createBoundedCache<string, number>(2);
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+
+    expect(cache.has('a')).toBe(false);
+    expect(cache.has('b')).toBe(true);
+    expect(cache.has('c')).toBe(true);
+    expect(cache.size).toBe(2);
+  });
+
+  it('calls onEvict with the evicted key and value', () => {
+    const onEvict = vi.fn();
+    const cache = createBoundedCache<string, number>(1, onEvict);
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    expect(onEvict).toHaveBeenCalledExactlyOnceWith('a', 1);
+  });
+
+  it('deletes and clears entries', () => {
+    const cache = createBoundedCache<string, number>(3);
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    expect(cache.delete('a')).toBe(true);
+    expect(cache.has('a')).toBe(false);
+
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.has('b')).toBe(false);
+  });
+});

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,45 @@
+export interface BoundedCache<K, V> {
+  has: (key: K) => boolean;
+  get: (key: K) => V | undefined;
+  set: (key: K, value: V) => void;
+  delete: (key: K) => boolean;
+  clear: () => void;
+  readonly size: number;
+}
+
+// Fixed-capacity cache shared by compile()/getCachedScriptBlob()/extract() —
+// each evicts the oldest entry once `limit` is reached, relying on Map's
+// insertion-order iteration to find it. `onEvict` lets callers release
+// resources tied to an evicted value (e.g. revoking a blob URL).
+export const createBoundedCache = <K, V>(
+  limit: number,
+  onEvict?: (key: K, value: V) => void,
+): BoundedCache<K, V> => {
+  const store = new Map<K, V>();
+
+  const set = (key: K, value: V) => {
+    if (store.size >= limit) {
+      const oldestKey = store.keys().next().value;
+
+      if (oldestKey !== undefined) {
+        const oldestValue = store.get(oldestKey)!;
+
+        store.delete(oldestKey);
+        onEvict?.(oldestKey, oldestValue);
+      }
+    }
+
+    store.set(key, value);
+  };
+
+  return {
+    has: key => store.has(key),
+    get: key => store.get(key),
+    set,
+    delete: key => store.delete(key),
+    clear: () => store.clear(),
+    get size() {
+      return store.size;
+    },
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,6 +16,7 @@ import {
   parseDocument,
   replaceDocumentSections,
 } from './ast/document';
+import { createBoundedCache } from './cache';
 
 const ts = await import('typescript');
 
@@ -28,7 +29,7 @@ export const baseModules = {
   'ui-kit/utils': utils,
 };
 
-const compilationCache = new Map<string, Module>();
+const compilationCache = createBoundedCache<string, Module>(CONFIG.CACHE_LIMIT);
 
 const simpleHash = (str: string): string => {
   let hash = 0;
@@ -67,14 +68,6 @@ export const compile = (
   }
 
   const result = compileModule(code, modules);
-
-  if (compilationCache.size >= CONFIG.CACHE_LIMIT) {
-    const firstKey = compilationCache.keys().next().value;
-
-    if (firstKey) {
-      compilationCache.delete(firstKey);
-    }
-  }
 
   compilationCache.set(cacheKey, result);
   return result;
@@ -205,7 +198,10 @@ export const generateSection = (code: string, fullCode: string) => {
   return generateSectionPreview(fullCode, code);
 };
 
-const scriptCache = new Map<string, string>();
+const scriptCache = createBoundedCache<string, string>(
+  CONFIG.CACHE_LIMIT,
+  (_src, blobUrl) => URL.revokeObjectURL(blobUrl),
+);
 const loadingScriptCache = new Map<string, Promise<string>>();
 
 export const getCachedScriptBlob = async (src: string): Promise<string> => {
@@ -226,20 +222,6 @@ export const getCachedScriptBlob = async (src: string): Promise<string> => {
     .then(text => {
       const blob = new Blob([text], { type: 'application/javascript' });
       const blobUrl = URL.createObjectURL(blob);
-
-      if (scriptCache.size >= CONFIG.CACHE_LIMIT) {
-        const firstKey = scriptCache.keys().next().value;
-
-        if (firstKey) {
-          const evictedUrl = scriptCache.get(firstKey);
-
-          if (evictedUrl) {
-            URL.revokeObjectURL(evictedUrl);
-          }
-
-          scriptCache.delete(firstKey);
-        }
-      }
 
       scriptCache.set(src, blobUrl);
       loadingScriptCache.delete(src);


### PR DESCRIPTION
## Summary
- add `src/utils/cache.ts`: `createBoundedCache()` — one fixed-capacity Map-backed cache with oldest-entry eviction and an optional `onEvict` hook, replacing the same hand-rolled eviction logic duplicated three times (`compilationCache`/`scriptCache` in `utils/index.ts`, `extractCache` in `utils/ast/extract.ts`)
- `utils/index.ts`: `compilationCache` and `scriptCache` now use `createBoundedCache`; `scriptCache`'s blob-URL revocation on eviction moves into an `onEvict` callback instead of being inlined at the call site (`loadingScriptCache` is unrelated in-flight-promise dedup, left as a plain `Map`)
- `utils/ast/extract.ts`: `extractCache` now uses `createBoundedCache`

Stage 2 of 3 on issue #76 (parser unification + incremental codegen), following #78. Stage 3 (Proxy/Immer incremental codegen) follows as a separate PR.

## Test plan
- [x] `cache.test.ts` (4 cases): get/set/has, eviction at capacity, `onEvict` callback, delete/clear
- [x] full suite (143 tests), typecheck, lint all pass
- [x] manually verified in a running dev instance: editor loads, no new console errors