### PR TITLE
⚡️ perf: debounce ColorPicker's commit to the AST pipeline

### DIFF
--- a/.changeset/fix-color-picker-debounce.md
+++ b/.changeset/fix-color-picker-debounce.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Added debouncing to ColorPicker's onChange to improve performance and prevent visual snapping back to the last committed color between debounced commits.

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   Checkbox,
@@ -9,6 +9,7 @@ import {
   Upload,
   type UploadFile,
 } from '@jbpark/ui-kit';
+import { useDebounce } from '@jbpark/use-hooks';
 
 import CoreEditor from '~/components/editor/core';
 import TiptapEditor from '~/components/editor/tiptap';
@@ -70,6 +71,89 @@ const formatDateValue = (date: Date): string => {
   const day = String(date.getDate()).padStart(2, '0');
 
   return `${year}-${month}-${day}`;
+};
+
+// ColorPicker's onChange fires on every drag frame — committing straight
+// to `onChange` (which drives the AST parse/mutate/re-serialize +
+// generateSections + compile pipeline, see #130) makes a single drag cost
+// upward of 15-25ms per frame. Debouncing the *commit* keeps that pipeline
+// to roughly one run per pause instead of one per frame, while a local
+// `liveValue` state keeps the swatch/hex text updating every frame for
+// responsiveness — ColorPicker is fully controlled (`useControllableState`
+// with `value` always set here), so without this it would visually snap
+// back to the last committed color between debounced commits.
+const COLOR_COMMIT_DELAY = 75;
+
+interface ColorPickerFieldProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange?: (params: { id: string; label: string; value: string }) => void;
+}
+
+const ColorPickerField = ({
+  id,
+  label,
+  value,
+  onChange,
+}: ColorPickerFieldProps) => {
+  const [liveValue, setLiveValue] = useState(value);
+  // Tracks `value` purely to detect an external change during render (see
+  // below) — refs can't be read/written during render, so this has to be
+  // state even though nothing here reads `prevValue` itself afterward.
+  const [prevValue, setPrevValue] = useState(value);
+  const lastCommittedRef = useRef(value);
+
+  // The committed `value` can also change from outside (undo/redo, another
+  // field touching the same binding) — stay in sync with it rather than
+  // only ever tracking our own commits. Adjusted during render (React's
+  // recommended "reset state when a prop changes" pattern) rather than in
+  // an effect, so the mismatched frame never actually paints.
+  if (value !== prevValue) {
+    setPrevValue(value);
+    setLiveValue(value);
+  }
+
+  // `lastCommittedRef` only needs to be current by the time `commit` next
+  // runs (always from an event handler / debounce timer, never render), so
+  // syncing it in an effect — instead of alongside the state adjustment
+  // above — keeps the ref access out of the render phase entirely.
+  useEffect(() => {
+    lastCommittedRef.current = value;
+  }, [value]);
+
+  const commit = (next: string) => {
+    if (next === lastCommittedRef.current) {
+      return;
+    }
+    lastCommittedRef.current = next;
+    onChange?.({ id, label, value: next });
+  };
+
+  const debouncedCommit = useDebounce(() => commit(liveValue), {
+    delay: COLOR_COMMIT_DELAY,
+    autoInvoke: false,
+  });
+
+  return (
+    <ColorPicker
+      showText
+      value={liveValue}
+      onChange={next => {
+        setLiveValue(next);
+        debouncedCommit();
+      }}
+      onOpenChange={open => {
+        // Flush immediately on close (picker dismissed / selection
+        // finished) instead of waiting out the debounce window, so the
+        // last color is never at risk of being dropped by an unmount
+        // racing the pending timeout.
+        if (!open) {
+          commit(liveValue);
+        }
+      }}
+    />
+  );
 };
 
 const ICON_OPTIONS = Object.entries(ICON_MAP).map(([name, Icon]) => ({
@@ -256,18 +340,11 @@ const Field = ({ binding, id, value, onChange }: Props) => {
 
   if (binding.type === 'color' || isColorProperty(binding.property)) {
     return (
-      <ColorPicker
-        showText
+      <ColorPickerField
+        id={id}
+        label={binding.label}
         value={normalizeToHex(stringValue)}
-        onChange={next => {
-          if (next !== value) {
-            onChange?.({
-              id,
-              label: binding.label,
-              value: next,
-            });
-          }
-        }}
+        onChange={onChange}
       />
     );
   }


### PR DESCRIPTION
## 문제 (#130)

`ColorPicker`의 `onChange`가 **드래그하는 매 프레임마다** 발생하는데, 이게 그대로 `Panel`의 섹션 파싱/재직렬화 → `dnd.tsx`의 `replaceSections` → `generateSections` 전체 재조립 → 변경 섹션 `compile()`까지 전부 트리거함. 프레임당 15~25ms(40섹션 기준 AST 편집 12ms + generateSections 12ms + compile ~10ms), 60프레임 드래그면 대략 1초가 이 경로에 소모됨.

같은 파일의 텍스트/URL/숫자 입력은 이미 `onBlur`에서만 커밋해 안전한데 컬러피커만 무방비였음.

## 변경

`ColorPickerField` 래퍼 컴포넌트를 추가:

- 로컬 `liveValue` state로 매 프레임 스와치/hex 텍스트는 즉시 갱신 — `ColorPicker`는 `useControllableState`로 완전 제어형이라, 이게 없으면 디바운스 커밋 사이에 마지막 커밋 색으로 시각적으로 스냅백됨
- 실제 파이프라인으로 가는 `onChange` 커밋은 `useDebounce`(기존 의존성, 신규 추가 없음)로 75ms 디바운스
- 팝오버가 닫힐 때(`onOpenChange(false)`)는 디바운스 대기 없이 즉시 flush — 대기 중인 타임아웃과 언마운트가 겹쳐 마지막 색이 유실될 가능성을 없앰

## 검증

이 저장소의 vitest는 `environment: 'node'` + `.test.ts`만 포함하는 순수 로직 테스트 인프라라 컴포넌트 렌더링 테스트를 지원하지 않음 — jsdom + `react-dom/client` + `act()`로 별도 실동작 검증 (임시 설치, 커밋 전 제거):

- 10프레임 연속 드래그(75ms 미만 간격) → 중간엔 커밋 0회, 대기 후 마지막 값으로 정확히 1회 커밋
- 드래그 중 팝오버 닫힘 → 즉시 flush, 이후 원래 타이머가 만료돼도 중복 커밋 없음
- 외부 값 변경(undo 등) → 표시값은 따라가되 그 자체로 `onChange`를 재발화하지 않음

`pnpm lint`, `pnpm check-types`, `pnpm test`(기존 166개 테스트) 모두 통과, 회귀 없음.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)