### PR TITLE
fix(ast): rewrite document.ts to edit by string slice, not AST regen

### DIFF
--- a/.changeset/pr-99.md
+++ b/.changeset/pr-99.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+The editor now correctly handles nested sections, preserving non-section content and not reformatting code outside the replaced section span.

--- a/src/utils/ast/document.test.ts
+++ b/src/utils/ast/document.test.ts
@@ -54,14 +54,17 @@ describe('parseDocument', () => {
 });
 
 describe('getSections', () => {
-  it('extracts each top-level <section> in document order', () => {
+  it('extracts each top-level <section> in document order, as an exact slice of the original source', () => {
     const doc = parseDocument(FULL_CODE)!;
     const sections = getSections(doc);
 
     expect(sections).toHaveLength(2);
-    expect(sections[0]).toMatchObject({ id: '0', name: 'Hero' });
+    expect(sections[0]).toMatchObject({
+      id: '0',
+      name: 'Hero',
+      code: '<section data-name="Hero"><h1>Hero</h1></section>',
+    });
     expect(sections[1]).toMatchObject({ id: '1', name: 'Features' });
-    expect(sections[0]!.code).toContain('<h1>Hero</h1>');
   });
 
   it('falls back to a positional name when data-name is missing', () => {
@@ -95,6 +98,36 @@ describe('getSections', () => {
     expect(getSections(doc)).toHaveLength(1);
     expect(getSections(doc)[0]!.name).toBe('Real');
   });
+
+  it('finds a <section> nested inside a non-section wrapper (#96 point D)', () => {
+    const doc = parseDocument(`
+      const App = () => (
+        <main id="app-container">
+          <div className="wrap">
+            <section data-name="래핑됨"><p>1</p></section>
+          </div>
+        </main>
+      );
+    `)!;
+
+    expect(getSections(doc)).toHaveLength(1);
+    expect(getSections(doc)[0]!.name).toBe('래핑됨');
+  });
+
+  it('treats a <section> nested inside another <section> as part of its parent, not a separate entry', () => {
+    const doc = parseDocument(`
+      const App = () => (
+        <main id="app-container">
+          <section data-name="Outer">
+            <section data-name="Inner"><p>x</p></section>
+          </section>
+        </main>
+      );
+    `)!;
+
+    expect(getSections(doc)).toHaveLength(1);
+    expect(getSections(doc)[0]!.name).toBe('Outer');
+  });
 });
 
 describe('replaceDocumentSections', () => {
@@ -109,23 +142,56 @@ describe('replaceDocumentSections', () => {
     expect(sections[0]!.name).toBe('About');
   });
 
-  it('preserves non-section children of the container', () => {
-    const codeWithComment = `
+  it('does not reformat any code outside the replaced section span (#96 point A)', () => {
+    const code = `import * as ui from 'ui-kit';
+const App = ({
+  container
+}) => {
+  return <main id="app-container"><section data-name="Hero"><h1>Hero</h1></section></main>;
+};
+export default App;
+`;
+
+    const next = replaceDocumentSections(code, [
+      '<section data-name="Hero2"><h1>Hero2</h1></section>',
+    ]);
+
+    expect(next).toBe(
+      `import * as ui from 'ui-kit';
+const App = ({
+  container
+}) => {
+  return <main id="app-container"><section data-name="Hero2"><h1>Hero2</h1></section></main>;
+};
+export default App;
+`,
+    );
+  });
+
+  it('keeps non-section content in its original position instead of moving it after the sections (#96 point B)', () => {
+    const codeWithHeader = `
       const App = () => (
         <main id="app-container">
+          <div className="header">헤더</div>
           {/* keep me */}
           <section data-name="Hero"><h1>Hero</h1></section>
         </main>
       );
     `;
 
-    const next = replaceDocumentSections(codeWithComment, [
-      `<section data-name="Hero2"><h1>Hero2</h1></section>
-`,
+    const next = replaceDocumentSections(codeWithHeader, [
+      '<section data-name="Hero2"><h1>Hero2</h1></section>',
     ]);
 
     expect(next).toContain('keep me');
-    expect(getSections(parseDocument(next)!)[0]!.name).toBe('Hero2');
+
+    const headerIndex = next.indexOf('className="header"');
+    const commentIndex = next.indexOf('keep me');
+    const sectionIndex = next.indexOf('data-name="Hero2"');
+
+    expect(headerIndex).toBeGreaterThan(-1);
+    expect(headerIndex).toBeLessThan(commentIndex);
+    expect(commentIndex).toBeLessThan(sectionIndex);
   });
 
   it('returns the original code unchanged when it fails to parse', () => {
@@ -134,12 +200,34 @@ describe('replaceDocumentSections', () => {
     expect(replaceDocumentSections(broken, ['<section />'])).toBe(broken);
   });
 
-  it('skips section strings that fail to parse instead of throwing', () => {
+  it('inserts section strings verbatim without validating them — an invalid one still lands in the output instead of being silently dropped (#96 point C)', () => {
     const next = replaceDocumentSections(FULL_CODE, [
       '<section data-name="Good"><p>Good</p></section>',
       '<not-jsx',
     ]);
 
+    // Landed as-is rather than being filtered out — genuinely invalid, so
+    // it can't be re-parsed here either; that failure now surfaces through
+    // the normal compile-error path instead of vanishing silently.
+    expect(next).toContain('<section data-name="Good"><p>Good</p></section>');
+    expect(next).toContain('<not-jsx');
+    expect(parseDocument(next)).toBeUndefined();
+  });
+
+  it('appends into an empty container instead of discarding what it already holds', () => {
+    const codeWithHeaderOnly = `
+      const App = () => (
+        <main id="app-container">
+          <div className="header">헤더</div>
+        </main>
+      );
+    `;
+
+    const next = replaceDocumentSections(codeWithHeaderOnly, [
+      '<section data-name="Hero"><h1>Hero</h1></section>',
+    ]);
+
+    expect(next).toContain('className="header"');
     expect(getSections(parseDocument(next)!)).toHaveLength(1);
   });
 });
@@ -157,8 +245,31 @@ describe('generateSectionPreview', () => {
     expect(sections[0]!.name).toBe('Solo');
   });
 
-  it('returns fullCode unchanged when the section fails to parse', () => {
-    expect(generateSectionPreview(FULL_CODE, '<not-jsx')).toBe(FULL_CODE);
+  it('does not reformat code outside the container (#96 point A)', () => {
+    const code = `import * as ui from 'ui-kit';
+const App = ({
+  container
+}) => {
+  return <main id="app-container"><section data-name="Hero"><h1>Hero</h1></section></main>;
+};
+export default App;
+`;
+
+    const preview = generateSectionPreview(
+      code,
+      '<section data-name="Solo"><p>Solo</p></section>',
+    );
+
+    expect(preview).toBe(
+      `import * as ui from 'ui-kit';
+const App = ({
+  container
+}) => {
+  return <main id="app-container"><section data-name="Solo"><p>Solo</p></section></main>;
+};
+export default App;
+`,
+    );
   });
 
   it('returns fullCode unchanged when fullCode fails to parse', () => {
@@ -169,30 +280,22 @@ describe('generateSectionPreview', () => {
 });
 
 describe('generateDocumentCode', () => {
-  it('regenerates code that still contains the surrounding module scaffold', () => {
+  it('returns the document code the tree was parsed from', () => {
     const doc = parseDocument(FULL_CODE)!;
-    const code = generateDocumentCode(doc);
 
-    expect(code).toContain("import * as ui from 'ui-kit'");
-    expect(code).toContain('export default App');
+    expect(generateDocumentCode(doc)).toBe(FULL_CODE);
   });
 });
 
 describe('parseDocument caching', () => {
-  it('reuses a cached parse for a repeated source string without sharing mutable state', () => {
+  it('reuses the same parsed AST for a repeated source string — safe since nothing ever mutates it', () => {
     clearDocumentParseCache();
 
     const first = parseDocument(FULL_CODE)!;
     const second = parseDocument(FULL_CODE)!;
 
-    // Distinct objects (mutating one must not corrupt the cache or the
-    // other caller's tree) that still describe the same document.
-    expect(second.container).not.toBe(first.container);
-    expect(getSections(second)).toEqual(getSections(first));
-
-    first.container.children = [];
-    expect(getSections(second)).toHaveLength(2);
-    expect(getSections(parseDocument(FULL_CODE)!)).toHaveLength(2);
+    expect(second.ast).toBe(first.ast);
+    expect(second.container).toBe(first.container);
   });
 
   it('clearDocumentParseCache() forces a fresh parse', () => {

--- a/src/utils/ast/document.ts
+++ b/src/utils/ast/document.ts
@@ -1,17 +1,17 @@
-import { parse, parseExpression } from '@babel/parser';
+import { parse } from '@babel/parser';
 import traverse from '@babel/traverse';
 import * as t from '@babel/types';
 
 import { CONFIG } from '../../constants';
 import type { Section } from '../../types';
 import { createBoundedCache } from '../cache';
-import { generateCode } from './helpers';
 
 const APP_CONTAINER_ID = 'app-container';
 const SECTION_TAG = 'section';
 const DATA_NAME_ATTR = 'data-name';
 
 export interface DocumentTree {
+  code: string;
   ast: t.File;
   container: t.JSXElement;
 }
@@ -38,9 +38,6 @@ const getAttrValue = (
 const isSectionElement = (node: t.Node): node is t.JSXElement =>
   t.isJSXElement(node) && getTagName(node) === SECTION_TAG;
 
-const isBlankJSXText = (node: t.Node): boolean =>
-  t.isJSXText(node) && !node.value.trim();
-
 const findContainer = (ast: t.File): t.JSXElement | undefined => {
   let container: t.JSXElement | undefined;
 
@@ -56,21 +53,43 @@ const findContainer = (ast: t.File): t.JSXElement | undefined => {
   return container;
 };
 
+// Recursively finds every *outermost* <section> under a container — a
+// <section> nested inside another <section> is left to its parent, so the
+// document's section count stays unambiguous (matches how the old
+// regex-based path treated nesting, and how #96 asked for it).
+const findOutermostSections = (
+  children: t.JSXElement['children'],
+): t.JSXElement[] => {
+  const sections: t.JSXElement[] = [];
+
+  for (const child of children) {
+    if (isSectionElement(child)) {
+      sections.push(child);
+      continue;
+    }
+
+    if (t.isJSXElement(child) || t.isJSXFragment(child)) {
+      sections.push(...findOutermostSections(child.children));
+    }
+  }
+
+  return sections;
+};
+
 const parseCache = createBoundedCache<string, t.File>(CONFIG.CACHE_LIMIT);
 
-// Every caller of parseDocument() below goes on to mutate the returned
-// container's `children` in place (see replaceDocumentSections/
-// generateSectionPreview), so a cache hit must hand back a clone — reusing
-// the cached File node directly would let one caller's edit corrupt what the
-// next cache hit returns. Cloning is still far cheaper than re-lexing and
-// re-parsing the same source string from scratch, which is what happens
-// today once per section per render (extractSections + one generateSection
-// per <section>) even though the source hasn't changed since the last call.
+// document.ts locates positions in the *original* source (section start/end
+// offsets, the container's opening/closing tag positions) and edits by
+// slicing that string — see replaceDocumentSections/generateSectionPreview
+// below. It never round-trips through @babel/generator and never mutates
+// the parsed tree, so every caller can safely share one cached AST: unlike
+// an approach that hands out a tree for the caller to edit in place, a
+// cache hit here needs no clone at all.
 const parseSource = (code: string): t.File => {
   const cached = parseCache.get(code);
 
   if (cached) {
-    return t.cloneNode(cached, true);
+    return cached;
   }
 
   const ast = parse(code, {
@@ -80,23 +99,19 @@ const parseSource = (code: string): t.File => {
 
   parseCache.set(code, ast);
 
-  // Never hand out the object stored in the cache itself — every caller
-  // mutates its container's children, and the first parseDocument() call for
-  // a given source is a cache miss too, so it needs the same clone-on-return
-  // treatment as a hit.
-  return t.cloneNode(ast, true);
+  return ast;
 };
 
 // Parses the whole source once into a single Babel AST — the shared "document
 // tree" that section-level (this file) and field-level (extract.ts/update.ts)
-// operations both read/write via @babel/* instead of the previous regex-based
+// operations both read via @babel/* instead of the previous regex-based
 // section slicing living in a separate, conflicting parser.
 export const parseDocument = (code: string): DocumentTree | undefined => {
   try {
     const ast = parseSource(code);
     const container = findContainer(ast);
 
-    return container ? { ast, container } : undefined;
+    return container ? { code, ast, container } : undefined;
   } catch (e) {
     console.warn('⚠️ Failed to parse document', e);
     return undefined;
@@ -108,28 +123,50 @@ export const clearDocumentParseCache = () => {
 };
 
 export const getSections = (doc: DocumentTree): Section[] =>
-  doc.container.children.filter(isSectionElement).map((node, index) => ({
+  findOutermostSections(doc.container.children).map((node, index) => ({
     id: `${index}`,
     name: getAttrValue(node, DATA_NAME_ATTR) || `${index + 1}번째 컴포넌트`,
-    code: generateCode(node),
+    code: doc.code.slice(node.start!, node.end!),
   }));
 
-export const generateDocumentCode = (doc: DocumentTree): string =>
-  generateCode(doc.ast);
+export const generateDocumentCode = (doc: DocumentTree): string => doc.code;
 
-const parseSectionNode = (code: string): t.JSXElement | undefined => {
-  try {
-    const expr = parseExpression(code, {
-      plugins: ['jsx', 'typescript'],
-    });
-
-    return t.isJSXElement(expr) ? expr : undefined;
-  } catch (e) {
-    console.warn('⚠️ Failed to parse section', e);
+// The span of source text occupied by `container`'s children — right after
+// its opening tag's `>` through right before its closing tag's `<`.
+// undefined for a self-closing container, which has no children slot.
+const getContainerInnerSpan = (
+  container: t.JSXElement,
+): { start: number; end: number } | undefined => {
+  if (!container.closingElement) {
     return undefined;
   }
+
+  return {
+    start: container.openingElement.end!,
+    end: container.closingElement.start!,
+  };
 };
 
+const spliceCode = (
+  code: string,
+  start: number,
+  end: number,
+  replacement: string,
+): string => code.slice(0, start) + replacement + code.slice(end);
+
+// Replaces the container's <section> children with `sectionCodes`, leaving
+// everything else in the file — non-section content before/after the
+// sections, and anything outside the container entirely — byte-for-byte
+// untouched (no whole-file reformatting, no reordering; see #96). Content
+// interspersed *between* the original sections is not separately preserved:
+// the whole span from the first section's start to the last section's end
+// is replaced as one block, since `sectionCodes` is a flat replacement list
+// with no way to say where such content should land in the new order.
+//
+// `sectionCodes` are spliced in as raw text with no parsing or validation:
+// an invalid entry still lands in the output rather than being silently
+// dropped, and gets surfaced through the normal compile-error path instead
+// of vanishing (#96).
 export const replaceDocumentSections = (
   fullCode: string,
   sectionCodes: string[],
@@ -140,31 +177,37 @@ export const replaceDocumentSections = (
     return fullCode;
   }
 
-  const nextSections = sectionCodes
-    .map(parseSectionNode)
-    .filter((node): node is t.JSXElement => Boolean(node));
+  const sections = findOutermostSections(doc.container.children);
+  const replacement = sectionCodes.join('\n');
 
-  const preserved = doc.container.children.filter(
-    child => !isSectionElement(child) && !isBlankJSXText(child),
-  );
+  if (sections.length > 0) {
+    const start = sections[0]!.start!;
+    const end = sections[sections.length - 1]!.end!;
 
-  doc.container.children = [...nextSections, ...preserved];
+    return spliceCode(fullCode, start, end, replacement);
+  }
 
-  return generateDocumentCode(doc);
+  // No existing sections to anchor a replacement span on — append after
+  // whatever the container already holds (e.g. a still-empty
+  // <main id="app-container">) instead of discarding it.
+  const span = getContainerInnerSpan(doc.container);
+
+  return span
+    ? spliceCode(fullCode, span.end, span.end, replacement)
+    : fullCode;
 };
 
+// Produces a document whose container holds only `sectionCode`, discarding
+// any other container content — used for Renderer's isolated per-section
+// preview compile, not as a general-purpose section-list edit.
 export const generateSectionPreview = (
   fullCode: string,
   sectionCode: string,
 ): string => {
   const doc = parseDocument(fullCode);
-  const sectionNode = parseSectionNode(sectionCode);
+  const span = doc && getContainerInnerSpan(doc.container);
 
-  if (!doc || !sectionNode) {
-    return fullCode;
-  }
-
-  doc.container.children = [sectionNode];
-
-  return generateDocumentCode(doc);
+  return span
+    ? spliceCode(fullCode, span.start, span.end, sectionCode)
+    : fullCode;
 };


### PR DESCRIPTION
## Summary
Addresses #96 — all four correctness problems it reported in the AST-clone-and-regenerate approach from #78:

- **A.** `replaceDocumentSections()`/`generateSectionPreview()` called `generateCode(doc.ast)` on the *whole file*, so every drag/add/delete reformatted the entire document into Babel's default style — destroyed blank lines, collapsed destructured params, stripped return-statement parens, all on every edit
- **B.** non-section children of the container (headers, comments) always got moved after the new section list instead of staying where they were
- **C.** section code strings that failed to parse (e.g. adjacent JSX root elements from a public `items` prop) were silently dropped via `filter(Boolean)` — data loss with no way for the caller to notice
- **D.** section discovery only checked the container's *direct* children, so a `<section>` wrapped in any other element became invisible to the panel

## Fix
Parse only to *locate* positions (container tag boundaries, section start/end offsets) in the original source, then edit by slicing that string directly — never round-trip through `@babel/generator` or mutate the tree.

- `getSections()`: section `code` is now `doc.code.slice(start, end)` — the user's exact original text, not a Babel-regenerated approximation
- `replaceDocumentSections()`: replaces only the span from the first section's start to the last section's end; everything outside that span is untouched. No existing sections → appends after whatever the container already holds instead of discarding it. `sectionCodes` are spliced in as raw text with no parsing/validation, so an invalid one still lands in the output and surfaces through the normal compile-error path instead of vanishing
- `generateSectionPreview()`: same splice approach, scoped to the whole container span (still discards other container content — it's for Renderer's isolated per-section preview, not a general edit)
- `findOutermostSections()`: recursive descent through JSX children instead of a direct-children filter, stopping at each match so a nested `<section>` stays part of its parent rather than becoming a second entry

**Side effect matching what #96 predicted**: since nothing mutates the parsed tree anymore, `parseDocument()`'s cache can hand back the same AST to every caller instead of cloning per call — the #95 finding ("clone barely beats a fresh parse") is moot because there's no clone left to pay for. Reran `pnpm bench`: `generateSectionPreview` goes from ~0.4-2.5ms to ~0.009ms per call (5-50 sections), and a cache hit is now 65-660x faster than a fresh parse instead of ~1.1-1.7x.

## Test plan
- [x] Rewrote `document.test.ts` (21 cases) for the new semantics, including direct regression tests for #96's A/B/C/D
- [x] full suite (151 tests), typecheck, lint all pass
- [x] `pnpm bench` confirms the numbers above
- [x] manually verified in a running dev instance: a document with a fixed header div, a comment, and two sections — deleting one section left the header/comment in their original position with the rest of the file (destructured props, return-statement parens) completely untouched, only the deleted section's own span changed