### PR TITLE
fix: resolve 7 confirmed bugs (#83-86, #103-105)

### DIFF
--- a/.changeset/fix-confirmed-bugs-batch-1.md
+++ b/.changeset/fix-confirmed-bugs-batch-1.md
@@ -1,5 +1,5 @@
 ---
-'@jbpark/live-editor': minor
+'@jbpark/live-editor': patch
 ---
 
-Added support for negative numeric literals in the AST value extractor, and improved the bounded cache implementation with eviction callbacks and a separate limit for script cache entries.
+Fixed 7 confirmed bugs: Guard's onError prop being shadowed and never invoked, Field's blur handlers blocking clearing a value to empty, extractNodeValue not recognizing negative numeric literals, Items crashing when adding an item to an empty array, createBoundedCache not calling onEvict on overwrite/delete/clear, scriptCache sharing an unrelated cache's size limit, and compile()'s cache key using a collision-prone 32-bit hash.

--- a/.changeset/fix-confirmed-bugs-batch-1.md
+++ b/.changeset/fix-confirmed-bugs-batch-1.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Added support for negative numeric literals in the AST value extractor, and improved the bounded cache implementation with eviction callbacks and a separate limit for script cache entries.

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -322,7 +322,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
 
             setValidationError(null);
 
-            if (next && next !== value) {
+            if (next !== value) {
               onChange?.({
                 id,
                 label: binding.label,
@@ -442,7 +442,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
 
             setValidationError(null);
 
-            if (next && next !== value) {
+            if (next !== value) {
               onChange?.({
                 id,
                 label: binding.label,
@@ -474,7 +474,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
 
           setValidationError(null);
 
-          if (next && next !== value) {
+          if (next !== value) {
             onChange?.({
               id,
               label: binding.label,

--- a/src/components/dnd/panel/items.tsx
+++ b/src/components/dnd/panel/items.tsx
@@ -479,7 +479,12 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
   };
 
   const addItem = () => {
-    const firstItem = objectItems[0]!;
+    const firstItem = objectItems[0];
+
+    if (!firstItem) {
+      return;
+    }
+
     const clonedElement = cloneObjectItemElement(firstItem);
     const editableProperties = extractObjectProperties(clonedElement);
 
@@ -632,6 +637,7 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
           icon={<Plus />}
           variant="solid"
           color="green"
+          disabled={objectItems.length === 0}
           onClick={addItem}
         >
           Add Item

--- a/src/components/error/guard.tsx
+++ b/src/components/error/guard.tsx
@@ -20,7 +20,7 @@ const Guard = ({ children, onError }: Props) => {
       return;
     }
 
-    const onError = (event: ErrorEvent) => {
+    const handleWindowError = (event: ErrorEvent) => {
       if (errorHandled.current) {
         return;
       }
@@ -44,7 +44,7 @@ const Guard = ({ children, onError }: Props) => {
       return true;
     };
 
-    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
       if (errorHandled.current) {
         return;
       }
@@ -62,14 +62,18 @@ const Guard = ({ children, onError }: Props) => {
       }, 100);
     };
 
-    window.addEventListener('error', onError, true);
-    window.addEventListener('unhandledrejection', onUnhandledRejection, true);
+    window.addEventListener('error', handleWindowError, true);
+    window.addEventListener(
+      'unhandledrejection',
+      handleUnhandledRejection,
+      true,
+    );
 
     return () => {
-      window.removeEventListener('error', onError, true);
+      window.removeEventListener('error', handleWindowError, true);
       window.removeEventListener(
         'unhandledrejection',
-        onUnhandledRejection,
+        handleUnhandledRejection,
         true,
       );
     };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,6 +11,13 @@ export const CONFIG = {
   // version), so keeping up to CACHE_LIMIT of them resident just wastes
   // memory. See #106 (measured ~0.66MB/document, ~2.6MB at this limit).
   DOCUMENT_CACHE_LIMIT: 4,
+  // Separate limit for utils/index.ts's scriptCache — those entries are
+  // live blob URLs handed to <script src>, and its onEvict immediately
+  // revokes the URL, unlike compilationCache's evictions which just discard
+  // a cheap-to-recompute Module. Sharing CACHE_LIMIT with compilationCache
+  // was coincidental, not a sizing decision for scriptCache's actual usage
+  // (a handful of distinct external preview scripts). See #104.
+  SCRIPT_CACHE_LIMIT: 10,
 } as const;
 
 export const DATA_ATTR = {

--- a/src/utils/ast/value.test.ts
+++ b/src/utils/ast/value.test.ts
@@ -94,6 +94,14 @@ describe('extractNodeValue', () => {
     });
   });
 
+  it('extracts negative numeric literals', () => {
+    const node = parseExpression('-5');
+    expect(extractNodeValue(node)).toEqual({
+      type: 'number',
+      value: -5,
+    });
+  });
+
   it('extracts string literals', () => {
     expect(extractNodeValue(t.stringLiteral('hi'))).toEqual({
       type: 'string',

--- a/src/utils/ast/value.ts
+++ b/src/utils/ast/value.ts
@@ -163,6 +163,14 @@ export const extractNodeValue = (node: t.Node): ExtractedNodeValue => {
     return { type: 'number', value: node.value };
   }
 
+  if (
+    t.isUnaryExpression(node) &&
+    node.operator === '-' &&
+    t.isNumericLiteral(node.argument)
+  ) {
+    return { type: 'number', value: -node.argument.value };
+  }
+
   if (t.isStringLiteral(node)) {
     return { type: 'string', value: node.value };
   }

--- a/src/utils/cache.test.ts
+++ b/src/utils/cache.test.ts
@@ -63,6 +63,39 @@ describe('createBoundedCache', () => {
     expect(cache.has('c')).toBe(true);
   });
 
+  it('calls onEvict when set() overwrites an existing key', () => {
+    const onEvict = vi.fn();
+    const cache = createBoundedCache<string, number>(3, onEvict);
+
+    cache.set('a', 1);
+    cache.set('a', 2);
+
+    expect(onEvict).toHaveBeenCalledExactlyOnceWith('a', 1);
+  });
+
+  it('calls onEvict when delete() removes an entry', () => {
+    const onEvict = vi.fn();
+    const cache = createBoundedCache<string, number>(3, onEvict);
+
+    cache.set('a', 1);
+    cache.delete('a');
+
+    expect(onEvict).toHaveBeenCalledExactlyOnceWith('a', 1);
+  });
+
+  it('calls onEvict for every remaining entry when clear() is called', () => {
+    const onEvict = vi.fn();
+    const cache = createBoundedCache<string, number>(3, onEvict);
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.clear();
+
+    expect(onEvict).toHaveBeenCalledTimes(2);
+    expect(onEvict).toHaveBeenCalledWith('a', 1);
+    expect(onEvict).toHaveBeenCalledWith('b', 2);
+  });
+
   it('set() on an existing key refreshes its recency instead of double-counting it', () => {
     const cache = createBoundedCache<string, number>(2);
 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -35,7 +35,10 @@ export const createBoundedCache = <K, V>(
 
   const set = (key: K, value: V) => {
     if (store.has(key)) {
+      const oldValue = store.get(key)!;
+
       store.delete(key);
+      onEvict?.(key, oldValue);
     } else if (store.size >= limit) {
       const oldestKey = store.keys().next().value;
 
@@ -50,12 +53,33 @@ export const createBoundedCache = <K, V>(
     store.set(key, value);
   };
 
+  const deleteKey = (key: K): boolean => {
+    if (!store.has(key)) {
+      return false;
+    }
+
+    const value = store.get(key)!;
+
+    store.delete(key);
+    onEvict?.(key, value);
+
+    return true;
+  };
+
+  const clear = () => {
+    for (const [key, value] of store) {
+      onEvict?.(key, value);
+    }
+
+    store.clear();
+  };
+
   return {
     has: key => store.has(key),
     get,
     set,
-    delete: key => store.delete(key),
-    clear: () => store.clear(),
+    delete: deleteKey,
+    clear,
     get size() {
       return store.size;
     },

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -32,30 +32,18 @@ export const baseModules = {
 
 const compilationCache = createBoundedCache<string, Module>(CONFIG.CACHE_LIMIT);
 
-const simpleHash = (str: string): string => {
-  let hash = 0;
-
-  if (str.length === 0) {
-    return '0';
-  }
-
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash;
-  }
-
-  return Math.abs(hash).toString(36);
-};
-
+// Uses the raw code+moduleKeys string as the key rather than hashing it —
+// a 32-bit hash (the previous approach) can collide between two genuinely
+// different inputs, which would silently serve one code string's compiled
+// Module for another. The bounded LRU cache already caps memory use, so
+// there's no need to shrink the key itself.
 const createCacheKey = (
   code: string,
   modules: Record<string, unknown>,
 ): string => {
   const moduleKeys = Object.keys(modules).sort().join(',');
-  const combined = code + '|' + moduleKeys;
 
-  return simpleHash(combined);
+  return code + '|' + moduleKeys;
 };
 
 export const compile = (
@@ -212,7 +200,7 @@ export const generateSections = (
 };
 
 const scriptCache = createBoundedCache<string, string>(
-  CONFIG.CACHE_LIMIT,
+  CONFIG.SCRIPT_CACHE_LIMIT,
   (_src, blobUrl) => URL.revokeObjectURL(blobUrl),
 );
 const loadingScriptCache = new Map<string, Promise<string>>();


### PR DESCRIPTION
## Summary

Batches the 7 issues labeled as confirmed (non-`needs-investigation`) bugs. All are small, low-risk, independent fixes; verified together via `check-types`/`lint`/`test`/`build`.

- **#84** — `Guard`'s local `const onError = (event: ErrorEvent) => {...}` window-error handler shadowed the `onError` prop for the rest of the effect closure. The `unhandledrejection` handler ended up calling the *window-error* handler instead of the prop (wrong signature, silently a no-op due to the `errorHandled` guard), and the window-error handler's own internal `onError?.(...)` call recursed into itself instead of invoking the prop. Net effect: the `onError` prop was never actually called. Renamed the locals to `handleWindowError`/`handleUnhandledRejection`.
- **#86** — `Field`'s blur handlers gated `onChange` behind `next && next !== value`, so clearing a text/url/number/textarea field to an empty string was silently dropped (never reached `onChange`). `validateBindingValue` already runs first and blocks genuinely invalid values, so the truthy guard was redundant and wrong for the empty-is-valid case. Changed to `next !== value` in all 3 occurrences (url, number, textarea branches — icon-picker/asset-picker were already correct).
- **#83** — `extractNodeValue` was missing the negative-numeric-literal (`UnaryExpression` with `-` + `NumericLiteral`) branch that `evaluateLiteral` already had, so e.g. `-5` extracted as `{ type: 'unknown', value: null }` instead of `{ type: 'number', value: -5 }`. Added the matching branch + a regression test.
- **#85** — `Items`' `addItem()` did `const firstItem = objectItems[0]!;` unconditionally, crashing when the array has zero object items (nothing to clone the shape from). Guarded with an early return, and disabled the "Add Item" button in that state since there's no existing item to clone.
- **#103** — `createBoundedCache`'s `onEvict` only fired on LRU eviction; `set()` overwriting an existing key, `delete()`, and `clear()` all discarded values without calling it. This matters for `scriptCache`, whose `onEvict` revokes the entry's blob URL — those paths were leaking blob URLs. Fixed all three, added regression tests for each.
- **#104** — `scriptCache` and `compilationCache` both read `CONFIG.CACHE_LIMIT` (50), which was a coincidence of both being defined in the same file rather than an actual sizing decision for `scriptCache` (whose entries are live blob URLs — eviction has an immediate side effect — versus `compilationCache`'s cheap-to-recompute `Module` values). Split into its own `CONFIG.SCRIPT_CACHE_LIMIT`.
- **#105** — `compile()`'s cache key was `simpleHash(code + moduleKeys)`, a 32-bit hash that can collide between two different inputs and would silently serve one code string's compiled `Module` for a different one. Switched to using the raw `code + '|' + moduleKeys` string as the key directly (the bounded LRU already caps memory; no need for the lossy hash).

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (incl. new regression tests for #83 and #103)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes