### PR TITLE
chore: switch release-note polishing from GitHub Models to NVIDIA API

### DIFF
--- a/.github/scripts/polish-release-notes.mjs
+++ b/.github/scripts/polish-release-notes.mjs
@@ -1,13 +1,47 @@
 #!/usr/bin/env node
 // Rewrites a raw Keep-a-Changelog-style version section into flowing prose
-// release notes via GitHub Models, for use as a GitHub Release body. Reads
-// the raw changelog text from stdin, writes polished text to stdout.
-// Exits non-zero on any failure — the caller falls back to the raw
-// changelog text in that case, so a release is never blocked on this.
+// release notes, for use as a GitHub Release body. Reads the raw changelog
+// text from stdin, writes polished text to stdout. Exits non-zero on any
+// failure — the caller falls back to the raw changelog text in that case,
+// so a release is never blocked on this.
+//
+// Uses NVIDIA's OpenAI-compatible API Catalog endpoint (not GitHub Models —
+// retired as of 2026-07-30; see draft-changeset.mjs for the same move).
 
-const MODEL = process.env.GITHUB_MODELS_MODEL || 'openai/gpt-4o-mini';
-const API_URL = 'https://models.github.ai/inference/chat/completions';
+const MODEL = process.env.NVIDIA_MODEL || 'meta/llama-3.1-8b-instruct';
+const API_URL = 'https://integrate.api.nvidia.com/v1/chat/completions';
 const MAX_CHARS = 6000;
+
+// The API occasionally returns 503/429 for a few minutes at a time — retry
+// those with backoff instead of failing outright. Non-retryable statuses
+// (bad key, bad request, etc.) still fail on the first attempt.
+const MAX_ATTEMPTS = 4;
+const RETRY_BASE_DELAY_MS = 2000;
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(url, options) {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const response = await fetch(url, options);
+
+    if (
+      response.ok ||
+      !RETRYABLE_STATUSES.has(response.status) ||
+      attempt === MAX_ATTEMPTS
+    ) {
+      return response;
+    }
+
+    const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    console.log(
+      `NVIDIA API returned ${response.status}, retrying in ${delayMs}ms (attempt ${attempt}/${MAX_ATTEMPTS})...`,
+    );
+    await sleep(delayMs);
+  }
+}
 
 function requireEnv(name) {
   const value = process.env[name];
@@ -22,7 +56,7 @@ async function readStdin() {
 }
 
 async function main() {
-  const token = requireEnv('GITHUB_TOKEN');
+  const apiKey = requireEnv('NVIDIA_API_KEY');
   const version = requireEnv('VERSION');
   const packageName = process.env.PACKAGE_NAME || '';
   const raw = (await readStdin()).trim();
@@ -46,13 +80,11 @@ async function main() {
     'no code fences.',
   ].join(' ');
 
-  const response = await fetch(API_URL, {
+  const response = await fetchWithRetry(API_URL, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
-      'X-GitHub-Api-Version': '2022-11-28',
     },
     body: JSON.stringify({
       model: MODEL,
@@ -66,14 +98,14 @@ async function main() {
 
   if (!response.ok) {
     throw new Error(
-      `GitHub Models request failed: ${response.status} ${response.statusText} — ${await response.text()}`,
+      `NVIDIA API request failed: ${response.status} ${response.statusText} — ${await response.text()}`,
     );
   }
 
   const body = await response.json();
   const content = body.choices?.[0]?.message?.content?.trim();
   if (!content) {
-    throw new Error('GitHub Models response missing choices[0].message.content');
+    throw new Error('NVIDIA API response missing choices[0].message.content');
   }
 
   process.stdout.write(content);

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,10 +113,10 @@ jobs:
         if: steps.tag_check.outputs.already_tagged == 'false'
         id: changelog
         env:
-          # Reused for the release-note polishing step below — a personal
-          # PAT with models:read (GITHUB_TOKEN doesn't get the free-tier
-          # rate-limit benefit of the personal subscription).
-          GITHUB_TOKEN: ${{ secrets.GH_MODELS_PAT }}
+          # Used by the release-note polishing step below. GH_MODELS_PAT/
+          # GitHub Models is retired (2026-07-30) — see draft-changeset.mjs
+          # for the same move to NVIDIA's API Catalog.
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           VERSION=${{ steps.tag_check.outputs.version }}
           CHANGELOG_FILE="CHANGELOG.md"
@@ -140,7 +140,7 @@ jobs:
           CONTENT="$RAW"
           if [ -n "$RAW" ]; then
             # Best-effort: polish the raw changelog bullets into flowing
-            # release notes via GitHub Models. Never blocks the release —
+            # release notes via NVIDIA's API. Never blocks the release —
             # fall back to the raw changelog text on any failure.
             if POLISHED=$(echo "$RAW" | PACKAGE_NAME="@jbpark/live-editor" VERSION="$VERSION" node .github/scripts/polish-release-notes.mjs); then
               CONTENT="$POLISHED"


### PR DESCRIPTION
## Summary
- `.github/scripts/polish-release-notes.mjs`: replace the GitHub Models call (`models.github.ai`, retired 2026-07-30) with NVIDIA's OpenAI-compatible API Catalog endpoint — same move already made for `draft-changeset.mjs` in #77. Model defaults to `meta/llama-3.1-8b-instruct` (`NVIDIA_MODEL` env override), auth via `NVIDIA_API_KEY` instead of `GITHUB_TOKEN`, plus the same retry-with-backoff on 429/5xx as `draft-changeset.mjs`.
- `.github/workflows/publish.yml`: pass `NVIDIA_API_KEY` (already a repo secret, set up for `draft-changeset.mjs`) to the "Get changelog entry" step instead of `GH_MODELS_PAT`.

This step only ran during the v1.5.0 release just now and failed with the same GitHub Models retirement error as the changeset-draft workflow originally did — this fixes it the same way.

`GH_MODELS_PAT` is now unused anywhere in `.github/`. Left the secret in place rather than removing it as a drive-by in this PR.

## Test plan
- [x] `node --check` on the script passes
- [x] YAML syntax valid
- [x] lint passes
- [ ] not integration-tested against the live NVIDIA endpoint (only runs during an actual version-bump release) — mirrors the already-verified `draft-changeset.mjs` pattern (same auth header shape, same endpoint, same retry logic), which has successfully drafted changesets on PRs #78, #79, #80