### PR TITLE
fix(ast): give documentCache its own small limit instead of sharing 50

### DIFF
--- a/.changeset/pr-107.md
+++ b/.changeset/pr-107.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+The editor now has a smaller memory footprint when editing large documents, with a separate cache limit for document ASTs to prevent unnecessary memory usage.

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,6 +4,13 @@ export const STORAGE_KEY = 'live-editor-code';
 
 export const CONFIG = {
   CACHE_LIMIT: 50,
+  // Separate, much smaller limit for document.ts's parsed-AST cache — its
+  // entries are full Babel Files (~10-20x source size), not the compiled
+  // Module/string entries CACHE_LIMIT was sized for, and real hits only ever
+  // land on the document being actively edited (current + previous
+  // version), so keeping up to CACHE_LIMIT of them resident just wastes
+  // memory. See #106 (measured ~0.66MB/document, ~2.6MB at this limit).
+  DOCUMENT_CACHE_LIMIT: 4,
 } as const;
 
 export const DATA_ATTR = {

--- a/src/utils/ast/document.bench.ts
+++ b/src/utils/ast/document.bench.ts
@@ -94,5 +94,25 @@ for (const sectionCount of SECTION_COUNTS) {
         generateSectionPreviews(code, allSectionCodes);
       },
     );
+
+    // #106: documentCache's limit was shrunk from 50 (shared with the
+    // compile cache) to 4 (see CONFIG.DOCUMENT_CACHE_LIMIT), since it holds
+    // full Babel Files rather than compiled Modules/strings. This simulates
+    // the actual access pattern a real edit produces — dnd.tsx's
+    // extractSections() and generateSections() both call parseDocument() on
+    // the *same* current value within one render, so only the
+    // most-recently-edited version ever needs to be resident, not a long
+    // tail of every version edited so far.
+    let editCounter = 0;
+
+    bench(
+      'simulated edit: extractSections()+generateSections() lookup pattern',
+      () => {
+        const edited = `${code}\n// edit ${editCounter++}`;
+
+        parseDocument(edited);
+        parseDocument(edited);
+      },
+    );
   });
 }

--- a/src/utils/ast/document.test.ts
+++ b/src/utils/ast/document.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { CONFIG } from '../../constants';
 import {
   clearDocumentParseCache,
   generateDocumentCode,
@@ -374,5 +375,19 @@ describe('parseDocument caching', () => {
     expect(warn).toHaveBeenCalledTimes(1);
 
     warn.mockRestore();
+  });
+
+  it('evicts old entries once DOCUMENT_CACHE_LIMIT is exceeded — a document that fell out re-parses fresh instead of staying resident forever (#106)', () => {
+    clearDocumentParseCache();
+
+    const first = parseDocument(FULL_CODE)!;
+
+    for (let i = 0; i < CONFIG.DOCUMENT_CACHE_LIMIT; i++) {
+      parseDocument(`${FULL_CODE}\n// filler ${i}`);
+    }
+
+    const second = parseDocument(FULL_CODE)!;
+
+    expect(second.ast).not.toBe(first.ast);
   });
 });

--- a/src/utils/ast/document.ts
+++ b/src/utils/ast/document.ts
@@ -85,7 +85,7 @@ const findOutermostSections = (
 // (#97) — parsing determines nothing here except whether it throws, so
 // there's no separate "did it parse" fact to cache apart from the result.
 const documentCache = createBoundedCache<string, DocumentTree | null>(
-  CONFIG.CACHE_LIMIT,
+  CONFIG.DOCUMENT_CACHE_LIMIT,
 );
 
 const buildDocument = (code: string): DocumentTree | undefined => {


### PR DESCRIPTION
## Summary
Addresses #106 — `documentCache` (holding full Babel `File`s, ~10-20x source size per #95's measurements) shared `CONFIG.CACHE_LIMIT` (50) with the compile cache, which holds much lighter compiled `Module`/string entries. Since the cache key is the whole source string, every keystroke adds a new entry, so up to 50 full ASTs could stay resident even though real hits only ever land on the version being actively edited (`extractSections()` and `generateSections()` both call `parseDocument()` on the same current value within one render — see #101) — the other ~46 entries just held memory for versions that will never be queried again.

- `constants/index.ts`: add `CONFIG.DOCUMENT_CACHE_LIMIT` (4, matching the measurement in #106/#97's fork)
- `document.ts`: `documentCache` now uses `DOCUMENT_CACHE_LIMIT` instead of `CACHE_LIMIT`
- add a test confirming eviction actually kicks in at the new, much smaller limit
- add a benchmark simulating the real access pattern (`parseDocument` called twice per edit — `extractSections()` + `generateSections()` both querying the same current value): its cost is dominated entirely by the one unavoidable fresh parse, confirming the second lookup is still a cache hit and the smaller limit doesn't reintroduce the problem #101 fixed

## Test plan
- [x] new test confirming eviction at the smaller limit
- [x] full suite (157 tests), typecheck, lint all pass
- [x] `pnpm bench` confirms the realistic access pattern still gets a cache hit on the second lookup
- [ ] no browser check — pure cache-limit constant change verified by unit test + benchmark, no behavior change to the app itself