### PR TITLE
fix: remove duplicate-causing event redispatch in Shadow (#92)

### DIFF
--- a/.changeset/fix-92-shadow-duplicate-event-dispatch.md
+++ b/.changeset/fix-92-shadow-duplicate-event-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fixed click/pointerdown/pointerup events being handled twice by listeners outside a shadow-mode frame. Shadow no longer manually redispatches these events on the host, since they already cross the shadow boundary on their own (composed: true).

--- a/src/components/frame/shadow.tsx
+++ b/src/components/frame/shadow.tsx
@@ -41,48 +41,14 @@ const Shadow = ({ children }: Props) => {
       renderTargetRef.current = target;
       setRenderTarget(target);
     }
-
-    const onClick = (e: Event) => {
-      const eventInit = {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-      };
-
-      let newEvent: Event;
-
-      if (e instanceof MouseEvent) {
-        newEvent = new MouseEvent(e.type, {
-          ...eventInit,
-          clientX: e.clientX,
-          clientY: e.clientY,
-          button: e.button,
-        });
-      } else if (e instanceof PointerEvent) {
-        newEvent = new PointerEvent(e.type, {
-          ...eventInit,
-          clientX: e.clientX,
-          clientY: e.clientY,
-          pointerId: e.pointerId,
-        });
-      } else {
-        newEvent = new Event(e.type, eventInit);
-      }
-
-      hostRef.current?.dispatchEvent(newEvent);
-    };
-
-    const eventTypes = ['click', 'pointerdown', 'pointerup'];
-
-    eventTypes.forEach(type => {
-      target.addEventListener(type, onClick, true);
-    });
-
-    return () => {
-      eventTypes.forEach(type => {
-        target?.removeEventListener(type, onClick, true);
-      });
-    };
+    // click/pointerdown/pointerup are `composed: true` by spec, so they
+    // already retarget across the shadow boundary and reach listeners
+    // outside it (document, this host's ancestors, React's own root
+    // listener) on their own - manually redispatching them here used to
+    // make every one of those listeners see the interaction twice. Anyone
+    // needing the real element inside the shadow tree (not the retargeted
+    // host) can still read it via event.composedPath()[0], unaffected by
+    // this removal. See #92.
   }, []);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary

Addresses #92 — `shadow.tsx` manually redispatched `click`/`pointerdown`/`pointerup` events on the shadow host after intercepting them on the shadow-internal render target.

## Why this is wrong

Per spec, `click`/`pointerdown`/`pointerup` are `composed: true` by default — they already retarget across a shadow boundary and reach listeners outside it (`document`, this host's ancestors, React's own root event listener) with zero help needed. Manually creating and dispatching a second copy of the same event on `hostRef` meant every one of those outside listeners saw the interaction **twice**: once from the natural composed propagation, once from the duplicate.

The redispatched event also didn't solve any real problem it might have been intended for: since it was dispatched on `hostRef` itself (not the actual element inside the shadow tree that was clicked), it has the *identical* target-retargeting behavior the natural composed event already has. Anyone needing the real inner element can read it via `event.composedPath()[0]` on either the natural event or a manually redispatched one — this bridge added nothing there.

## Fix

Removed the manual redispatch (the whole `onClick`/`eventTypes`/listener registration block). Native composed-event propagation now handles this on its own.

## Verification limitation

I could not verify this interactively — browser automation is unavailable in this environment (`browser action=start` times out, confirmed again while working this issue). This is a static-analysis-only fix based on the UI Events spec's `composed` behavior; please manually verify click/selection behavior in a `mode: "shadow"` frame before relying on it, ideally checking for the specific symptom the issue describes (double-firing click handlers / double-selection).

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated; no component-level/interaction test infra in this repo)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes