### PR TITLE
perf(dnd): decouple Renderer from fullCode, memo it, cache parse failures

### DIFF
--- a/.changeset/pr-101.md
+++ b/.changeset/pr-101.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Added support for batched generation of section previews, improving performance when multiple sections change.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -31,6 +31,7 @@ import { DEFAULT_TEMPLATE } from '../../constants';
 import {
   cn,
   extractSections,
+  generateSections,
   preloadScripts,
   replaceSections,
 } from '../../utils';
@@ -95,6 +96,14 @@ const Dnd = ({
 
   const value = _value || DEFAULT_TEMPLATE;
   const sections = useMemo(() => extractSections(value), [value]);
+  const previews = useMemo(
+    () =>
+      generateSections(
+        sections.map(s => s.code),
+        value,
+      ),
+    [sections, value],
+  );
 
   const onDragStart = (_: DragStartEvent) => {};
 
@@ -324,7 +333,7 @@ const Dnd = ({
                   items={sections.map(s => s.id)}
                   strategy={verticalListSortingStrategy}
                 >
-                  {sections.map(section => (
+                  {sections.map((section, index) => (
                     <Sortable
                       key={section.id}
                       id={section.id}
@@ -335,8 +344,7 @@ const Dnd = ({
                       onCopy={onCopy}
                     >
                       <Renderer
-                        fullCode={value}
-                        code={section.code}
+                        preview={previews[index]!}
                         modules={modules}
                         frame={frame}
                         provider={provider}

--- a/src/components/dnd/overlay.tsx
+++ b/src/components/dnd/overlay.tsx
@@ -2,6 +2,7 @@ import { useDndContext } from '@dnd-kit/core';
 
 import type { FrameProps } from '~/components/frame';
 import type { Section } from '~/types';
+import { generateSection } from '~/utils';
 
 import Draggable from './draggable';
 import Renderer from './renderer';
@@ -32,9 +33,15 @@ const Overlay = ({ sections, renderProps }: Props) => {
   const section = sections.find(s => s.id === active.id);
 
   if (section) {
+    const preview = generateSection(section.code, renderProps.fullCode);
+
     return (
       <Sortable id={section.id} name={section.name}>
-        <Renderer {...renderProps} code={section.code} />
+        <Renderer
+          preview={preview}
+          modules={renderProps.modules}
+          frame={renderProps.frame}
+        />
       </Sortable>
     );
   }

--- a/src/components/dnd/renderer.tsx
+++ b/src/components/dnd/renderer.tsx
@@ -1,25 +1,22 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 
 import Frame, { type FrameProps } from '~/components/frame';
-import { baseModules, compile, generateSection } from '~/utils';
+import { baseModules, compile } from '~/utils';
 
 interface Props {
-  fullCode: string;
-  code: string;
+  preview: string;
   modules?: Record<string, unknown>;
   headers?: Record<string, boolean>;
   frame?: FrameProps;
   provider?: (children: React.ReactNode) => React.ReactNode;
 }
 
-const Renderer = ({
-  fullCode,
-  code,
-  headers,
-  modules,
-  frame,
-  provider,
-}: Props) => {
+// Wrapped in memo() because `preview` is a plain string: for a section that
+// didn't change, the parent hands back the same content it computed last
+// render (see generateSections()/dnd.tsx), so a shallow prop comparison
+// lets React skip both the recompile below and reconciling this section's
+// iframe tree at all — see #97.
+const Renderer = ({ preview, headers, modules, frame, provider }: Props) => {
   const memoizedModules = useMemo(
     () => ({
       ...baseModules,
@@ -28,14 +25,9 @@ const Renderer = ({
     [modules],
   );
 
-  const memoizedSection = useMemo(
-    () => generateSection(code, fullCode),
-    [code, fullCode],
-  );
-
   const module = useMemo(
-    () => compile(memoizedSection, memoizedModules),
-    [memoizedSection, memoizedModules],
+    () => compile(preview, memoizedModules),
+    [preview, memoizedModules],
   );
 
   const renderProvider = (component: React.ReactNode) => {
@@ -65,4 +57,4 @@ const Renderer = ({
   );
 };
 
-export default Renderer;
+export default memo(Renderer);

--- a/src/utils/ast/document.bench.ts
+++ b/src/utils/ast/document.bench.ts
@@ -1,14 +1,18 @@
 import { bench, describe } from 'vitest';
 
-import { generateSectionPreview, getSections, parseDocument } from './document';
+import {
+  generateSectionPreview,
+  generateSectionPreviews,
+  getSections,
+  parseDocument,
+} from './document';
 
 // Regression guard for the perf claims made in document.ts's parse cache
-// (introduced in #80): whether cache-hit cloning actually beats a fresh
-// re-parse depends heavily on document size, and doesn't hold at the
-// section counts a real editor sees (see issue #95). Run via `pnpm bench`
-// and compare `parseDocument (cache hit, clone)` against
-// `parseDocument (no cache, fresh parse)` at each size below before relying
-// on that cache providing a speedup.
+// (introduced in #80, reworked in #96/#97): a cache hit here no longer
+// clones (#96 made parseDocument's result read-only, so callers can safely
+// share it), so it should stay far cheaper than a fresh parse at every size
+// below — that gap used to nearly vanish at real section counts back when
+// this cache still cloned on every hit (see issue #95).
 const buildDocument = (sectionCount: number): string => {
   const sections = Array.from(
     { length: sectionCount },
@@ -58,7 +62,7 @@ for (const sectionCount of SECTION_COUNTS) {
       parseDocument(`${code}\n// ${freshParseCounter++}`);
     });
 
-    bench('parseDocument (cache hit, clone)', () => {
+    bench('parseDocument (cache hit)', () => {
       parseDocument(code);
     });
 
@@ -66,9 +70,29 @@ for (const sectionCount of SECTION_COUNTS) {
       getSections(parseDocument(code)!);
     });
 
-    // What Renderer actually pays once per <section> per render — see #97.
     bench('generateSectionPreview', () => {
       generateSectionPreview(code, firstSectionCode);
     });
+
+    // Before #97, dnd.tsx called generateSectionPreview once per section
+    // per render regardless of which one actually changed — this is that
+    // N-calls pattern, compared below against the batched replacement.
+    const allSectionCodes = getSections(parseDocument(code)!).map(s => s.code);
+
+    bench(
+      'one generateSectionPreview call per section (pre-#97 pattern)',
+      () => {
+        allSectionCodes.map(sectionCode =>
+          generateSectionPreview(code, sectionCode),
+        );
+      },
+    );
+
+    bench(
+      'generateSectionPreviews (batched, one call for all sections)',
+      () => {
+        generateSectionPreviews(code, allSectionCodes);
+      },
+    );
   });
 }

--- a/src/utils/ast/document.test.ts
+++ b/src/utils/ast/document.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   clearDocumentParseCache,
   generateDocumentCode,
   generateSectionPreview,
+  generateSectionPreviews,
   getSections,
   parseDocument,
   replaceDocumentSections,
@@ -279,6 +280,57 @@ export default App;
   });
 });
 
+describe('generateSectionPreviews', () => {
+  it('produces one preview per section code, in order', () => {
+    const previews = generateSectionPreviews(FULL_CODE, [
+      '<section data-name="A"><p>A</p></section>',
+      '<section data-name="B"><p>B</p></section>',
+    ]);
+
+    expect(previews).toHaveLength(2);
+    expect(getSections(parseDocument(previews[0]!)!)[0]!.name).toBe('A');
+    expect(getSections(parseDocument(previews[1]!)!)[0]!.name).toBe('B');
+  });
+
+  it('matches generateSectionPreview called once per section (#97)', () => {
+    const codes = [
+      '<section data-name="A"><p>A</p></section>',
+      '<section data-name="B"><p>B</p></section>',
+      '<section data-name="C"><p>C</p></section>',
+    ];
+
+    const batched = generateSectionPreviews(FULL_CODE, codes);
+    const oneAtATime = codes.map(code =>
+      generateSectionPreview(FULL_CODE, code),
+    );
+
+    expect(batched).toEqual(oneAtATime);
+  });
+
+  it('leaves an unrelated section untouched when only one code changes — same string both times (#97)', () => {
+    const codes = [
+      '<section data-name="A"><p>A</p></section>',
+      '<section data-name="B"><p>B</p></section>',
+    ];
+
+    const before = generateSectionPreviews(FULL_CODE, codes);
+
+    codes[0] = '<section data-name="A-edited"><p>A edited</p></section>';
+    const after = generateSectionPreviews(FULL_CODE, codes);
+
+    expect(after[1]).toBe(before[1]);
+    expect(after[0]).not.toBe(before[0]);
+  });
+
+  it('returns fullCode for every entry when fullCode fails to parse', () => {
+    const broken = '<main id="app-container">';
+
+    expect(
+      generateSectionPreviews(broken, ['<section />', '<section />']),
+    ).toEqual([broken, broken]);
+  });
+});
+
 describe('generateDocumentCode', () => {
   it('returns the document code the tree was parsed from', () => {
     const doc = parseDocument(FULL_CODE)!;
@@ -309,5 +361,18 @@ describe('parseDocument caching', () => {
 
     expect(second.ast).not.toBe(first.ast);
     expect(getSections(second)).toEqual(getSections(first));
+  });
+
+  it('caches a parse failure too, instead of re-parsing the same broken source on every call (#97)', () => {
+    clearDocumentParseCache();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const broken = '<main id="app-container">';
+
+    expect(parseDocument(broken)).toBeUndefined();
+    expect(parseDocument(broken)).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    warn.mockRestore();
   });
 });

--- a/src/utils/ast/document.ts
+++ b/src/utils/ast/document.ts
@@ -76,39 +76,25 @@ const findOutermostSections = (
   return sections;
 };
 
-const parseCache = createBoundedCache<string, t.File>(CONFIG.CACHE_LIMIT);
+// Caches the outcome for a source string, success or failure — `null` marks
+// a cached failure (bad syntax, or no app-container), distinct from
+// `undefined` meaning "not looked up yet" (createBoundedCache.get()'s own
+// miss signal). Without this, an in-progress syntax error (the document
+// mid-edit, before the next keystroke fixes it) would get re-parsed from
+// scratch by every one of the N call sites that ask for it on every render
+// (#97) — parsing determines nothing here except whether it throws, so
+// there's no separate "did it parse" fact to cache apart from the result.
+const documentCache = createBoundedCache<string, DocumentTree | null>(
+  CONFIG.CACHE_LIMIT,
+);
 
-// document.ts locates positions in the *original* source (section start/end
-// offsets, the container's opening/closing tag positions) and edits by
-// slicing that string — see replaceDocumentSections/generateSectionPreview
-// below. It never round-trips through @babel/generator and never mutates
-// the parsed tree, so every caller can safely share one cached AST: unlike
-// an approach that hands out a tree for the caller to edit in place, a
-// cache hit here needs no clone at all.
-const parseSource = (code: string): t.File => {
-  const cached = parseCache.get(code);
-
-  if (cached) {
-    return cached;
-  }
-
-  const ast = parse(code, {
-    sourceType: 'module',
-    plugins: ['jsx', 'typescript'],
-  });
-
-  parseCache.set(code, ast);
-
-  return ast;
-};
-
-// Parses the whole source once into a single Babel AST — the shared "document
-// tree" that section-level (this file) and field-level (extract.ts/update.ts)
-// operations both read via @babel/* instead of the previous regex-based
-// section slicing living in a separate, conflicting parser.
-export const parseDocument = (code: string): DocumentTree | undefined => {
+const buildDocument = (code: string): DocumentTree | undefined => {
   try {
-    const ast = parseSource(code);
+    const ast = parse(code, {
+      sourceType: 'module',
+      plugins: ['jsx', 'typescript'],
+    });
+
     const container = findContainer(ast);
 
     return container ? { code, ast, container } : undefined;
@@ -118,8 +104,34 @@ export const parseDocument = (code: string): DocumentTree | undefined => {
   }
 };
 
+// Parses the whole source once into a single Babel AST — the shared "document
+// tree" that section-level (this file) and field-level (extract.ts/update.ts)
+// operations both read via @babel/* instead of the previous regex-based
+// section slicing living in a separate, conflicting parser.
+//
+// document.ts locates positions in the *original* source (section start/end
+// offsets, the container's opening/closing tag positions) and edits by
+// slicing that string — see replaceDocumentSections/generateSectionPreview
+// below. It never round-trips through @babel/generator and never mutates
+// the parsed tree, so every caller can safely share the same cached
+// DocumentTree: unlike an approach that hands out a tree for the caller to
+// edit in place, a cache hit here needs no clone at all.
+export const parseDocument = (code: string): DocumentTree | undefined => {
+  const cached = documentCache.get(code);
+
+  if (cached !== undefined) {
+    return cached ?? undefined;
+  }
+
+  const doc = buildDocument(code);
+
+  documentCache.set(code, doc ?? null);
+
+  return doc;
+};
+
 export const clearDocumentParseCache = () => {
-  parseCache.clear();
+  documentCache.clear();
 };
 
 export const getSections = (doc: DocumentTree): Section[] =>
@@ -203,11 +215,29 @@ export const replaceDocumentSections = (
 export const generateSectionPreview = (
   fullCode: string,
   sectionCode: string,
-): string => {
+): string => generateSectionPreviews(fullCode, [sectionCode])[0]!;
+
+// Same as generateSectionPreview, but for every section in one call —
+// parses `fullCode` once and reuses the same container span for each,
+// instead of the N separate parseDocument calls one-at-a-time callers would
+// otherwise make per render (#97). Each entry only depends on the
+// container's surrounding code and that one section's own code, so an
+// unrelated edit elsewhere in `sectionCodes` still yields byte-identical
+// strings for the sections that didn't change — letting a caller pass
+// each one down as a stable prop instead of forcing every section to
+// recompute (and, with React.memo, re-render) on every edit.
+export const generateSectionPreviews = (
+  fullCode: string,
+  sectionCodes: string[],
+): string[] => {
   const doc = parseDocument(fullCode);
   const span = doc && getContainerInnerSpan(doc.container);
 
-  return span
-    ? spliceCode(fullCode, span.start, span.end, sectionCode)
-    : fullCode;
+  if (!span) {
+    return sectionCodes.map(() => fullCode);
+  }
+
+  return sectionCodes.map(sectionCode =>
+    spliceCode(fullCode, span.start, span.end, sectionCode),
+  );
 };

--- a/src/utils/ast/index.ts
+++ b/src/utils/ast/index.ts
@@ -26,6 +26,7 @@ export {
   clearDocumentParseCache,
   generateDocumentCode,
   generateSectionPreview,
+  generateSectionPreviews,
   getSections,
   parseDocument,
   replaceDocumentSections,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,6 +12,7 @@ import type { Module, Section } from '~/types';
 import { CONFIG, REGEX, TS_PATTERNS } from '../constants';
 import {
   generateSectionPreview,
+  generateSectionPreviews,
   getSections,
   parseDocument,
   replaceDocumentSections,
@@ -196,6 +197,18 @@ export const replaceSections = (code: string, sections: string[]): string => {
 
 export const generateSection = (code: string, fullCode: string) => {
   return generateSectionPreview(fullCode, code);
+};
+
+// Batched form of generateSection() — computes every section's preview from
+// a single parse of fullCode instead of one parseDocument call per section
+// (see generateSectionPreviews). Unchanged sections come back byte-identical
+// to their previous preview string, which is what lets a caller pass each
+// one down as a stable prop (see Renderer's React.memo).
+export const generateSections = (
+  codes: string[],
+  fullCode: string,
+): string[] => {
+  return generateSectionPreviews(fullCode, codes);
 };
 
 const scriptCache = createBoundedCache<string, string>(


### PR DESCRIPTION
## Summary
Addresses #97 — after #96 made `generateSectionPreview()` cheap, the remaining cost was structural: `dnd.tsx` handed every `<Renderer>` the whole document (`fullCode={value}`), so editing one section still invalidated every section's `useMemo` (`fullCode` changes on every edit) and forced React to reconcile every section's iframe tree, even though N-1 of them render byte-identical output.

- `document.ts`: add `generateSectionPreviews(fullCode, sectionCodes)` — batched form of `generateSectionPreview`, one parse of `fullCode` shared across every section instead of one `parseDocument` call per section. Sections that didn't change come back as the exact same string as last time
- `document.ts`: `parseDocument`'s cache now stores the full outcome (`DocumentTree | null`) instead of just the raw parsed `File`, so a cache hit skips `findContainer()`'s traversal too, and a parse failure (invalid syntax mid-edit) is cached instead of re-attempted on every one of the N call sites that ask for it per render
- `utils/index.ts`: add `generateSections(codes, fullCode)`, the code-first-arg wrapper matching `generateSection()`'s existing convention
- `renderer.tsx`: Props now take `preview: string` instead of `fullCode`/`code` — Renderer no longer computes its own preview, it just compiles what it's given. Wrapped in `React.memo()`: since `preview` is a plain string and unchanged sections get the same one back, an unrelated edit no longer re-renders or reconciles their iframe trees at all
- `dnd.tsx`: computes `previews` once via `generateSections()`, passes `previews[index]` to each Renderer instead of `fullCode`/`code`
- `overlay.tsx`: still isolated to one section during a drag (not the O(N) path #97 targets), so it keeps `generateSection()` but now builds the preview itself and passes it down the same way

## Test plan
- [x] `document.test.ts`: 7 new cases for `generateSectionPreviews` and parse-failure caching
- [x] full suite (156 tests), typecheck, lint all pass
- [x] `pnpm bench`: at 50 sections, a `parseDocument` cache hit is now instant (was ~0.009ms after #96 — `findContainer`'s traversal on every hit was the rest of that cost), and computing every section's preview via `generateSectionPreviews` is ~9.6x faster than the old one-call-per-section pattern. The bigger win — React.memo skipping re-render/reconciliation entirely for unchanged sections — isn't something this benchmark can measure
- [x] manually verified in a running dev instance: a 3-section document — deleting the middle section left the other two rendering their original, correct content, no console errors