### PR TITLE
fix: Tailwind dynamic CSS race condition + stale CSS on disable (#89)

### DIFF
--- a/.changeset/fix-89-tailwind-race-and-cleanup.md
+++ b/.changeset/fix-89-tailwind-race-and-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Dynamic Tailwind CSS is now properly cleaned up when components are unmounted, preventing potential memory leaks.

--- a/.changeset/fix-89-tailwind-race-and-cleanup.md
+++ b/.changeset/fix-89-tailwind-race-and-cleanup.md
@@ -1,5 +1,5 @@
 ---
-'@jbpark/live-editor': minor
+'@jbpark/live-editor': patch
 ---
 
-Dynamic Tailwind CSS is now properly cleaned up when components are unmounted, preventing potential memory leaks.
+Fixed a race condition where rapid code edits could let a stale Tailwind CSS generation request overwrite the current one, and fixed dynamically-generated CSS staying injected after turning dynamicTailwind off.

--- a/src/components/preview/preview.tsx
+++ b/src/components/preview/preview.tsx
@@ -48,7 +48,17 @@ const Preview = ({
       return;
     }
 
-    generateTailwindCSS(code).then(setDynamicCSS);
+    let cancelled = false;
+
+    generateTailwindCSS(code).then(css => {
+      if (!cancelled) {
+        setDynamicCSS(css);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [code, dynamicTailwind]);
 
   if (runtimeError) {
@@ -93,7 +103,7 @@ const Preview = ({
         {renderProvider(
           <LiveError.Guard onError={e => setRuntimeError(e.message)}>
             <Component {...props} />
-            {dynamicCSS && <style>{dynamicCSS}</style>}
+            {dynamicTailwind && dynamicCSS && <style>{dynamicCSS}</style>}
           </LiveError.Guard>,
         )}
       </LiveError.Boundary>


### PR DESCRIPTION
## Summary

Fixes #89 — two bugs in `preview.tsx`'s dynamic Tailwind CSS generation.

**Race condition:** `generateTailwindCSS(code).then(setDynamicCSS)` had no cancellation or sequencing. If `code` changed rapidly, promises could resolve out of order and a stale (earlier) request's CSS could overwrite the current one. Added the standard cancellation-flag guard, reset per effect run and set on cleanup, so only the request matching the current `code`/`dynamicTailwind` actually applies its result.

**Stale CSS on disable:** toggling `dynamicTailwind` off left the last-generated CSS injected via `<style>{dynamicCSS}</style>`. Rather than resetting `dynamicCSS` state from inside the effect — this repo's `react-hooks` lint rule flags synchronous `setState` calls directly in an effect body ("causes cascading renders... should be derived instead") — gated the `<style>` render on `dynamicTailwind` as well as `dynamicCSS`, so previously-generated CSS simply stops rendering the instant the prop flips off, no state reset needed.

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes (this fix was in fact shaped by this repo's own `react-hooks` lint rule catching my first draft)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated; no component-level test infra in this repo yet)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes