### PR TITLE
refactor: adopt use-hooks 3.0.0's new/redesigned hooks (#111)

### DIFF
--- a/.changeset/feat-111-use-hooks-adoption.md
+++ b/.changeset/feat-111-use-hooks-adoption.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Internal refactor: adopted @jbpark/use-hooks 3.0.0's useKeyPress, useResizeObserver, useMutationObserver, useEventListener, and useDebouncedValue in place of hand-rolled window/DOM listener wiring in the editor shortcut handling, iframe auto-height/style-sync, error listeners, and debounced code commits. No intended behavior change.

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -1,6 +1,6 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 
-import { useDebounce } from '@jbpark/use-hooks';
+import { useDebouncedValue } from '@jbpark/use-hooks';
 
 import { useError, usePreview } from '~/components/context/states';
 import { DEFAULT_TEMPLATE } from '~/constants';
@@ -46,13 +46,11 @@ const Editor = ({
     [setError],
   );
 
-  useDebounce(
-    () => {
-      setCode(value);
-    },
-    { delay: debounce },
-    [value],
-  );
+  const debouncedValue = useDebouncedValue(value, debounce);
+
+  useEffect(() => {
+    setCode(debouncedValue);
+  }, [debouncedValue, setCode]);
 
   return (
     <Core

--- a/src/components/error/guard.tsx
+++ b/src/components/error/guard.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
+import { useEventListener } from '@jbpark/use-hooks';
+
 import ErrorComponent from './error';
 
 export interface Props {
@@ -13,14 +15,9 @@ const Guard = ({ children, onError }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const errorHandled = useRef(false);
 
-  useEffect(() => {
-    const container = containerRef.current;
-
-    if (!container) {
-      return;
-    }
-
-    const handleWindowError = (event: ErrorEvent) => {
+  useEventListener(
+    'error',
+    event => {
       if (errorHandled.current) {
         return;
       }
@@ -40,9 +37,16 @@ const Guard = ({ children, onError }: Props) => {
       setTimeout(() => {
         errorHandled.current = false;
       }, 100);
+    },
+    { capture: true },
+  );
 
-      return true;
-    };
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!container) {
+      return;
+    }
 
     const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
       if (errorHandled.current) {
@@ -62,7 +66,6 @@ const Guard = ({ children, onError }: Props) => {
       }, 100);
     };
 
-    window.addEventListener('error', handleWindowError, true);
     window.addEventListener(
       'unhandledrejection',
       handleUnhandledRejection,
@@ -70,7 +73,6 @@ const Guard = ({ children, onError }: Props) => {
     );
 
     return () => {
-      window.removeEventListener('error', handleWindowError, true);
       window.removeEventListener(
         'unhandledrejection',
         handleUnhandledRejection,

--- a/src/components/error/runtime.tsx
+++ b/src/components/error/runtime.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { useEventListener } from '@jbpark/use-hooks';
+
 import { useError } from '~/components/context/states';
 
 import Error from './error';
@@ -12,18 +14,13 @@ export interface Props extends React.ComponentPropsWithRef<'div'> {
 const Runtime = ({ open = true, reset }: Props) => {
   const { error: message, setError } = useError();
 
+  useEventListener('error', e => {
+    setError(e.message);
+    e.preventDefault();
+  });
+
   useEffect(() => {
-    const onError = (e: ErrorEvent) => {
-      setError(e.message);
-      e.preventDefault();
-    };
-
-    window.addEventListener('error', onError);
-
-    return () => {
-      setError(null);
-      window.removeEventListener('error', onError);
-    };
+    return () => setError(null);
   }, [setError]);
 
   if (!open) {

--- a/src/components/frame/iframe.tsx
+++ b/src/components/frame/iframe.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useMutationObserver, useResizeObserver } from '@jbpark/use-hooks';
+
 import { getCachedScriptBlob } from '~/utils';
 
 export interface Props {
@@ -106,6 +108,28 @@ const IFrame = ({
     }
   }, [syncStyle]);
 
+  const applyStyleTimeoutRef = useRef<number>(undefined);
+
+  // Debounced so a burst of head mutations (a stylesheet swap can fire
+  // several in quick succession) only re-runs applyStyle once, matching the
+  // original raw-MutationObserver setup's 50ms debounce.
+  const debouncedApplyStyle = useCallback(() => {
+    clearTimeout(applyStyleTimeoutRef.current);
+    applyStyleTimeoutRef.current = window.setTimeout(applyStyle, 50);
+  }, [applyStyle]);
+
+  useEffect(() => {
+    return () => clearTimeout(applyStyleTimeoutRef.current);
+  }, []);
+
+  useMutationObserver(document.head, debouncedApplyStyle, {
+    enabled: syncStyle,
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['href'],
+  });
+
   useEffect(() => {
     const $iframe = iframeRef.current;
 
@@ -162,33 +186,14 @@ const IFrame = ({
 
     $iframe.addEventListener('load', onLoad);
 
-    let timeoutId: number;
-    let observer: MutationObserver | null = null;
-
-    if (syncStyle) {
-      observer = new MutationObserver(() => {
-        clearTimeout(timeoutId);
-        timeoutId = window.setTimeout(applyStyle, 50);
-      });
-
-      observer.observe(document.head, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['href'],
-      });
-    }
-
     if ($iframe.contentDocument?.readyState === 'complete') {
       onLoad();
     }
 
     return () => {
       $iframe.removeEventListener('load', onLoad);
-      observer?.disconnect();
-      clearTimeout(timeoutId);
     };
-  }, [syncStyle, scripts, onLoaded, applyStyle]);
+  }, [scripts, onLoaded, applyStyle]);
 
   useEffect(() => {
     const doc = iframeRef.current?.contentDocument;
@@ -251,109 +256,124 @@ const IFrame = ({
     prevStylesheetCountRef.current = stylesheets.length;
   }, [styles, stylesheets]);
 
-  useEffect(() => {
+  const updateHeight = useCallback(() => {
     if (!shouldAutoHeight || !mountNode || !iframeRef.current) {
       return;
     }
 
     const iframe = iframeRef.current;
 
-    const updateHeight = () => {
-      const scrollParent = iframe.closest(
-        '[data-frame-container]',
-      ) as HTMLElement | null;
-      const savedScrollTop = scrollParent?.scrollTop ?? 0;
+    const scrollParent = iframe.closest(
+      '[data-frame-container]',
+    ) as HTMLElement | null;
+    const savedScrollTop = scrollParent?.scrollTop ?? 0;
 
-      iframe.style.height = '0px';
+    iframe.style.height = '0px';
 
-      let childrenHeight = 0;
+    let childrenHeight = 0;
 
-      Array.from(mountNode.children).forEach(child => {
-        const el = child as HTMLElement;
-        childrenHeight = Math.max(childrenHeight, el.scrollHeight);
-      });
-
-      const doc = iframe.contentDocument;
-      const win = doc?.defaultView;
-
-      const popups = mountNode.querySelectorAll<HTMLElement>(
-        '[data-floating-ui-focusable]',
-      );
-
-      popups.forEach(popup => {
-        if (popup.offsetHeight > 0) {
-          let offsetY = 0;
-
-          const transform = popup.style.transform;
-          if (transform) {
-            const match = transform.match(
-              /translate\([^,]+,\s*([+-]?\d+(?:\.\d+)?)/,
-            );
-            if (match?.[1]) {
-              offsetY = parseFloat(match[1]);
-            }
-          }
-
-          const estimatedHeight = offsetY + popup.offsetHeight;
-          childrenHeight = Math.max(childrenHeight, estimatedHeight);
-        }
-      });
-
-      if (win) {
-        Array.from(mountNode.children).forEach(child => {
-          const el = child as HTMLElement;
-          const style = win.getComputedStyle(el);
-
-          if (style.position === 'fixed' || style.position === 'absolute') {
-            if (el.offsetHeight > 0) {
-              let offsetY = 0;
-
-              const transform = el.style.transform;
-              if (transform) {
-                const match = transform.match(
-                  /translate\([^,]+,\s*([+-]?\d+(?:\.\d+)?)/,
-                );
-                if (match?.[1]) {
-                  offsetY = parseFloat(match[1]);
-                }
-              }
-
-              const estimatedHeight = offsetY + el.offsetHeight;
-              childrenHeight = Math.max(childrenHeight, estimatedHeight);
-            }
-          }
-        });
-      }
-
-      const contentHeight = Math.max(mountNode.scrollHeight, childrenHeight);
-
-      if (contentHeight > 0) {
-        iframe.style.height = `${Math.ceil(contentHeight)}px`;
-      }
-
-      if (scrollParent) {
-        scrollParent.scrollTop = savedScrollTop;
-      }
-    };
-
-    updateHeight();
-
-    const resizeObserver = new ResizeObserver(updateHeight);
-    resizeObserver.observe(mountNode);
-
-    const mutationObserver = new MutationObserver(updateHeight);
-    mutationObserver.observe(mountNode, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      characterData: true,
+    Array.from(mountNode.children).forEach(child => {
+      const el = child as HTMLElement;
+      childrenHeight = Math.max(childrenHeight, el.scrollHeight);
     });
 
-    return () => {
-      resizeObserver.disconnect();
-      mutationObserver.disconnect();
-    };
-  }, [mountNode, shouldAutoHeight]);
+    const doc = iframe.contentDocument;
+    const win = doc?.defaultView;
+
+    const popups = mountNode.querySelectorAll<HTMLElement>(
+      '[data-floating-ui-focusable]',
+    );
+
+    popups.forEach(popup => {
+      if (popup.offsetHeight > 0) {
+        let offsetY = 0;
+
+        const transform = popup.style.transform;
+        if (transform) {
+          const match = transform.match(
+            /translate\([^,]+,\s*([+-]?\d+(?:\.\d+)?)/,
+          );
+          if (match?.[1]) {
+            offsetY = parseFloat(match[1]);
+          }
+        }
+
+        const estimatedHeight = offsetY + popup.offsetHeight;
+        childrenHeight = Math.max(childrenHeight, estimatedHeight);
+      }
+    });
+
+    if (win) {
+      Array.from(mountNode.children).forEach(child => {
+        const el = child as HTMLElement;
+        const style = win.getComputedStyle(el);
+
+        if (style.position === 'fixed' || style.position === 'absolute') {
+          if (el.offsetHeight > 0) {
+            let offsetY = 0;
+
+            const transform = el.style.transform;
+            if (transform) {
+              const match = transform.match(
+                /translate\([^,]+,\s*([+-]?\d+(?:\.\d+)?)/,
+              );
+              if (match?.[1]) {
+                offsetY = parseFloat(match[1]);
+              }
+            }
+
+            const estimatedHeight = offsetY + el.offsetHeight;
+            childrenHeight = Math.max(childrenHeight, estimatedHeight);
+          }
+        }
+      });
+    }
+
+    const contentHeight = Math.max(mountNode.scrollHeight, childrenHeight);
+
+    if (contentHeight > 0) {
+      iframe.style.height = `${Math.ceil(contentHeight)}px`;
+    }
+
+    if (scrollParent) {
+      scrollParent.scrollTop = savedScrollTop;
+    }
+  }, [shouldAutoHeight, mountNode]);
+
+  useEffect(() => {
+    updateHeight();
+  }, [updateHeight]);
+
+  const [resizeRef, resizeSize] = useResizeObserver<HTMLElement>();
+
+  // useResizeObserver's ref callback isn't wired through this component's
+  // own JSX (mountNode is the portal's imperatively-created container, not
+  // something rendered here), so it's attached/detached imperatively
+  // instead. Its reported size is intentionally unused - updateHeight's own
+  // walk (popups, position:fixed/absolute children) computes a more
+  // accurate height than mountNode's own content-box size would, so a
+  // change in `resizeSize` is only used as a trigger to recompute.
+  useEffect(() => {
+    if (!shouldAutoHeight || !mountNode) {
+      return;
+    }
+
+    resizeRef(mountNode);
+    return () => resizeRef(null);
+  }, [shouldAutoHeight, mountNode, resizeRef]);
+
+  useEffect(() => {
+    updateHeight();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resizeSize]);
+
+  useMutationObserver(mountNode, updateHeight, {
+    enabled: shouldAutoHeight,
+    childList: true,
+    subtree: true,
+    attributes: true,
+    characterData: true,
+  });
 
   const content = mountNode
     ? createPortal(children(mountNode), mountNode)

--- a/src/pages/editor/index.tsx
+++ b/src/pages/editor/index.tsx
@@ -10,6 +10,7 @@ import {
 import {
   useDebounce,
   useHistoryState,
+  useKeyPress,
   useLocalStorage,
   useResponsiveSize,
 } from '@jbpark/use-hooks';
@@ -69,33 +70,13 @@ const App = () => {
     setValue(historyValue);
   }, [historyValue]);
 
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      const isMod = e.metaKey || e.ctrlKey;
-
-      if (!isMod || e.key.toLowerCase() !== 'z') {
-        return;
-      }
-
-      const target = e.target as HTMLElement | null;
-
-      if (target?.closest('.cm-editor')) {
-        // Let CodeMirror's own text-level undo/redo handle this instead.
-        return;
-      }
-
-      e.preventDefault();
-
-      if (e.shiftKey) {
-        redo();
-      } else {
-        undo();
-      }
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [undo, redo]);
+  // Let CodeMirror's own text-level undo/redo handle keystrokes inside the
+  // raw editor instead of triggering the history-level undo/redo here.
+  useKeyPress('mod+z', undo, { ignore: '.cm-editor', preventDefault: true });
+  useKeyPress('mod+shift+z', redo, {
+    ignore: '.cm-editor',
+    preventDefault: true,
+  });
 
   return (
     <>


### PR DESCRIPTION
## Summary

Addresses all 4 action items in the #111 tracking issue, now that `@jbpark/use-hooks` is on 3.0.0.

### 1. `useKeyPress` (`pages/editor/index.tsx`)
Replaced the hand-rolled `window.addEventListener('keydown', ...)` + `e.target.closest('.cm-editor')` undo/redo shortcut handling with `useKeyPress('mod+z', undo, { ignore: '.cm-editor', preventDefault: true })` / `useKeyPress('mod+shift+z', redo, ...)`, exactly as the issue specifies.

### 2. `useResizeObserver` + `useMutationObserver` (`frame/iframe.tsx`)
- The `document.head` `<link href>`-change detection (drives the debounced `applyStyle`) now uses `useMutationObserver(document.head, ...)` instead of a manually constructed `MutationObserver`. Kept the 50ms debounce as a small wrapper around the callback, since the hook doesn't debounce internally.
- Auto-height's `ResizeObserver`+`MutationObserver` combo on `mountNode` now uses `useResizeObserver` + `useMutationObserver`. Note: `useResizeObserver` is a ref-callback API (`[refCallback, size]`), not an imperative `.observe(existingNode)` — since `mountNode` is the portal's imperatively-created container (not wired through this component's own JSX), the ref callback is attached/detached via a small effect instead. Its reported `size` is intentionally treated as a trigger only, not consumed as a value — the existing `updateHeight()` walk (handling `position: fixed`/`absolute` popups that escape normal flow, like floating-ui portals) computes a more accurate height than the hook's plain content-box size would.

### 3. `useEventListener` (`error/runtime.tsx`, `error/guard.tsx`)
- `runtime.tsx`'s `window.addEventListener('error', ...)` now uses `useEventListener('error', ...)` (defaults to `window` when no `target` is given).
- `guard.tsx`'s `window.addEventListener('error', ..., true)` now uses `useEventListener('error', handler, { capture: true })`. Left `'unhandledrejection'` as a manual `addEventListener`, matching the issue's stated scope (only the `'error'` listener is called out for guard.tsx) — both still coordinate correctly through the same `errorHandled` ref regardless of which mechanism registers the listener.

### 4. `useDebouncedValue` (`editor/editor.tsx`)
Replaced `useDebounce(() => setCode(value), { delay: debounce }, [value])` with `useDebouncedValue(value, debounce)` + a `useEffect` calling `setCode(debouncedValue)`. Verified equivalence: `useDebouncedValue`'s initial value is immediate (`useState(value)`), matching `useDebounce`'s default `leading: true` behavior for the very first call; subsequent `value` changes debounce identically (trailing-edge, timeout reset on each change).

Left `pages/editor/index.tsx`'s `useDebounce(() => commitHistory(value), { delay: 500 }, [value])` as-is, per the issue's own note that it's optional there since `commitHistory` is a side-effecting call, not a plain value substitution.

## Verification limitation

Could not test interactively — browser automation is unavailable in this environment (`browser action=start` times out, confirmed again). All changes verified via `check-types`/`lint`/`test`/`build` and careful reading of `use-hooks`' actual compiled implementation (not just its type signatures) to confirm behavioral equivalence with what was replaced. I'd especially want independent verification of:
- The auto-height iframe behavior (the `useResizeObserver` ref-callback attach/detach is the riskiest part of this change)
- The undo/redo keyboard shortcuts still work the same, including the CodeMirror carve-out

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated; no component-level/interaction test infra in this repo)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes