### PR TITLE
perf(ast): cache Babel parse results in document.ts

### DIFF
--- a/.changeset/pr-80.md
+++ b/.changeset/pr-80.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Added caching to improve performance of document parsing, allowing for repeated parses of the same source string without re-lexing and re-parsing from scratch.

--- a/src/utils/ast/document.test.ts
+++ b/src/utils/ast/document.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  clearDocumentParseCache,
   generateDocumentCode,
   generateSectionPreview,
   getSections,
@@ -174,5 +175,36 @@ describe('generateDocumentCode', () => {
 
     expect(code).toContain("import * as ui from 'ui-kit'");
     expect(code).toContain('export default App');
+  });
+});
+
+describe('parseDocument caching', () => {
+  it('reuses a cached parse for a repeated source string without sharing mutable state', () => {
+    clearDocumentParseCache();
+
+    const first = parseDocument(FULL_CODE)!;
+    const second = parseDocument(FULL_CODE)!;
+
+    // Distinct objects (mutating one must not corrupt the cache or the
+    // other caller's tree) that still describe the same document.
+    expect(second.container).not.toBe(first.container);
+    expect(getSections(second)).toEqual(getSections(first));
+
+    first.container.children = [];
+    expect(getSections(second)).toHaveLength(2);
+    expect(getSections(parseDocument(FULL_CODE)!)).toHaveLength(2);
+  });
+
+  it('clearDocumentParseCache() forces a fresh parse', () => {
+    clearDocumentParseCache();
+
+    const first = parseDocument(FULL_CODE)!;
+
+    clearDocumentParseCache();
+
+    const second = parseDocument(FULL_CODE)!;
+
+    expect(second.ast).not.toBe(first.ast);
+    expect(getSections(second)).toEqual(getSections(first));
   });
 });

--- a/src/utils/ast/document.ts
+++ b/src/utils/ast/document.ts
@@ -2,7 +2,9 @@ import { parse, parseExpression } from '@babel/parser';
 import traverse from '@babel/traverse';
 import * as t from '@babel/types';
 
+import { CONFIG } from '../../constants';
 import type { Section } from '../../types';
+import { createBoundedCache } from '../cache';
 import { generateCode } from './helpers';
 
 const APP_CONTAINER_ID = 'app-container';
@@ -54,17 +56,44 @@ const findContainer = (ast: t.File): t.JSXElement | undefined => {
   return container;
 };
 
+const parseCache = createBoundedCache<string, t.File>(CONFIG.CACHE_LIMIT);
+
+// Every caller of parseDocument() below goes on to mutate the returned
+// container's `children` in place (see replaceDocumentSections/
+// generateSectionPreview), so a cache hit must hand back a clone — reusing
+// the cached File node directly would let one caller's edit corrupt what the
+// next cache hit returns. Cloning is still far cheaper than re-lexing and
+// re-parsing the same source string from scratch, which is what happens
+// today once per section per render (extractSections + one generateSection
+// per <section>) even though the source hasn't changed since the last call.
+const parseSource = (code: string): t.File => {
+  const cached = parseCache.get(code);
+
+  if (cached) {
+    return t.cloneNode(cached, true);
+  }
+
+  const ast = parse(code, {
+    sourceType: 'module',
+    plugins: ['jsx', 'typescript'],
+  });
+
+  parseCache.set(code, ast);
+
+  // Never hand out the object stored in the cache itself — every caller
+  // mutates its container's children, and the first parseDocument() call for
+  // a given source is a cache miss too, so it needs the same clone-on-return
+  // treatment as a hit.
+  return t.cloneNode(ast, true);
+};
+
 // Parses the whole source once into a single Babel AST — the shared "document
 // tree" that section-level (this file) and field-level (extract.ts/update.ts)
 // operations both read/write via @babel/* instead of the previous regex-based
 // section slicing living in a separate, conflicting parser.
 export const parseDocument = (code: string): DocumentTree | undefined => {
   try {
-    const ast = parse(code, {
-      sourceType: 'module',
-      plugins: ['jsx', 'typescript'],
-    });
-
+    const ast = parseSource(code);
     const container = findContainer(ast);
 
     return container ? { ast, container } : undefined;
@@ -72,6 +101,10 @@ export const parseDocument = (code: string): DocumentTree | undefined => {
     console.warn('⚠️ Failed to parse document', e);
     return undefined;
   }
+};
+
+export const clearDocumentParseCache = () => {
+  parseCache.clear();
 };
 
 export const getSections = (doc: DocumentTree): Section[] =>

--- a/src/utils/ast/index.ts
+++ b/src/utils/ast/index.ts
@@ -23,6 +23,7 @@ export { generateCode } from './helpers';
 export { clearExtractCache, extract } from './extract';
 export type { DocumentTree } from './document';
 export {
+  clearDocumentParseCache,
   generateDocumentCode,
   generateSectionPreview,
   getSections,


### PR DESCRIPTION
## Summary
- `document.ts`: `parseDocument()` now caches the parsed `File` AST by source string (via the Stage 2 `createBoundedCache`), avoiding a full Babel re-parse of the same document text on every call — today that happens once per section per render (`extractSections` + one `generateSection` per `<section>`) even when the source hasn't changed since the last call
- every call still returns an independent clone (`t.cloneNode`, same pattern already used by `tree.ts`'s `clone()`) so callers that mutate `container.children` (`replaceDocumentSections`/`generateSectionPreview`) can't corrupt the cache or another caller's tree — this applies to cache misses too, since the object stored in the cache is never handed back directly
- add `clearDocumentParseCache()`, exported alongside the others

Stage 3 of 3 on issue #76 (parser unification + incremental codegen), following #78 and #79.

**Scope note**: this is scoped to removing redundant re-parsing of *unchanged* document text. Making individual field edits (`update()` in `extract.ts`/`update.ts`) skip re-parsing their own section entirely would require `dnd.tsx`/`panel.tsx` to hold a persistent tree across renders instead of deriving it from `value` each time — a separate, much higher-risk change left out of this PR.

## Test plan
- [x] 2 new tests: cache reuse without shared mutable state, `clearDocumentParseCache()` forcing a fresh parse. The first version of this cache returned the live cached object on a miss, which one of these tests caught before it shipped (mutating that tree corrupted later cache hits) — fixed by always cloning, including on miss.
- [x] full suite (145 tests), typecheck, lint all pass
- [x] manually verified in a running dev instance: added 3 sections, selected one, deleted it — remaining sections correct, no new console errors