### PR TITLE
fix: auto-reset stale error state when code changes (#87)

### DIFF
--- a/.changeset/fix-87-error-boundary-auto-reset.md
+++ b/.changeset/fix-87-error-boundary-auto-reset.md
@@ -1,5 +1,5 @@
 ---
-'@jbpark/live-editor': minor
+'@jbpark/live-editor': patch
 ---
 
-Add support for auto-recovery of caught errors without remounting the error boundary when the underlying code changes.
+Fixed ErrorBoundary (and Preview's own runtime-error state) staying stuck on a stale error screen after the underlying code was fixed. ErrorBoundary gained an optional resetKeys prop, but this is a backward-compatible fix — every real usage in Preview/Client now auto-recovers without any consumer action needed.

--- a/.changeset/fix-87-error-boundary-auto-reset.md
+++ b/.changeset/fix-87-error-boundary-auto-reset.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add support for auto-recovery of caught errors without remounting the error boundary when the underlying code changes.

--- a/.changeset/fix-88-stale-error-not-cleared-on-code-change.md
+++ b/.changeset/fix-88-stale-error-not-cleared-on-code-change.md
@@ -1,5 +1,5 @@
 ---
-'@jbpark/live-editor': minor
+'@jbpark/live-editor': patch
 ---
 
-Add support for preview context and improve error handling in the context provider.
+Fixed the runtime/compile error overlay staying up indefinitely after the underlying code was fixed. ContextProvider's setCode now clears the stale error in the same update that changes the code.

--- a/.changeset/fix-88-stale-error-not-cleared-on-code-change.md
+++ b/.changeset/fix-88-stale-error-not-cleared-on-code-change.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add support for preview context and improve error handling in the context provider.

--- a/src/components/context/context.tsx
+++ b/src/components/context/context.tsx
@@ -1,16 +1,29 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { DEFAULT_TEMPLATE } from '~/constants';
 import { clearCompilationCache } from '~/utils';
 
-import type { ErrorContextType } from './states';
+import type { ErrorContextType, PreviewContextType } from './states';
 import { ErrorContext, PreviewContext } from './states';
 
 const ContextProvider = ({ children }: { children?: React.ReactNode }) => {
-  const [code, setCode] = useState(DEFAULT_TEMPLATE);
+  const [code, setCodeState] = useState(DEFAULT_TEMPLATE);
   const [error, setError] = useState<ErrorContextType['error']>(null);
+
+  // Clears any stale runtime/compile error in the same update batch that
+  // changes `code`, rather than in a separate useEffect — a useEffect here
+  // would race with componentDidCatch/Guard's onError firing for the *new*
+  // code's own errors within the same commit (layout effects run before
+  // passive effects, so a passive-effect reset could wipe out an error the
+  // new code just threw). Batching setError(null) into the same update as
+  // setCode guarantees stale errors are gone by the time the new code even
+  // renders, with nothing left afterward that could clobber a fresh one.
+  const setCode = useCallback<PreviewContextType['setCode']>(next => {
+    setError(null);
+    setCodeState(next);
+  }, []);
 
   useEffect(() => {
     return () => {

--- a/src/components/error/boundary.tsx
+++ b/src/components/error/boundary.tsx
@@ -6,6 +6,14 @@ interface Props {
   children: React.ReactNode;
   fallback?: (message?: string) => React.ReactNode;
   onError?: (e: Error, info: React.ErrorInfo) => void;
+  // Values whose identity changing (typically the code/module that produced
+  // `children`) should auto-recover a caught error without needing a
+  // remount — compared shallowly, one entry at a time, same idea as
+  // react-error-boundary's resetKeys. Without this, once tripped, render()
+  // never even attempts `children` again (see below), so a fix to the
+  // underlying code has no way to reach the screen until this array changes
+  // or something remounts the boundary via `key`.
+  resetKeys?: readonly unknown[];
 }
 
 interface State {
@@ -26,6 +34,28 @@ class ErrorBoundary extends React.Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('🚨 [Boundary] Rendering error:', error, errorInfo);
     this.props.onError?.(error, errorInfo);
+  }
+
+  // Safe to reset unconditionally here (no race with a freshly-thrown
+  // error): while hasError is true, render() below never attempts
+  // `children` at all, so resetting just schedules a follow-up render where
+  // `children` gets its first real chance to run with the new resetKeys —
+  // if that throws too, getDerivedStateFromError catches it fresh in that
+  // later, separate commit.
+  componentDidUpdate(prevProps: Props) {
+    if (!this.state.hasError) {
+      return;
+    }
+
+    const prevKeys = prevProps.resetKeys ?? [];
+    const nextKeys = this.props.resetKeys ?? [];
+    const changed =
+      prevKeys.length !== nextKeys.length ||
+      nextKeys.some((key, i) => key !== prevKeys[i]);
+
+    if (changed) {
+      this.setState({ hasError: false, error: undefined });
+    }
   }
 
   render() {

--- a/src/components/preview/client.tsx
+++ b/src/components/preview/client.tsx
@@ -25,12 +25,13 @@ const Client = ({
   const classNames = cn(isError && 'hidden', className);
 
   const mergedModules = { ...baseModules, ...modules };
+  const effectiveCode = _code || code;
 
   let module = null;
 
-  if (_code || code) {
+  if (effectiveCode) {
     try {
-      module = compile(_code || code, mergedModules);
+      module = compile(effectiveCode, mergedModules);
     } catch (e) {
       module = {
         exports: {},
@@ -73,7 +74,10 @@ const Client = ({
         <div className={cn('h-full w-full', classNames)}>
           <Frame {...(frame as FrameProps)}>
             {container => (
-              <LiveError.Boundary onError={(e: Error) => setError(e.message)}>
+              <LiveError.Boundary
+                resetKeys={[effectiveCode]}
+                onError={(e: Error) => setError(e.message)}
+              >
                 {renderProvider(
                   <LiveError.Guard onError={e => setError(e.message)}>
                     <Component {...componentProps} container={container} />
@@ -95,7 +99,10 @@ const Client = ({
             containerType: 'inline-size',
           }}
         >
-          <LiveError.Boundary onError={e => setError(e.message)}>
+          <LiveError.Boundary
+            resetKeys={[effectiveCode]}
+            onError={e => setError(e.message)}
+          >
             {renderProvider(
               <LiveError.Guard onError={e => setError(e.message)}>
                 <Component {...componentProps} />

--- a/src/components/preview/preview.tsx
+++ b/src/components/preview/preview.tsx
@@ -27,6 +27,17 @@ const Preview = ({
 }: Props) => {
   const [runtimeError, setRuntimeError] = useState<string | null>(null);
   const [dynamicCSS, setDynamicCSS] = useState('');
+  // "Adjusting state when a prop changes" pattern (React docs) rather than
+  // a useEffect: resets synchronously within the same render `code`
+  // changes in, before Guard/Component render at all, so there's no
+  // passive-effect-ordering window where a genuinely new runtime error
+  // could get wiped back out right after Guard's onError sets it.
+  const [prevCode, setPrevCode] = useState(code);
+
+  if (code !== prevCode) {
+    setPrevCode(code);
+    setRuntimeError(null);
+  }
 
   const renderProvider = (component: React.ReactNode) => {
     return provider ? provider(component) : component;
@@ -74,6 +85,7 @@ const Preview = ({
 
     return (
       <LiveError.Boundary
+        resetKeys={[code]}
         fallback={message => (
           <LiveError title="Rendering Error" message={message} />
         )}


### PR DESCRIPTION
## Summary

Fixes #87 — `ErrorBoundary`'s `hasError` state never cleared automatically. Once tripped, `render()` short-circuits straight to the fallback and never even attempts `this.props.children` again (see the `if (this.state.hasError) { return fallback; }` gate) — so a fix to the underlying code had no way to reach the screen until something unrelated remounted the boundary.

## Fix

Added an optional `resetKeys` prop to `ErrorBoundary` (same idea as `react-error-boundary`'s `resetKeys`): `componentDidUpdate` shallow-compares it against the previous render and clears `hasError` when it changes.

This is race-free by construction, unlike a naive per-render reset would be: while `hasError` is `true`, `children` never renders at all, so clearing it just schedules a follow-up commit where `children` gets its *first* real attempt with the new code. If that throws too, `getDerivedStateFromError` catches it fresh in that later, separate commit — there's no way for the reset and a brand-new error to land in the same commit and race.

Wired `resetKeys={[code]}` at all 3 real call sites: `preview.tsx`'s boundary, and both of `client.tsx`'s (frame + non-frame branches).

## Also fixed: preview.tsx's local runtimeError (same underlying problem, different state)

`Preview` has its own local `runtimeError` state, set via `LiveError.Guard`'s `onError` (window `error`/`unhandledrejection` listeners — this is a separate mechanism from `ErrorBoundary`, catching errors that happen *after* mount rather than render-time crashes). It had the identical "never resets on code change" bug.

Fixed using React's documented "adjusting state when a prop changes" pattern (comparing against a `prevCode` state snapshot during render, not a `useEffect`) — `Guard`'s error handling is async/event-driven with no ordering guarantee relative to a passive-effect reset, so resetting synchronously within the same render `code` changes in avoids that class of race entirely, consistent with how #88 was fixed.

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated; no jsdom/testing-library in this repo for component-level regression tests — verified via full render/commit-order trace instead)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes