### PR TITLE
feat: allow fully custom Dnd palette/panel rendering via render props

### DIFF
--- a/.changeset/feat-dnd-custom-palette-panel-render.md
+++ b/.changeset/feat-dnd-custom-palette-panel-render.md
@@ -2,4 +2,4 @@
 '@jbpark/live-editor': minor
 ---
 
-Customize the drag-and-drop panel and right panel with custom markup, while maintaining drag-and-drop functionality.
+Added renderPalette/renderPanel props to Dnd, letting consumers fully replace the built-in left component-palette and right property-panel with custom markup while drag-and-drop and field editing keep working. Also exported DraggableItem (Dnd.DraggableItem), a children-render-prop component that owns the drag wiring for custom palette items.

--- a/.changeset/feat-dnd-custom-palette-panel-render.md
+++ b/.changeset/feat-dnd-custom-palette-panel-render.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Customize the drag-and-drop panel and right panel with custom markup, while maintaining drag-and-drop functionality.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -37,12 +37,24 @@ import {
 } from '../../utils';
 import { usePreview } from '../context/states';
 import { type FrameProps } from '../frame';
-import Draggable from './draggable';
+import DraggableItem, { DefaultDraggableItem } from './draggable';
 import Droppable from './droppable';
 import Overlay from './overlay';
 import Panel from './panel';
 import Renderer from './renderer';
 import Sortable from './sortable';
+
+export interface PaletteRenderData {
+  items: Section[];
+  onAdd: (item: Section) => void;
+  DraggableItem: typeof DraggableItem;
+}
+
+export interface PanelRenderData {
+  item?: Section;
+  onChange: (next: Partial<Section>) => void;
+  onDelete: (id: string) => void;
+}
 
 export interface Props extends Omit<
   React.ComponentPropsWithRef<'div'>,
@@ -55,6 +67,13 @@ export interface Props extends Omit<
   frame?: FrameProps;
   provider?: (children: React.ReactNode) => React.ReactNode;
   onChange?: (value: string) => void;
+  // Full replacements for the built-in left palette / right panel — receive
+  // the same data/callbacks Dnd itself uses, so drag-and-drop and field
+  // editing keep working exactly as before, just with custom markup. Used
+  // for both the desktop layout and the mobile drawer, since those already
+  // render identical content today.
+  renderPalette?: (data: PaletteRenderData) => React.ReactNode;
+  renderPanel?: (data: PanelRenderData) => React.ReactNode;
 }
 
 const conditionalModifiers: Modifier = args => {
@@ -76,6 +95,8 @@ const Dnd = ({
   items = [],
   frame,
   provider,
+  renderPalette,
+  renderPanel,
   ...restProps
 }: Props) => {
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -255,15 +276,33 @@ const Dnd = ({
     }
   }, [frame?.scripts]);
 
-  const renderPaletteItems = (
-    onAdd: (item: (typeof DRAGGABLE_ITEMS)[0]) => void,
-  ) => (
-    <Space orientation="vertical" align="start">
-      {(items?.length ? items : DRAGGABLE_ITEMS).map(item => (
-        <Draggable key={item.id} item={item} onAdd={onAdd} />
-      ))}
-    </Space>
-  );
+  const renderPaletteItems = (onAdd: (item: Section) => void) => {
+    const paletteItems = items?.length ? items : DRAGGABLE_ITEMS;
+
+    if (renderPalette) {
+      return renderPalette({ items: paletteItems, onAdd, DraggableItem });
+    }
+
+    return (
+      <Space orientation="vertical" align="start">
+        {paletteItems.map(item => (
+          <DefaultDraggableItem key={item.id} item={item} onAdd={onAdd} />
+        ))}
+      </Space>
+    );
+  };
+
+  const renderPanelContent = () => {
+    const selectedItem = sections.find(s => s.id === selectedId);
+
+    if (renderPanel) {
+      return renderPanel({ item: selectedItem, onChange, onDelete });
+    }
+
+    return (
+      <Panel item={selectedItem} onChange={onChange} onDelete={onDelete} />
+    );
+  };
 
   return (
     <>
@@ -356,13 +395,7 @@ const Dnd = ({
               )}
             </Droppable>
           </div>
-          <div className="hidden w-1/5 md:block">
-            <Panel
-              item={sections.find(s => s.id === selectedId)}
-              onChange={onChange}
-              onDelete={onDelete}
-            />
-          </div>
+          <div className="hidden w-1/5 md:block">{renderPanelContent()}</div>
           <Button
             type="primary"
             shape="circle"
@@ -390,11 +423,7 @@ const Dnd = ({
             size="large"
             title="Properties"
           >
-            <Panel
-              item={sections.find(s => s.id === selectedId)}
-              onChange={onChange}
-              onDelete={onDelete}
-            />
+            {renderPanelContent()}
           </Drawer>
         </div>
         <DragOverlay>

--- a/src/components/dnd/draggable.tsx
+++ b/src/components/dnd/draggable.tsx
@@ -1,47 +1,68 @@
 import { useDraggable } from '@dnd-kit/core';
 import { Card } from '@jbpark/ui-kit';
 
-import type { DRAGGABLE_ITEMS } from '~/constants';
+import type { Section } from '~/types';
 import { cn } from '~/utils';
 
-type Item = (typeof DRAGGABLE_ITEMS)[0];
+export interface DraggableItemDragState {
+  ref: (node: HTMLElement | null) => void;
+  dragProps: React.HTMLAttributes<HTMLElement>;
+  isDragging: boolean;
+}
 
-const Draggable = ({
-  item,
-  onAdd,
-}: {
-  item: Item;
-  onAdd?: (item: Item) => void;
-}) => {
-  const { attributes, listeners, setNodeRef, transform, isDragging } =
-    useDraggable({
-      id: item.id,
-      data: { type: 'new-item', item },
-    });
+export interface DraggableItemProps {
+  item: Section;
+  children: (drag: DraggableItemDragState) => React.ReactNode;
+}
 
-  const style = transform
-    ? {
-        opacity: isDragging ? 0.5 : 1,
-      }
-    : undefined;
+// Owns the dnd-kit wiring (useDraggable + the `type: 'new-item'` data shape
+// Dnd's onDragEnd expects) so a custom renderPalette only has to decide how
+// an item *looks*, not how dragging itself works. Exported as
+// Dnd.DraggableItem for that purpose; also used internally for the default
+// palette rendering, so both paths share the exact same drag wiring.
+const DraggableItem = ({ item, children }: DraggableItemProps) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: item.id,
+    data: { type: 'new-item', item },
+  });
 
-  return (
-    <Card
-      ref={setNodeRef}
-      style={style}
-      {...listeners}
-      {...attributes}
-      className={cn(
-        'cursor-grab',
-        'outline-none',
-        'hover:border-blue-300 hover:shadow-md',
-        isDragging && 'opacity-50',
-      )}
-      onDoubleClick={() => onAdd?.(item)}
-    >
-      {item.name}
-    </Card>
-  );
+  return children({
+    ref: setNodeRef,
+    dragProps: { ...listeners, ...attributes },
+    isDragging,
+  });
 };
 
-export default Draggable;
+// The built-in card look, shared by the default (non-custom) palette
+// rendering and the drag overlay's floating preview — both rendered a plain
+// `<Draggable>` before this became a children-render-prop component.
+export interface DefaultDraggableItemProps {
+  item: Section;
+  onAdd?: (item: Section) => void;
+}
+
+export const DefaultDraggableItem = ({
+  item,
+  onAdd,
+}: DefaultDraggableItemProps) => (
+  <DraggableItem item={item}>
+    {({ ref, dragProps, isDragging }) => (
+      <Card
+        ref={ref}
+        style={{ opacity: isDragging ? 0.5 : 1 }}
+        {...dragProps}
+        className={cn(
+          'cursor-grab',
+          'outline-none',
+          'hover:border-blue-300 hover:shadow-md',
+          isDragging && 'opacity-50',
+        )}
+        onDoubleClick={onAdd ? () => onAdd(item) : undefined}
+      >
+        {item.name}
+      </Card>
+    )}
+  </DraggableItem>
+);
+
+export default DraggableItem;

--- a/src/components/dnd/index.ts
+++ b/src/components/dnd/index.ts
@@ -1,1 +1,27 @@
-export { default, type Props } from './dnd';
+import DndImpl, {
+  type PaletteRenderData,
+  type PanelRenderData,
+  type Props,
+} from './dnd';
+import DraggableItem, {
+  type DraggableItemDragState,
+  type DraggableItemProps,
+} from './draggable';
+
+type DndComponent = typeof DndImpl & {
+  DraggableItem: typeof DraggableItem;
+};
+
+const Dnd = DndImpl as DndComponent;
+
+Dnd.DraggableItem = DraggableItem;
+
+export { DraggableItem };
+export type {
+  Props,
+  PaletteRenderData,
+  PanelRenderData,
+  DraggableItemProps,
+  DraggableItemDragState,
+};
+export default Dnd;

--- a/src/components/dnd/overlay.tsx
+++ b/src/components/dnd/overlay.tsx
@@ -4,7 +4,7 @@ import type { FrameProps } from '~/components/frame';
 import type { Section } from '~/types';
 import { generateSection } from '~/utils';
 
-import Draggable from './draggable';
+import { DefaultDraggableItem } from './draggable';
 import Renderer from './renderer';
 import Sortable from './sortable';
 
@@ -27,7 +27,7 @@ const Overlay = ({ sections, renderProps }: Props) => {
   if (active.data.current?.type === 'new-item') {
     const item = active.data.current.item;
 
-    return <Draggable item={item} />;
+    return <DefaultDraggableItem item={item} />;
   }
 
   const section = sections.find(s => s.id === active.id);


### PR DESCRIPTION
## Summary

New feature (design discussed and agreed on beforehand): lets consumers fully replace `Dnd`'s built-in left component-palette and right property-panel with their own layout/markup, via two new optional props.

### `renderPalette?: (data: PaletteRenderData) => React.ReactNode`
```ts
interface PaletteRenderData {
  items: Section[];
  onAdd: (item: Section) => void;
  DraggableItem: typeof DraggableItem; // also exported as Dnd.DraggableItem
}
```
`DraggableItem` is a new exported children-render-prop component that owns the `@dnd-kit/core` `useDraggable` wiring — including the `{ type: 'new-item', item }` data shape `Dnd`'s `onDragEnd` already expects. A consumer only decides how an item *looks*; dragging itself keeps working out of the box:
```tsx
<DraggableItem item={item}>
  {({ ref, dragProps, isDragging }) => (
    <MyCustomCard ref={ref} {...dragProps} style={{ opacity: isDragging ? 0.5 : 1 }} />
  )}
</DraggableItem>
```

### `renderPanel?: (data: PanelRenderData) => React.ReactNode`
```ts
interface PanelRenderData {
  item?: Section;
  onChange: (next: Partial<Section>) => void;
  onDelete: (id: string) => void;
}
```
No drag wiring needed here — just the selected section and the same callbacks `Dnd` already uses internally.

Both props are invoked from a single call site each (`renderPaletteItems` / `renderPanelContent`), and the desktop layout + mobile drawer already rendered identical content before this change, so a custom renderer automatically applies to both with no extra wiring needed.

## Scope decisions (discussed before implementing)

- **Full-replacement only for now**, not partial slots (e.g. a custom panel header while keeping the built-in field editor). Can split into finer-grained props later if that turns out to be needed — deliberately not over-building this up front.
- **No responsive/breakpoint data passed through either render prop.** `@jbpark/use-hooks`' `useResponsiveSize` is already public, so a consumer can call it themselves inside their custom renderer if their layout needs to react to breakpoints, rather than coupling this API to one specific responsive strategy.

## Implementation note

Refactored the internal `Draggable` component into `DraggableItem` (the new public children-render-prop primitive) + `DefaultDraggableItem` (the existing Card-based visual, now just one particular children function using it). This keeps the built-in palette rendering and the drag overlay's floating preview (`overlay.tsx`) sharing the exact same default markup instead of duplicating it — both used the same `Draggable` component before this change too.

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated; no component-level test infra in this repo)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes; confirmed `dist/index.d.mts` correctly exposes `DraggableItem`, `PaletteRenderData`, `PanelRenderData`
- [ ] Not verified interactively — browser automation is unavailable in this environment. Please verify drag-and-drop still works for the default (non-custom) palette, and sanity-check a custom `renderPalette`/`renderPanel` implementation before relying on this.