### PR TITLE
fix(utils): make createBoundedCache real LRU, add a parse benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "bench": "vitest bench",
     "preview": "vite preview",
     "sync:draggable-items": "node scripts/sync-draggable-items.mjs",
     "prepublishOnly": "pnpm build",

--- a/src/utils/ast/document.bench.ts
+++ b/src/utils/ast/document.bench.ts
@@ -1,0 +1,74 @@
+import { bench, describe } from 'vitest';
+
+import { generateSectionPreview, getSections, parseDocument } from './document';
+
+// Regression guard for the perf claims made in document.ts's parse cache
+// (introduced in #80): whether cache-hit cloning actually beats a fresh
+// re-parse depends heavily on document size, and doesn't hold at the
+// section counts a real editor sees (see issue #95). Run via `pnpm bench`
+// and compare `parseDocument (cache hit, clone)` against
+// `parseDocument (no cache, fresh parse)` at each size below before relying
+// on that cache providing a speedup.
+const buildDocument = (sectionCount: number): string => {
+  const sections = Array.from(
+    { length: sectionCount },
+    (_, i) => `
+      <section data-name="Section ${i}">
+        <div
+          data-id="s${i}"
+          data-binding="[{label:'Title',property:'innerText'}]"
+        >
+          <h2>Title ${i}</h2>
+          <p>Description for section ${i}</p>
+        </div>
+      </section>`,
+  ).join('\n');
+
+  return `
+import * as ui from 'ui-kit';
+
+const App = () => {
+  return (
+    <main id="app-container">
+      ${sections}
+    </main>
+  )
+}
+
+export default App;
+`;
+};
+
+const SECTION_COUNTS = [5, 20, 50];
+
+for (const sectionCount of SECTION_COUNTS) {
+  const code = buildDocument(sectionCount);
+  const firstSectionCode = getSections(parseDocument(code)!)[0]!.code;
+
+  describe(`document.ts @ ${sectionCount} sections`, () => {
+    // tinybench's setup/teardown hooks run per measurement *cycle*, not per
+    // call, so they can't reliably force a cache miss on every single
+    // invocation. Appending a per-call counter to the source instead
+    // guarantees a unique cache key every time — a real re-parse each call,
+    // and (as a bonus) a fair stand-in for "the user is typing, so the
+    // source string is different on every edit" in practice.
+    let freshParseCounter = 0;
+
+    bench('parseDocument (no cache, fresh parse)', () => {
+      parseDocument(`${code}\n// ${freshParseCounter++}`);
+    });
+
+    bench('parseDocument (cache hit, clone)', () => {
+      parseDocument(code);
+    });
+
+    bench('getSections', () => {
+      getSections(parseDocument(code)!);
+    });
+
+    // What Renderer actually pays once per <section> per render — see #97.
+    bench('generateSectionPreview', () => {
+      generateSectionPreview(code, firstSectionCode);
+    });
+  });
+}

--- a/src/utils/cache.test.ts
+++ b/src/utils/cache.test.ts
@@ -49,4 +49,31 @@ describe('createBoundedCache', () => {
     expect(cache.size).toBe(0);
     expect(cache.has('b')).toBe(false);
   });
+
+  it('evicts least-recently-used, not literally-oldest-inserted — a get() hit protects an entry from the next eviction', () => {
+    const cache = createBoundedCache<string, number>(2);
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.get('a'); // touch 'a' so 'b' becomes the least-recently-used entry
+    cache.set('c', 3);
+
+    expect(cache.has('a')).toBe(true);
+    expect(cache.has('b')).toBe(false);
+    expect(cache.has('c')).toBe(true);
+  });
+
+  it('set() on an existing key refreshes its recency instead of double-counting it', () => {
+    const cache = createBoundedCache<string, number>(2);
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('a', 10); // re-set 'a' so 'b' becomes the least-recently-used entry
+    cache.set('c', 3);
+
+    expect(cache.get('a')).toBe(10);
+    expect(cache.has('b')).toBe(false);
+    expect(cache.has('c')).toBe(true);
+    expect(cache.size).toBe(2);
+  });
 });

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -7,18 +7,36 @@ export interface BoundedCache<K, V> {
   readonly size: number;
 }
 
-// Fixed-capacity cache shared by compile()/getCachedScriptBlob()/extract() —
-// each evicts the oldest entry once `limit` is reached, relying on Map's
-// insertion-order iteration to find it. `onEvict` lets callers release
-// resources tied to an evicted value (e.g. revoking a blob URL).
+// Fixed-capacity LRU cache shared by compile()/getCachedScriptBlob()/
+// extract() — evicts the *least recently used* entry once `limit` is
+// reached. Relies on Map's insertion-order iteration: the first key is
+// always the least recently touched, because both get() (on a hit) and
+// set() (when overwriting an existing key) delete-then-reinsert the entry
+// to move it to the end. `onEvict` lets callers release resources tied to
+// an evicted value (e.g. revoking a blob URL).
 export const createBoundedCache = <K, V>(
   limit: number,
   onEvict?: (key: K, value: V) => void,
 ): BoundedCache<K, V> => {
   const store = new Map<K, V>();
 
+  const get = (key: K): V | undefined => {
+    if (!store.has(key)) {
+      return undefined;
+    }
+
+    const value = store.get(key)!;
+
+    store.delete(key);
+    store.set(key, value);
+
+    return value;
+  };
+
   const set = (key: K, value: V) => {
-    if (store.size >= limit) {
+    if (store.has(key)) {
+      store.delete(key);
+    } else if (store.size >= limit) {
       const oldestKey = store.keys().next().value;
 
       if (oldestKey !== undefined) {
@@ -34,7 +52,7 @@ export const createBoundedCache = <K, V>(
 
   return {
     has: key => store.has(key),
-    get: key => store.get(key),
+    get,
     set,
     delete: key => store.delete(key),
     clear: () => store.clear(),


### PR DESCRIPTION
## Summary
Addresses #95, scoped down per discussion on that issue: the "switch AST caching to result-string caching" recommendation is skipped here since #96 (document.ts redesign) already plans to remove the `generateCode`/`cloneNode` dependency that recommendation was working around — doing it now would just get redone once #96 lands.

- `utils/cache.ts`: `createBoundedCache` was FIFO despite backing three caches meant to keep hot entries around — `get()` never touched recency, so an entry evicted purely for being old could be the one read on every single call. `get()` now moves a hit to the most-recently-used position (delete + re-set, relying on `Map`'s insertion-order iteration), and `set()` on an existing key refreshes it the same way instead of silently double-counting it toward the size check
- add `src/utils/ast/document.bench.ts` (`pnpm bench`) benchmarking `parseDocument`/`getSections`/`generateSectionPreview` at 5/20/50 sections — confirms #95's finding: cache-hit cloning is only ~1.1-1.7x faster than a fresh parse at these sizes, not "far cheaper" as `document.ts`'s comment claimed. Forces a fresh parse every call via a unique per-call source string rather than a setup/teardown hook, since tinybench's hooks run once per measurement cycle rather than once per call and can't reliably force a miss on every iteration

## Test plan
- [x] 2 new tests: a `get()` hit protects an entry from the next eviction; `set()` on an existing key refreshes recency instead of double-counting
- [x] full suite (147 tests), typecheck, lint all pass
- [x] `pnpm bench` runs and produces the numbers cited above
- [ ] no browser check this time — pure cache-eviction-order change (interface unchanged) plus a benchmark file that isn't imported by app code at all