### PR TITLE
feat: allow fully custom Editor rendering via renderEditor render prop

### DIFF
--- a/.changeset/feat-editor-render-prop.md
+++ b/.changeset/feat-editor-render-prop.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Custom render editors are now supported, allowing users to fully replace the built-in CodeMirror editing surface with their own implementation while still syncing to the shared preview code automatically.

--- a/.changeset/feat-editor-render-prop.md
+++ b/.changeset/feat-editor-render-prop.md
@@ -2,4 +2,4 @@
 '@jbpark/live-editor': minor
 ---
 
-Custom render editors are now supported, allowing users to fully replace the built-in CodeMirror editing surface with their own implementation while still syncing to the shared preview code automatically.
+Added a renderEditor render prop to Editor, letting consumers fully replace the built-in CodeMirror editing surface with their own implementation while still syncing to the shared preview code automatically. Exposes formatCode (the same prettier-based formatting Core's Cmd+S uses) so a custom editor can offer equivalent format-on-save behavior.

--- a/src/components/editor/core.tsx
+++ b/src/components/editor/core.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { javascript } from '@codemirror/lang-javascript';
 import { vscodeLight } from '@uiw/codemirror-theme-vscode';
@@ -7,21 +7,10 @@ import CodeMirror, {
   type ReactCodeMirrorRef,
 } from '@uiw/react-codemirror';
 import { EditorView } from 'codemirror';
-import * as prettier from 'prettier';
-import prettierPluginBabel from 'prettier/plugins/babel';
-import prettierPluginEstree from 'prettier/plugins/estree';
-import prettierPluginTypeScript from 'prettier/plugins/typescript';
 
-import { cn, detectTypeScript } from '~/utils';
+import { cn } from '~/utils';
 
-const prettierInitialOptions: Record<string, unknown> = {
-  tabWidth: 2,
-  singleQuote: true,
-  trailingComma: 'all',
-  htmlWhitespaceSensitivity: 'ignore',
-  arrowParens: 'avoid',
-  printWidth: 60,
-};
+import { useFormatCode } from './use-format-code';
 
 export interface Props {
   value: string;
@@ -51,40 +40,7 @@ const Core = ({
 }: Props) => {
   const editorRef = useRef<ReactCodeMirrorRef>(null);
 
-  const prettierConfig = useMemo(
-    () => ({
-      ...prettierInitialOptions,
-      ...prettierOptions,
-    }),
-    [prettierOptions],
-  );
-
-  const formatCode = useCallback(
-    async (code: string) => {
-      const isTypeScript = detectTypeScript(code);
-      const source = fragment ? `<>${code}</>` : code;
-      const formatted = await prettier.format(source, {
-        parser: isTypeScript ? 'typescript' : 'babel',
-        plugins: [
-          prettierPluginBabel,
-          prettierPluginEstree,
-          prettierPluginTypeScript,
-        ],
-        ...prettierConfig,
-      });
-
-      if (fragment) {
-        return formatted
-          .replace(/^<>\n?/, '')
-          .replace(/\n?<\/>;?\s*$/, '')
-          .replace(/^ {2}/gm, '')
-          .trim();
-      }
-
-      return formatted;
-    },
-    [prettierConfig, fragment],
-  );
+  const formatCode = useFormatCode({ fragment, prettierOptions });
 
   const onSave = useCallback(
     async (val: string) => {

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -6,10 +6,24 @@ import { useError, usePreview } from '~/components/context/states';
 import { DEFAULT_TEMPLATE } from '~/constants';
 
 import Core, { type Props as CoreProps } from './core';
+import { useFormatCode } from './use-format-code';
+
+export interface EditorRenderData {
+  value: string;
+  onChange: (value: string) => void;
+  // Same prettier-based formatting Core's own Cmd+S uses - reused rather
+  // than reimplemented, so a custom editor can offer equivalent
+  // format-on-save behavior without duplicating the prettier wiring.
+  formatCode: (code: string) => Promise<string>;
+}
 
 export interface Props extends Omit<CoreProps, 'onSave' | 'onError'> {
   defaultValue?: string;
   debounce?: number;
+  // Full replacement for the built-in CodeMirror editor. Editor still owns
+  // syncing `value` to the shared preview code (debounced), regardless of
+  // which UI renders it - only the editing surface itself is customizable.
+  renderEditor?: (data: EditorRenderData) => React.ReactNode;
 }
 
 const Editor = ({
@@ -17,6 +31,9 @@ const Editor = ({
   value: _value,
   debounce = 1000,
   onChange: _onChange,
+  renderEditor,
+  fragment,
+  prettierOptions,
   ...props
 }: Props) => {
   const { setCode } = usePreview();
@@ -46,11 +63,17 @@ const Editor = ({
     [setError],
   );
 
+  const formatCode = useFormatCode({ fragment, prettierOptions });
+
   const debouncedValue = useDebouncedValue(value, debounce);
 
   useEffect(() => {
     setCode(debouncedValue);
   }, [debouncedValue, setCode]);
+
+  if (renderEditor) {
+    return renderEditor({ value, onChange, formatCode });
+  }
 
   return (
     <Core
@@ -58,6 +81,8 @@ const Editor = ({
       onChange={onChange}
       onSave={onSave}
       onError={onError}
+      fragment={fragment}
+      prettierOptions={prettierOptions}
       {...props}
     />
   );

--- a/src/components/editor/index.ts
+++ b/src/components/editor/index.ts
@@ -1,5 +1,5 @@
 import Core, { type Props as CoreProps } from './core';
-import EditorImpl, { type Props } from './editor';
+import EditorImpl, { type EditorRenderData, type Props } from './editor';
 
 type EditorComponent = typeof EditorImpl & { Core: typeof Core };
 
@@ -8,5 +8,5 @@ const Editor = EditorImpl as EditorComponent;
 Editor.Core = Core;
 
 export { Core };
-export type { Props, CoreProps };
+export type { Props, CoreProps, EditorRenderData };
 export default Editor;

--- a/src/components/editor/use-format-code.ts
+++ b/src/components/editor/use-format-code.ts
@@ -1,0 +1,65 @@
+import { useCallback, useMemo } from 'react';
+
+import * as prettier from 'prettier';
+import prettierPluginBabel from 'prettier/plugins/babel';
+import prettierPluginEstree from 'prettier/plugins/estree';
+import prettierPluginTypeScript from 'prettier/plugins/typescript';
+
+import { detectTypeScript } from '~/utils';
+
+const DEFAULT_PRETTIER_OPTIONS: Record<string, unknown> = {
+  tabWidth: 2,
+  singleQuote: true,
+  trailingComma: 'all',
+  htmlWhitespaceSensitivity: 'ignore',
+  arrowParens: 'avoid',
+  printWidth: 60,
+};
+
+export interface UseFormatCodeOptions {
+  fragment?: boolean;
+  prettierOptions?: Record<string, unknown>;
+}
+
+// Extracted out of Core so a custom renderEditor (see editor.tsx's
+// renderEditor prop) can reuse the exact same formatting behavior instead
+// of reimplementing prettier wiring from scratch.
+export const useFormatCode = ({
+  fragment,
+  prettierOptions,
+}: UseFormatCodeOptions = {}) => {
+  const prettierConfig = useMemo(
+    () => ({
+      ...DEFAULT_PRETTIER_OPTIONS,
+      ...prettierOptions,
+    }),
+    [prettierOptions],
+  );
+
+  return useCallback(
+    async (code: string) => {
+      const isTypeScript = detectTypeScript(code);
+      const source = fragment ? `<>${code}</>` : code;
+      const formatted = await prettier.format(source, {
+        parser: isTypeScript ? 'typescript' : 'babel',
+        plugins: [
+          prettierPluginBabel,
+          prettierPluginEstree,
+          prettierPluginTypeScript,
+        ],
+        ...prettierConfig,
+      });
+
+      if (fragment) {
+        return formatted
+          .replace(/^<>\n?/, '')
+          .replace(/\n?<\/>;?\s*$/, '')
+          .replace(/^ {2}/gm, '')
+          .trim();
+      }
+
+      return formatted;
+    },
+    [prettierConfig, fragment],
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import {
   DndDoc,
   DocsLayout,
   Editor,
+  EditorCustomRenderDoc,
   EditorModeDoc,
   Overview,
   Playground,
@@ -21,6 +22,10 @@ createRoot(document.getElementById('root')!).render(
         <Route element={<DocsLayout />}>
           <Route path="/" element={<Overview />} />
           <Route path="/docs/editor-mode" element={<EditorModeDoc />} />
+          <Route
+            path="/docs/editor-mode/custom-render"
+            element={<EditorCustomRenderDoc />}
+          />
           <Route path="/docs/dnd" element={<DndDoc />} />
           <Route
             path="/docs/dnd/custom-render"

--- a/src/pages/docs/editor-custom-render/index.tsx
+++ b/src/pages/docs/editor-custom-render/index.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+
+import { Typography } from '@jbpark/ui-kit';
+
+import Live from '~/.';
+import { cn } from '~/utils';
+
+const SAMPLE_CODE = `
+import * as ui from 'ui-kit';
+
+const App = () => {
+  return (
+    <div className="p-6 space-y-2">
+      <ui.Typography.Title level={3}>Hello from a custom editor</ui.Typography.Title>
+      <ui.Button type="primary">Edit me</ui.Button>
+    </div>
+  );
+};
+
+export default App;
+`;
+
+const EditorCustomRenderDoc = () => {
+  const [value, setValue] = useState(SAMPLE_CODE);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Typography.Title level={1}>Custom Editor</Typography.Title>
+        <Typography.Paragraph className="text-gray-500">
+          <code>Live.Editor</code> accepts <code>renderEditor</code> to fully
+          replace the built-in CodeMirror editing surface — this example uses a
+          plain <code>&lt;textarea&gt;</code> — while <code>Live.Editor</code>{' '}
+          still syncs to the shared preview code automatically, same as the
+          default.
+        </Typography.Paragraph>
+      </div>
+      <Live>
+        <div
+          className={cn(
+            'grid h-[500px] grid-cols-1 gap-4 overflow-hidden rounded-lg',
+            'border border-gray-200 md:grid-cols-2',
+          )}
+        >
+          <div
+            className={cn(
+              'overflow-auto border-b border-gray-200',
+              'md:border-r md:border-b-0',
+            )}
+          >
+            <Live.Preview
+              showError
+              frame={{
+                mode: 'iframe',
+                syncStyle: true,
+                scripts: ['/js/tailwindcss.js'],
+              }}
+            />
+          </div>
+          <div className="overflow-auto p-2">
+            <Live.Editor
+              value={value}
+              onChange={setValue}
+              renderEditor={({ value: text, onChange }) => (
+                <textarea
+                  value={text}
+                  onChange={e => onChange(e.target.value)}
+                  spellCheck={false}
+                  className={cn(
+                    'h-full w-full resize-none rounded border',
+                    'border-gray-200 p-3 font-mono text-sm',
+                  )}
+                />
+              )}
+            />
+          </div>
+        </div>
+      </Live>
+    </div>
+  );
+};
+
+export default EditorCustomRenderDoc;

--- a/src/pages/docs/index.ts
+++ b/src/pages/docs/index.ts
@@ -1,6 +1,7 @@
 export { default as DocsLayout } from './layout';
 export { default as Overview } from './overview';
 export { default as EditorModeDoc } from './editor-mode';
+export { default as EditorCustomRenderDoc } from './editor-custom-render';
 export { default as DndDoc } from './dnd';
 export { default as DndCustomRenderDoc } from './dnd-custom-render';
 export { default as PreviewModesDoc } from './preview-modes';

--- a/src/pages/docs/layout.tsx
+++ b/src/pages/docs/layout.tsx
@@ -10,6 +10,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { key: '/', label: 'Overview' },
   { key: '/docs/editor-mode', label: 'Editor Mode' },
+  { key: '/docs/editor-mode/custom-render', label: 'Custom Editor' },
   { key: '/docs/dnd', label: 'Drag & Drop' },
   { key: '/docs/dnd/custom-render', label: 'Custom Palette & Panel' },
   { key: '/docs/preview-modes', label: 'Preview Modes' },

--- a/src/pages/docs/overview/index.tsx
+++ b/src/pages/docs/overview/index.tsx
@@ -13,6 +13,12 @@ const HIGHLIGHTS = [
     path: '/docs/editor-mode',
   },
   {
+    title: 'Custom Editor',
+    description:
+      'Replace the built-in CodeMirror editor with your own editing surface via a render prop.',
+    path: '/docs/editor-mode/custom-render',
+  },
+  {
     title: 'Drag & Drop',
     description:
       'Build UIs visually by dragging components onto a canvas and editing their properties from a side panel.',

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,6 +2,7 @@ export {
   DocsLayout,
   Overview,
   EditorModeDoc,
+  EditorCustomRenderDoc,
   DndDoc,
   DndCustomRenderDoc,
   PreviewModesDoc,


### PR DESCRIPTION
## Summary

New feature, mirroring the `renderPalette`/`renderPanel` pattern added to `Dnd` earlier. Adds a `renderEditor` prop to `Editor`, letting consumers replace the built-in CodeMirror editing surface entirely while `Editor` still owns syncing `value` to the shared preview code (debounced), regardless of which UI renders it.

```ts
interface EditorRenderData {
  value: string;
  onChange: (value: string) => void;
  formatCode: (code: string) => Promise<string>;
}

renderEditor?: (data: EditorRenderData) => React.ReactNode;
```

`formatCode` is the same prettier-based formatting `Core`'s own Cmd+S already uses — extracted out of `core.tsx` into a shared `useFormatCode` hook so a custom editor can offer equivalent format-on-save behavior without reimplementing the prettier wiring from scratch. `Core` itself now consumes the same hook; no behavior change there (verified via `build` + `check-types`, and by reading through the extracted logic line-by-line against the original).

`Editor.Core` already existed as an escape hatch (bypasses `Editor`'s context-sync wrapper entirely, requiring the consumer to redo that wiring themselves). `renderEditor` is complementary — it lets a consumer swap only the editing UI while still getting the debounce-to-context sync "for free."

## Demo page

Added `/docs/editor-mode/custom-render` (linked from the sidebar nav and Overview's highlight cards) — a plain `<textarea>` example dogfooding the new prop, following the same pattern as the DnD custom-render page.

## Test plan

- [x] `pnpm check-types` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm lint` — passes
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm test` — 166/166 passing (unrelated)
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build` — passes; confirmed `dist/index.d.mts` correctly exposes `EditorRenderData`/`renderEditor`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 pnpm build:demo` — passes
- [ ] Not verified interactively — browser automation is unavailable in this environment. Please click through the new demo page and confirm the textarea stays in sync with the preview, and that `Core`'s existing Cmd+S formatting still works unchanged.