### PR TITLE
fix: iframe stale scripts/styles when props change (#91)

### DIFF
--- a/.changeset/fix-91-iframe-scripts-styles-stale.md
+++ b/.changeset/fix-91-iframe-scripts-styles-stale.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add support for injecting multiple scripts and stylesheets into an iframe's document, allowing for more complex and dynamic content to be rendered within the editor.

--- a/.changeset/fix-91-iframe-scripts-styles-stale.md
+++ b/.changeset/fix-91-iframe-scripts-styles-stale.md
@@ -1,5 +1,5 @@
 ---
-'@jbpark/live-editor': minor
+'@jbpark/live-editor': patch
 ---
 
-Add support for injecting multiple scripts and stylesheets into an iframe's document, allowing for more complex and dynamic content to be rendered within the editor.
+Fixed the iframe frame not loading new scripts after the scripts prop changed post-initial-load, and fixed removed styles/stylesheets staying injected in the iframe instead of being cleaned up.

--- a/src/components/frame/iframe.tsx
+++ b/src/components/frame/iframe.tsx
@@ -35,7 +35,13 @@ const IFrame = ({
 }: Props) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
-  const scriptsLoadedRef = useRef<boolean>(false);
+  // Tracks which script srcs have already been injected into this iframe's
+  // document, keyed by src rather than a single loaded/not-loaded boolean —
+  // a boolean latched to `true` forever meant a later change to `scripts`
+  // (new entries) never got loaded once the first batch had.
+  const loadedScriptsRef = useRef<Set<string>>(new Set());
+  const prevStyleCountRef = useRef(0);
+  const prevStylesheetCountRef = useRef(0);
   const shouldAutoHeight = autoHeight && style.height == null;
 
   const styleManagerRef = useRef<{
@@ -129,10 +135,14 @@ const IFrame = ({
 
       applyStyle();
 
-      if (scripts.length && !scriptsLoadedRef.current) {
-        scriptsLoadedRef.current = true;
+      const pendingScripts = scripts.filter(
+        src => !loadedScriptsRef.current.has(src),
+      );
 
-        Promise.all(scripts.map(getCachedScriptBlob)).then(blobUrls => {
+      if (pendingScripts.length) {
+        pendingScripts.forEach(src => loadedScriptsRef.current.add(src));
+
+        Promise.all(pendingScripts.map(getCachedScriptBlob)).then(blobUrls => {
           if (!doc.head) {
             return;
           }
@@ -202,6 +212,19 @@ const IFrame = ({
       }
     });
 
+    // Indices beyond the current array's length are stale from a previous,
+    // longer `styles`/`stylesheets` — the loops above only add/update up to
+    // the current length, so anything past it (from before an item was
+    // removed, or the array shrank) would otherwise stay injected forever.
+    for (
+      let index = styles.length;
+      index < prevStyleCountRef.current;
+      index++
+    ) {
+      doc.getElementById(`injected-style-${index}`)?.remove();
+    }
+    prevStyleCountRef.current = styles.length;
+
     stylesheets.forEach((href, index) => {
       const linkId = `injected-stylesheet-${index}`;
       let linkEl = doc.getElementById(linkId) as HTMLLinkElement | null;
@@ -217,6 +240,15 @@ const IFrame = ({
         linkEl.href = href;
       }
     });
+
+    for (
+      let index = stylesheets.length;
+      index < prevStylesheetCountRef.current;
+      index++
+    ) {
+      doc.getElementById(`injected-stylesheet-${index}`)?.remove();
+    }
+    prevStylesheetCountRef.current = stylesheets.length;
   }, [styles, stylesheets]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #91 — two bugs in `iframe.tsx`'s script/style injection.

**scripts prop change not reloading:** `scriptsLoadedRef` was a single boolean latched to `true` after the first successful load. If the `scripts` prop later changed (new entries added), the `!scriptsLoadedRef.current` gate blocked them from ever being injected. Replaced with a `Set<string>` tracking which srcs are already loaded — each `onLoad` now only injects whatever's actually new (diffed against the set), regardless of how many times it's called.

**Stale styles/stylesheets on shrink:** the injection effect only ever added or updated elements up to the *current* array's length (`injected-style-${index}`/`injected-stylesheet-${index}`). If an entry was removed or the array shrank, whatever was previously injected at the now-unused higher indices stayed in the iframe forever. Added a cleanup pass that tracks the previous length in a ref and removes anything beyond the current one.

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated; no component-level test infra in this repo yet for iframe/DOM-manipulation-heavy code like this)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes