### PR TITLE
♻️ refactor: key changeset drafting off branch slug instead of PR number

### DIFF
--- a/.github/scripts/draft-changeset.mjs
+++ b/.github/scripts/draft-changeset.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-// Drafts a .changeset/pr-<number>.md file by asking an LLM to summarize
+// Drafts a .changeset/<branch-slug>.md file by asking an LLM to summarize
 // this PR's diff to src/ as a semver bump + one-paragraph description, in
 // changesets' own file format. Runs once per PR (the calling workflow skips
-// this script entirely if a changeset file for this PR already exists), so
-// it never overwrites something a human already wrote or edited.
+// this script entirely if a changeset file for this branch already
+// exists), so it never overwrites something a human already wrote or
+// edited.
 //
 // Uses NVIDIA's OpenAI-compatible API Catalog endpoint (not Gemini/GitHub
 // Models — both have hit sustained outages/retirement before this).
@@ -76,7 +77,7 @@ async function main() {
   const apiKey = requireEnv('NVIDIA_API_KEY');
   const baseSha = requireEnv('BASE_SHA');
   const headSha = requireEnv('HEAD_SHA');
-  const prNumber = requireEnv('PR_NUMBER');
+  const branchSlug = requireEnv('BRANCH_SLUG');
 
   let diff;
   try {
@@ -171,7 +172,7 @@ async function main() {
     return;
   }
 
-  const filePath = `.changeset/pr-${prNumber}.md`;
+  const filePath = `.changeset/${branchSlug}.md`;
   const fileContent = [
     '---',
     `'${PACKAGE_NAME}': ${result.bump}`,

--- a/.github/workflows/changeset-draft.yml
+++ b/.github/workflows/changeset-draft.yml
@@ -32,13 +32,31 @@ jobs:
         with:
           node-version: 24.x
 
-      # Only draft once per PR — if a changeset already exists (hand-written
-      # or from an earlier run of this workflow on this PR), leave it alone
-      # rather than overwriting a human's edits on every subsequent push.
+      # Only draft once per PR — if a changeset already exists for *this
+      # branch* (hand-written, or from an earlier run of this workflow on
+      # this PR), leave it alone rather than overwriting a human's edits on
+      # every subsequent push. Keyed off the branch name (slugified: `/`
+      # and other unsafe characters become `-`) rather than PR number so
+      # the check itself doubles as a human-readable filename — matches
+      # ui-kit#197/use-hooks#138, which fixed a false positive elsewhere
+      # from checking "does any changeset file exist at all" instead of
+      # scoping to a specific PR/branch (an older, still-unreleased PR's
+      # changeset would otherwise make every PR merged after it silently
+      # skip drafting its own). This repo's check was already scoped
+      # per-PR (by number) and never had that bug — switching to a branch
+      # slug here is purely for the readable-filename benefit and
+      # consistency with the other two repos, not a bug fix.
       - name: Check for existing changeset
         id: existing
+        env:
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if compgen -G ".changeset/pr-${{ github.event.pull_request.number }}.md" > /dev/null; then
+          slug=$(printf '%s' "$BRANCH_REF" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+          shopt -s nullglob
+          files=(".changeset/${slug}"*.md)
+          shopt -u nullglob
+          if [ "${#files[@]}" -gt 0 ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -50,7 +68,7 @@ jobs:
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH_SLUG: ${{ steps.existing.outputs.slug }}
         run: node .github/scripts/draft-changeset.mjs
 
       - name: Commit and push changeset


### PR DESCRIPTION
## Summary

Switches the existing-changeset check and drafted filename from \`pr-<PR#>.md\` to a slugified branch name (\`/\` and other unsafe characters → \`-\`).

This repo's check was already scoped per-PR (by number) and never had the "any file exists" false-positive bug that hit ui-kit#197/use-hooks#138 (where an older, still-unreleased PR's changeset made every later PR silently skip drafting its own). This change is purely for the readable-filename benefit and consistency with the other two repos, not a bug fix here.

## Test plan
- [x] Verified the slug + glob logic locally (same test as ui-kit#197/use-hooks#138)
- [x] This PR's own \`Changeset Draft\` run is a live test of the workflow YAML executing without errors