### PR TITLE
fix(ast): diff sections by common prefix/suffix instead of one span

### DIFF
--- a/.changeset/pr-109.md
+++ b/.changeset/pr-109.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Improve the diffing and replacement of document sections, preserving non-section content and wrapper elements when sections are reordered or deleted.

--- a/src/utils/ast/document.test.ts
+++ b/src/utils/ast/document.test.ts
@@ -234,6 +234,139 @@ export default App;
   });
 });
 
+describe('replaceDocumentSections diffing (#102)', () => {
+  it('a true no-op round-trip is byte-for-byte identical to the input', () => {
+    const code = `
+      const App = () => (
+        <div id="app-container">
+          <div className="header">header</div>
+          {/* between */}
+          <section data-name="s1"><p>1</p></section>
+          <div className="mid">middle content</div>
+          <section data-name="s2"><p>2</p></section>
+          <div className="footer">footer</div>
+        </div>
+      );
+    `;
+
+    const roundTripped = replaceDocumentSections(
+      code,
+      getSections(parseDocument(code)!).map(s => s.code),
+    );
+
+    expect(roundTripped).toBe(code);
+  });
+
+  it('editing one section leaves a sibling section in a different wrapper — and its wrapper — untouched', () => {
+    const code = `
+      const App = () => (
+        <div id="app-container">
+          <div className="a">
+            <section data-name="s1"><p>1</p></section>
+          </div>
+          <div className="b">
+            <section data-name="s2"><p>2</p></section>
+          </div>
+        </div>
+      );
+    `;
+
+    const sections = getSections(parseDocument(code)!);
+
+    const next = replaceDocumentSections(code, [
+      '<section data-name="s1-edited"><p>1 edited</p></section>',
+      sections[1]!.code,
+    ]);
+
+    expect(next).toContain('className="a"');
+    expect(next).toContain('className="b"');
+    expect(next).toContain('<section data-name="s2"><p>2</p></section>');
+    expect(getSections(parseDocument(next)!).map(s => s.name)).toEqual([
+      's1-edited',
+      's2',
+    ]);
+  });
+
+  it('deleting one section leaves non-section content between the others untouched', () => {
+    const code = `
+      const App = () => (
+        <div id="app-container">
+          <section data-name="s1"><p>1</p></section>
+          <div className="mid">middle banner</div>
+          <section data-name="s2"><p>2</p></section>
+          <section data-name="s3"><p>3</p></section>
+        </div>
+      );
+    `;
+
+    const sections = getSections(parseDocument(code)!);
+
+    // Delete s2, keeping s1 and s3 (dnd.tsx's onDelete: filter, preserve order)
+    const next = replaceDocumentSections(code, [
+      sections[0]!.code,
+      sections[2]!.code,
+    ]);
+
+    expect(next).toContain('middle banner');
+    expect(getSections(parseDocument(next)!).map(s => s.name)).toEqual([
+      's1',
+      's3',
+    ]);
+  });
+
+  it('inserting a section in the middle leaves the rest of the document untouched', () => {
+    const code = `
+      const App = () => (
+        <div id="app-container">
+          <section data-name="s1"><p>1</p></section>
+          <div className="mid">middle banner</div>
+          <section data-name="s2"><p>2</p></section>
+        </div>
+      );
+    `;
+
+    const sections = getSections(parseDocument(code)!);
+
+    const next = replaceDocumentSections(code, [
+      sections[0]!.code,
+      '<section data-name="new"><p>new</p></section>',
+      sections[1]!.code,
+    ]);
+
+    expect(next).toContain('middle banner');
+    expect(getSections(parseDocument(next)!).map(s => s.name)).toEqual([
+      's1',
+      'new',
+      's2',
+    ]);
+  });
+
+  it('appending a section at the end leaves earlier sections and their wrappers untouched', () => {
+    const code = `
+      const App = () => (
+        <div id="app-container">
+          <div className="a">
+            <section data-name="s1"><p>1</p></section>
+          </div>
+        </div>
+      );
+    `;
+
+    const sections = getSections(parseDocument(code)!);
+
+    const next = replaceDocumentSections(code, [
+      sections[0]!.code,
+      '<section data-name="s2"><p>2</p></section>',
+    ]);
+
+    expect(next).toContain('className="a"');
+    expect(getSections(parseDocument(next)!).map(s => s.name)).toEqual([
+      's1',
+      's2',
+    ]);
+  });
+});
+
 describe('generateSectionPreview', () => {
   it('produces a document whose container holds only the given section', () => {
     const preview = generateSectionPreview(

--- a/src/utils/ast/document.ts
+++ b/src/utils/ast/document.ts
@@ -166,14 +166,53 @@ const spliceCode = (
   replacement: string,
 ): string => code.slice(0, start) + replacement + code.slice(end);
 
-// Replaces the container's <section> children with `sectionCodes`, leaving
-// everything else in the file — non-section content before/after the
-// sections, and anything outside the container entirely — byte-for-byte
-// untouched (no whole-file reformatting, no reordering; see #96). Content
-// interspersed *between* the original sections is not separately preserved:
-// the whole span from the first section's start to the last section's end
-// is replaced as one block, since `sectionCodes` is a flat replacement list
-// with no way to say where such content should land in the new order.
+// Length of the run at the start of `a`/`b` where elements are equal
+// (by exact string value), e.g. commonPrefixLength(['a','b','x'], ['a','b','y']) === 2.
+const commonPrefixLength = (a: string[], b: string[]): number => {
+  const max = Math.min(a.length, b.length);
+  let i = 0;
+
+  while (i < max && a[i] === b[i]) {
+    i++;
+  }
+
+  return i;
+};
+
+// Same as commonPrefixLength but from the end, bounded by `limit` so it
+// can't reclaim elements the prefix already matched.
+const commonSuffixLength = (
+  a: string[],
+  b: string[],
+  limit: number,
+): number => {
+  let i = 0;
+
+  while (i < limit && a[a.length - 1 - i] === b[b.length - 1 - i]) {
+    i++;
+  }
+
+  return i;
+};
+
+// Replaces the container's <section> children with `sectionCodes`. Rather
+// than treating "all the sections" as one contiguous block to overwrite —
+// which silently deleted whatever sat between them, including entire
+// wrapper elements around sections that live in different parents (#102) —
+// this diffs the old and new section-code lists by common prefix/suffix
+// (matching by exact content, same idea as a line-based text diff) and only
+// touches the byte range spanning the run that actually changed. Everything
+// outside that run — unchanged leading/trailing sections and all
+// non-section content around them, including different wrappers — is left
+// byte-for-byte untouched. A no-op call (sectionCodes identical to the
+// current sections) touches nothing at all.
+//
+// This doesn't reach full minimal-diff generality for content that's
+// simultaneously reordered *and* unchanged (e.g. swapping two sections with
+// nothing else different still replaces the whole swapped run, so content
+// sitting between them isn't preserved) — every real caller (dnd.tsx) only
+// ever performs one edit/add/delete/reorder per call, which this handles
+// precisely; see #102 for the general case this doesn't cover.
 //
 // `sectionCodes` are spliced in as raw text with no parsing or validation:
 // an invalid entry still lands in the output rather than being silently
@@ -190,23 +229,57 @@ export const replaceDocumentSections = (
   }
 
   const sections = findOutermostSections(doc.container.children);
-  const replacement = sectionCodes.join('\n');
 
-  if (sections.length > 0) {
-    const start = sections[0]!.start!;
-    const end = sections[sections.length - 1]!.end!;
+  if (sections.length === 0) {
+    // No existing sections to diff against — append after whatever the
+    // container already holds (e.g. a still-empty <main id="app-container">)
+    // instead of discarding it.
+    const span = getContainerInnerSpan(doc.container);
 
-    return spliceCode(fullCode, start, end, replacement);
+    return span
+      ? spliceCode(fullCode, span.end, span.end, sectionCodes.join('\n'))
+      : fullCode;
   }
 
-  // No existing sections to anchor a replacement span on — append after
-  // whatever the container already holds (e.g. a still-empty
-  // <main id="app-container">) instead of discarding it.
-  const span = getContainerInnerSpan(doc.container);
+  const oldCodes = sections.map(node => fullCode.slice(node.start!, node.end!));
 
-  return span
-    ? spliceCode(fullCode, span.end, span.end, replacement)
-    : fullCode;
+  const prefixLength = commonPrefixLength(oldCodes, sectionCodes);
+  const suffixLength = commonSuffixLength(
+    oldCodes,
+    sectionCodes,
+    Math.min(oldCodes.length, sectionCodes.length) - prefixLength,
+  );
+
+  const oldChangedStart = prefixLength;
+  const oldChangedEndExclusive = oldCodes.length - suffixLength;
+  const newChanged = sectionCodes.slice(
+    prefixLength,
+    sectionCodes.length - suffixLength,
+  );
+
+  if (oldChangedStart >= oldChangedEndExclusive) {
+    // Nothing removed — either a pure no-op (newChanged also empty) or a
+    // pure insertion, anchored right before the first untouched section
+    // that follows it (or after the last section, if inserted at the end).
+    if (newChanged.length === 0) {
+      return fullCode;
+    }
+
+    if (oldChangedStart < sections.length) {
+      const at = sections[oldChangedStart]!.start!;
+
+      return spliceCode(fullCode, at, at, `${newChanged.join('\n')}\n`);
+    }
+
+    const at = sections[sections.length - 1]!.end!;
+
+    return spliceCode(fullCode, at, at, `\n${newChanged.join('\n')}`);
+  }
+
+  const start = sections[oldChangedStart]!.start!;
+  const end = sections[oldChangedEndExclusive - 1]!.end!;
+
+  return spliceCode(fullCode, start, end, newChanged.join('\n'));
 };
 
 // Produces a document whose container holds only `sectionCode`, discarding


### PR DESCRIPTION
## Summary
Addresses #102 — `replaceDocumentSections()` treated "all the sections" as one contiguous block: it replaced from the first section's start to the last section's end with `sectionCodes.join('\n')`, so anything between them — including entire wrapper elements around sections that live in different parents, not just interstitial siblings — got silently deleted. This became reachable once #96 made section discovery recursive (sections wrapped in other elements are now found), but the span-replace logic hadn't caught up.

## Fix
Diff `oldCodes` (the current sections' text) against the incoming `sectionCodes` by common prefix/suffix — the same idea as a line-based text diff, matching by exact content — and only touch the byte range spanning the run that actually changed. A no-op call (`sectionCodes` identical to the current sections) now touches nothing at all; editing/adding/removing one section leaves every other section, and everything around them (different wrappers included), byte-for-byte untouched.

This doesn't reach full minimal-diff generality for content that's simultaneously reordered *and* unchanged (e.g. swapping two sections with nothing else different still replaces the whole swapped run) — every real caller (`dnd.tsx`) only ever performs one edit/add/delete/reorder per call, which this handles precisely; the general case is noted in the code as a known, documented limitation (also called out in #102).

- add `commonPrefixLength()`/`commonSuffixLength()` helpers
- rewrite `replaceDocumentSections()` to diff-then-splice instead of always replacing the full first-to-last span
- add 5 tests: byte-identical no-op round-trip, edit/delete/insert/append all leaving unrelated wrappers and interstitial content untouched

## Test plan
- [x] all existing tests pass unchanged (this is a strict improvement — no existing test needed adjustment)
- [x] 5 new tests covering #102's exact scenarios
- [x] full suite (162 tests), typecheck, lint all pass
- [x] manually verified in a running dev instance: two sections in separate wrapper `<div>`s — deleting one left the other's wrapper (and its section) completely intact, where the previous span-replace behavior would have deleted the second wrapper's opening tag along with it