### PR TITLE
fix: wrap unguarded compile() calls in try/catch (#90, #93)

### DIFF
--- a/.changeset/fix-90-93-compile-defensive-try-catch.md
+++ b/.changeset/fix-90-93-compile-defensive-try-catch.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+The live editor now handles module transformation errors more robustly, providing a fallback module with an error message when compilation fails.

--- a/.changeset/fix-90-93-compile-defensive-try-catch.md
+++ b/.changeset/fix-90-93-compile-defensive-try-catch.md
@@ -1,5 +1,5 @@
 ---
-'@jbpark/live-editor': minor
+'@jbpark/live-editor': patch
 ---
 
-The live editor now handles module transformation errors more robustly, providing a fallback module with an error message when compilation fails.
+Hardened Preview and the DnD renderer's compile() calls with try/catch, matching Client's existing defensive pattern, so a future regression in compileModule can't crash the whole tree instead of falling back to the existing error UI.

--- a/src/components/dnd/renderer.tsx
+++ b/src/components/dnd/renderer.tsx
@@ -25,10 +25,16 @@ const Renderer = ({ preview, headers, modules, frame, provider }: Props) => {
     [modules],
   );
 
-  const module = useMemo(
-    () => compile(preview, memoizedModules),
-    [preview, memoizedModules],
-  );
+  const module = useMemo(() => {
+    try {
+      return compile(preview, memoizedModules);
+    } catch (e) {
+      return {
+        exports: {},
+        error: e instanceof Error ? e.message : 'Module transformation error',
+      };
+    }
+  }, [preview, memoizedModules]);
 
   const renderProvider = (component: React.ReactNode) => {
     return provider ? provider(component) : component;

--- a/src/components/preview/preview.tsx
+++ b/src/components/preview/preview.tsx
@@ -73,7 +73,16 @@ const Preview = ({
   }
 
   if (code) {
-    const module = compile(code, { ...baseModules, ...modules });
+    let module;
+
+    try {
+      module = compile(code, { ...baseModules, ...modules });
+    } catch (e) {
+      module = {
+        exports: {},
+        error: e instanceof Error ? e.message : 'Module transformation error',
+      };
+    }
 
     if (module.error) {
       return (


### PR DESCRIPTION
## Summary

Addresses #90 and #93 — `preview.tsx` and `dnd/renderer.tsx` both called `compile()` directly during render/`useMemo` without a `try/catch`, unlike `client.tsx`'s equivalent call, which already wraps it.

## Investigation note (both issues are labeled `needs-investigation`)

I traced every path inside `compileModule` (`detectTypeScript`, `compileTypeScript`, `transformCode`, the `new Function(...)` construction, and the top-level module execution) and confirmed each is already internally guarded with its own `try/catch`, returning a safe `{ exports: {}, error }` fallback rather than propagating. So as it stands today, `compile()` doesn't actually throw for malformed/malicious code content — I couldn't reproduce an actual crash. (I also couldn't fuzz-test this empirically: `utils/index.ts` transitively imports `@jbpark/ui-kit`'s CSS, which this repo's `node`-environment vitest config can't parse, so `compile()` isn't importable in isolation for a unit test here.)

Given that, this PR is a hardening/consistency fix rather than a reproducible-bug fix: closing the gap so a future change to `compileModule` can't silently reopen a real crash path, and making both call sites consistent with `client.tsx`'s existing defensive pattern. `dnd/renderer.tsx` had no error-rendering path at all before or after this change (a compile error there already just renders nothing, same as `!Component`) — this only prevents an exception from escaping, it doesn't add new error UI.

`generateSection`/`generateSections` (the other functions #93 mentions) are unrelated to this — I traced those separately and they're already fully guarded (`parseDocument`'s `buildDocument` already try/catches and returns `undefined`, and every caller already falls back to the original `fullCode` on that), so no change was needed there.

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated; see the fuzz-testing limitation noted above)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes