### PR TITLE
feat: throw on missing Provider + memoize context values (#94)

### DIFF
--- a/.changeset/feat-94-context-improvements.md
+++ b/.changeset/feat-94-context-improvements.md
@@ -2,4 +2,4 @@
 '@jbpark/live-editor': minor
 ---
 
-Added memoization to ContextProvider to prevent unnecessary re-renders of usePreview and useError consumers.
+usePreview/useError now throw a clear error when used without a `<Live>` ancestor instead of silently no-op'ing (this is a behavior change for any code that was relying on the silent no-op — please verify all usages are correctly wrapped). Also memoized ContextProvider's Provider values so consumers only re-render when code/error actually change.

--- a/.changeset/feat-94-context-improvements.md
+++ b/.changeset/feat-94-context-improvements.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Added memoization to ContextProvider to prevent unnecessary re-renders of usePreview and useError consumers.

--- a/src/components/context/context.tsx
+++ b/src/components/context/context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DEFAULT_TEMPLATE } from '~/constants';
 import { clearCompilationCache } from '~/utils';
@@ -31,9 +31,23 @@ const ContextProvider = ({ children }: { children?: React.ReactNode }) => {
     };
   }, []);
 
+  // Without this, a new object identity on every ContextProvider render
+  // (even ones that don't touch code/error at all, e.g. a parent
+  // re-rendering) meant every usePreview()/useError() consumer re-rendered
+  // too, regardless of whether the values they care about actually changed.
+  const previewValue = useMemo<PreviewContextType>(
+    () => ({ code, setCode }),
+    [code, setCode],
+  );
+
+  const errorValue = useMemo<ErrorContextType>(
+    () => ({ error, setError }),
+    [error, setError],
+  );
+
   return (
-    <PreviewContext.Provider value={{ code, setCode }}>
-      <ErrorContext.Provider value={{ error, setError }}>
+    <PreviewContext.Provider value={previewValue}>
+      <ErrorContext.Provider value={errorValue}>
         {children}
       </ErrorContext.Provider>
     </PreviewContext.Provider>

--- a/src/components/context/states.ts
+++ b/src/components/context/states.ts
@@ -13,20 +13,35 @@ export interface ErrorContextType {
   setError: Dispatch<SetStateAction<string | null>>;
 }
 
-export const PreviewContext = createContext<PreviewContextType>({
-  code: '',
-  setCode: () => {},
-});
+// `undefined` (rather than a no-op default) so usePreview/useError can tell
+// "no <Live>/ContextProvider ancestor" apart from "a real value" and throw
+// instead of silently no-op'ing — forgetting to wrap with <Live> previously
+// failed silently (setCode/setError did nothing, code/error just stayed at
+// their hardcoded defaults) instead of surfacing as a clear error.
+export const PreviewContext = createContext<PreviewContextType | undefined>(
+  undefined,
+);
 
-export const ErrorContext = createContext<ErrorContextType>({
-  error: null,
-  setError: () => {},
-});
+export const ErrorContext = createContext<ErrorContextType | undefined>(
+  undefined,
+);
 
 export const usePreview = () => {
-  return useContext(PreviewContext);
+  const context = useContext(PreviewContext);
+
+  if (context === undefined) {
+    throw new Error('usePreview must be used within <Live> (ContextProvider)');
+  }
+
+  return context;
 };
 
 export const useError = () => {
-  return useContext(ErrorContext);
+  const context = useContext(ErrorContext);
+
+  if (context === undefined) {
+    throw new Error('useError must be used within <Live> (ContextProvider)');
+  }
+
+  return context;
 };


### PR DESCRIPTION
## Summary

Addresses both improvements in #94.

### 1. Throw when used outside a Provider

`PreviewContext`/`ErrorContext` defaulted to a no-op object (`{ code: '', setCode: () => {} }`, etc), so `usePreview()`/`useError()` used without a `<Live>` (`ContextProvider`) ancestor silently did nothing instead of surfacing the mistake — a bug that's easy to hide and hard to debug.

Changed the default to `undefined`, and both hooks now throw a clear error when they read that default.

**Public API behavior change, per the issue's own note.** Verified every real usage in this repo is already correctly wrapped:
- `dnd.tsx`, `editor.tsx`, `client.tsx`, `runtime.tsx` all call `usePreview()`/`useError()`
- All of them are only ever rendered as children of `<Live>` (`src/pages/editor/index.tsx`, `src/pages/preview/index.tsx`) — confirmed via `App`/`Context` wiring in `src/index.tsx`
- `src/App.tsx` (the `/` landing page) and the playground page don't use these hooks at all

So this doesn't break anything in this repo's own app, but it is a real breaking-in-spirit change for any external consumer who was (incorrectly) using `Live.Editor`/`Live.Dnd`/etc without wrapping in `<Live>` and relying on the silent no-op.

### 2. Memoize the Provider `value` objects

The `value` passed to both `PreviewContext.Provider`/`ErrorContext.Provider` was a fresh object literal every render, so every consumer re-rendered whenever `ContextProvider` re-rendered for any reason — not just when `code`/`error` actually changed. Wrapped both in `useMemo`, keyed on their actual dependencies.

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated; no component-level test infra in this repo)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes