### PR TITLE
feat: show a diff of pending changes before save (#36)

### DIFF
--- a/.changeset/feat-36-diff-before-save.md
+++ b/.changeset/feat-36-diff-before-save.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Review changes before saving with a diff modal, showing what changed since the last save.

--- a/.changeset/feat-36-diff-before-save.md
+++ b/.changeset/feat-36-diff-before-save.md
@@ -1,5 +1,4 @@
 ---
-'@jbpark/live-editor': minor
 ---
 
-Review changes before saving with a diff modal, showing what changed since the last save.
+Demo-app-only change (pages/editor/\*) — not part of the published package (package.json's `files` is `["dist"]`), so no version bump is needed here. @codemirror/merge is a new dependency but is only imported from demo-app-only code, same as react-router-dom/antd/@ant-design/icons already in this package.json.

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@ant-design/icons": "^6.1.0",
     "@babel/standalone": "^7.28.4",
     "@codemirror/lang-javascript": "^6.2.4",
+    "@codemirror/merge": "^6.12.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@codemirror/lang-javascript':
         specifier: ^6.2.4
         version: 6.2.4
+      '@codemirror/merge':
+        specifier: ^6.12.2
+        version: 6.12.2
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -384,6 +387,9 @@ packages:
 
   '@codemirror/lint@6.9.2':
     resolution: {integrity: sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==}
+
+  '@codemirror/merge@6.12.2':
+    resolution: {integrity: sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==}
 
   '@codemirror/search@6.6.0':
     resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
@@ -4625,6 +4631,14 @@ snapshots:
       '@codemirror/state': 6.7.1
       '@codemirror/view': 6.39.11
       crelt: 1.0.7
+
+  '@codemirror/merge@6.12.2':
+    dependencies:
+      '@codemirror/language': 6.12.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.39.11
+      '@lezer/highlight': 1.2.3
+      style-mod: 4.1.3
 
   '@codemirror/search@6.6.0':
     dependencies:

--- a/src/pages/editor/diff-modal.tsx
+++ b/src/pages/editor/diff-modal.tsx
@@ -1,0 +1,49 @@
+import { javascript } from '@codemirror/lang-javascript';
+import { unifiedMergeView } from '@codemirror/merge';
+import { Modal } from '@jbpark/ui-kit';
+import { vscodeLight } from '@uiw/codemirror-theme-vscode';
+import CodeMirror from '@uiw/react-codemirror';
+import { EditorView } from 'codemirror';
+
+interface Props {
+  open: boolean;
+  original: string;
+  current: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+// Read-only review step before persisting to localStorage — shows what
+// changed since the last save (unifiedMergeView diffs the editor's own
+// content against `original`), so the user can confirm the AST-transform
+// pipeline did what they expected before it's saved. Not an editing tool:
+// mergeControls/editable are both off, this is display-only.
+const DiffModal = ({ open, original, current, onConfirm, onCancel }: Props) => {
+  return (
+    <Modal
+      open={open}
+      title="Review changes before saving"
+      okText="Save"
+      cancelText="Cancel"
+      onOk={onConfirm}
+      onCancel={onCancel}
+      style={{ width: 800, maxWidth: '90vw' }}
+    >
+      <div className="max-h-[60vh] overflow-auto rounded border border-gray-200">
+        <CodeMirror
+          value={current}
+          theme={vscodeLight}
+          editable={false}
+          readOnly
+          extensions={[
+            javascript({ jsx: true, typescript: true }),
+            EditorView.lineWrapping,
+            unifiedMergeView({ original, mergeControls: false }),
+          ]}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default DiffModal;

--- a/src/pages/editor/index.tsx
+++ b/src/pages/editor/index.tsx
@@ -18,6 +18,7 @@ import { Button, Flex, Radio, Space, Splitter, message } from 'antd';
 
 import Live from '../../';
 import { DEFAULT_TEMPLATE, STORAGE_KEY } from '../../constants';
+import DiffModal from './diff-modal';
 
 const options = [
   { label: 'Drag & Drop', value: 'dnd' },
@@ -40,6 +41,8 @@ const App = () => {
     canRedo,
   } = useHistoryState(value);
   const [type, setType] = useState<'dnd' | 'editor'>('editor');
+  const [diffModalOpen, setDiffModalOpen] = useState(false);
+  const hasUnsavedChanges = value !== savedValue;
 
   const { breakpoint } = useResponsiveSize();
   const isMobile = breakpoint.current === 'xs' || breakpoint.current === 'sm';
@@ -104,10 +107,8 @@ const App = () => {
             <Button
               icon={<SaveOutlined />}
               type="primary"
-              onClick={() => {
-                setSavedValue(value);
-                message.success('Code saved successfully');
-              }}
+              disabled={!hasUnsavedChanges}
+              onClick={() => setDiffModalOpen(true)}
             />
             <Button
               icon={<EyeOutlined />}
@@ -149,6 +150,17 @@ const App = () => {
           </Live>
         </Flex>
       </Flex>
+      <DiffModal
+        open={diffModalOpen}
+        original={savedValue}
+        current={value}
+        onConfirm={() => {
+          setSavedValue(value);
+          setDiffModalOpen(false);
+          message.success('Code saved successfully');
+        }}
+        onCancel={() => setDiffModalOpen(false)}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Summary

Fixes #36 — Save (in `pages/editor/index.tsx`, the demo app's localStorage-backed persistence) previously applied immediately with no visibility into what changed since the last save. Given the AST-transform pipeline has had several correctness bugs found/fixed (#28 and others this session), showing a review step before persisting builds trust that the tool did what was expected.

## Approach

Went with `@codemirror/merge`'s `unifiedMergeView` extension on the same `@uiw/react-codemirror` setup already used elsewhere in this repo, rather than a separate text-diff library — it's the officially maintained sibling package to the CodeMirror version already in use, so styling/theming stays consistent for free.

- New `DiffModal` (`pages/editor/diff-modal.tsx`): a read-only `CodeMirror` instance (`editable={false}` + `readOnly`) showing `value` (current working code) diffed against `savedValue` (last-saved code) via `unifiedMergeView({ original: savedValue, mergeControls: false })`. `mergeControls` is off since this is a review step, not a partial-accept/reject editing tool.
- Save button now opens the diff modal instead of saving directly, and is `disabled` when there's nothing to save (`value === savedValue`).
- Confirming inside the modal is what actually calls `setSavedValue(value)`.

## Scope note

Demo-app-only change (`pages/editor/*`) — doesn't touch the published package's `dist` output at all, so no changeset needed (same reasoning as the docs-pages PR).

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes (library)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build:demo` — passes (demo app)
- [ ] Not verified interactively — browser automation is unavailable in this environment. Please make an edit in the editor, click Save, and confirm the diff view renders correctly and both Save/Cancel behave as expected.