### PR TITLE
fix: clear stale runtime error when code changes (#88)

### DIFF
--- a/.changeset/fix-88-stale-error-not-cleared-on-code-change.md
+++ b/.changeset/fix-88-stale-error-not-cleared-on-code-change.md
@@ -1,5 +1,5 @@
 ---
-'@jbpark/live-editor': minor
+'@jbpark/live-editor': patch
 ---
 
-Add support for preview context and improve error handling in the context provider.
+Fixed the runtime/compile error overlay staying up indefinitely after the underlying code was fixed. ContextProvider's setCode now clears the stale error in the same update that changes the code.

--- a/.changeset/fix-88-stale-error-not-cleared-on-code-change.md
+++ b/.changeset/fix-88-stale-error-not-cleared-on-code-change.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add support for preview context and improve error handling in the context provider.

--- a/src/components/context/context.tsx
+++ b/src/components/context/context.tsx
@@ -1,16 +1,29 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { DEFAULT_TEMPLATE } from '~/constants';
 import { clearCompilationCache } from '~/utils';
 
-import type { ErrorContextType } from './states';
+import type { ErrorContextType, PreviewContextType } from './states';
 import { ErrorContext, PreviewContext } from './states';
 
 const ContextProvider = ({ children }: { children?: React.ReactNode }) => {
-  const [code, setCode] = useState(DEFAULT_TEMPLATE);
+  const [code, setCodeState] = useState(DEFAULT_TEMPLATE);
   const [error, setError] = useState<ErrorContextType['error']>(null);
+
+  // Clears any stale runtime/compile error in the same update batch that
+  // changes `code`, rather than in a separate useEffect — a useEffect here
+  // would race with componentDidCatch/Guard's onError firing for the *new*
+  // code's own errors within the same commit (layout effects run before
+  // passive effects, so a passive-effect reset could wipe out an error the
+  // new code just threw). Batching setError(null) into the same update as
+  // setCode guarantees stale errors are gone by the time the new code even
+  // renders, with nothing left afterward that could clobber a fresh one.
+  const setCode = useCallback<PreviewContextType['setCode']>(next => {
+    setError(null);
+    setCodeState(next);
+  }, []);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary

Fixes #88 — after a runtime error occurred, editing/fixing the code never cleared the `ErrorContext`'s `error` state, so the error overlay stayed up indefinitely. Worse than the issue describes: `client.tsx` renders `<LiveError.Runtime open={isError} />` without a `reset` prop, and `Runtime`'s `Error` UI only renders a "Try Again" button when `onReset` is provided — so there was no manual escape hatch either, only clearable by unmounting `ErrorContext.Provider` entirely.

## Root cause

`ContextProvider` (`src/components/context/context.tsx`) exposed the raw `useState` setter as `setCode`, with nothing wired to clear `error` when code changes.

## Fix

Wrapped the exposed `setCode` to batch `setError(null)` into the same update as the code change, rather than adding a separate `useEffect` keyed on `code`:

A `useEffect` approach would run in React's passive phase, which fires *after* the layout phase — and `componentDidCatch`/`Guard`'s `onError` (which also call `setError`) run in the layout phase. If the newly-edited code throws immediately on its own first render (user's fix was itself still broken), the passive-phase reset would run after the layout-phase error-set and clobber the fresh error right back to `null`.

Batching `setError(null)` into `setCode` itself avoids this: both updates are dispatched synchronously in the same call (React 18 auto-batches this regardless of caller context — event handler or debounce timeout), so the stale error is already gone by the time the new code even renders. Nothing runs afterward in that same commit that could overwrite a genuinely new error.

## Scope note

Verified real usage (`src/pages/editor/index.tsx`, `src/main.tsx`) only ever renders `<Live.Preview>`/`<Preview>` without a direct `code` prop, so this always goes through `PreviewContext`'s `code`/`setCode` — the path this fix covers. `Preview`'s own local `runtimeError` state (used only when a `code` prop is passed directly, bypassing context) has the same class of bug but is a separate `useState`; tracked together with #87 (ErrorBoundary not auto-resetting) since both are "local error state not reset on code change," to be handled next.

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated to this change; no jsdom/testing-library in this repo yet, so this component-level fix isn't covered by an automated regression test — verified via full commit-order code trace instead)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes