### PR TITLE
✨ feat: port convertViewportUnits for the autoHeight redesign (#132 stage 1)

### DIFF
--- a/.changeset/fix-iframe-viewport-units.md
+++ b/.changeset/fix-iframe-viewport-units.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Rewrite vh/svh/lvh/dvh/vmin/vmax units to cqh/cqmin/cqmax equivalents in CSS dimensions, including nested inside calc()/var() fallbacks, while preserving vw and custom property names.

--- a/src/components/frame/viewport-units.test.ts
+++ b/src/components/frame/viewport-units.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { convertViewportUnits } from './viewport-units';
+
+describe('convertViewportUnits (#132 stage 1)', () => {
+  it.each([
+    ['height: 100vh', 'height: 100cqh'],
+    ['height: 100VH', 'height: 100cqh'],
+    ['width: 50.5vh', 'width: 50.5cqh'],
+    ['margin-top: -10vh', 'margin-top: -10cqh'],
+  ])('converts vh: %s -> %s', (input, expected) => {
+    expect(convertViewportUnits(input)).toBe(expected);
+  });
+
+  it.each([
+    ['height: 100svh', 'height: 100cqh'],
+    ['height: 100lvh', 'height: 100cqh'],
+    ['height: 100dvh', 'height: 100cqh'],
+    ['font-size: 5vmin', 'font-size: 5cqmin'],
+    ['font-size: 5vmax', 'font-size: 5cqmax'],
+  ])(
+    'converts the svh/lvh/dvh/vmin/vmax family: %s -> %s',
+    (input, expected) => {
+      expect(convertViewportUnits(input)).toBe(expected);
+    },
+  );
+
+  it.each([
+    ['height: calc(100vh - 20px)', 'height: calc(100cqh - 20px)'],
+    ['height: var(--x, 100vh)', 'height: var(--x, 100cqh)'],
+    [
+      'height: calc(var(--y, 50vh) + 10dvh)',
+      'height: calc(var(--y, 50cqh) + 10cqh)',
+    ],
+  ])('converts inside calc()/var() nesting: %s -> %s', (input, expected) => {
+    expect(convertViewportUnits(input)).toBe(expected);
+  });
+
+  it('converts every occurrence in a multi-declaration rule', () => {
+    expect(convertViewportUnits('height: 100vh; max-height: 50vh;')).toBe(
+      'height: 100cqh; max-height: 50cqh;',
+    );
+  });
+
+  it.each([
+    ['width: 100vw', 'width: 100vw'], // width-based, no circular reference to fix
+    ['max-width: 50vw', 'max-width: 50vw'],
+  ])('preserves vw (%s)', (input, expected) => {
+    expect(convertViewportUnits(input)).toBe(expected);
+  });
+
+  it.each([
+    ['--my-vh: 10px', '--my-vh: 10px'],
+    ['--container-lvh-offset: 4px', '--container-lvh-offset: 4px'],
+  ])('preserves custom property names (%s)', (input, expected) => {
+    expect(convertViewportUnits(input)).toBe(expected);
+  });
+
+  it.each([
+    ['background: url(a5vh.png)', 'background: url(a5vh.png)'],
+    [
+      'background: url(hero-100vh-bg.jpg)',
+      'background: url(hero-100vh-bg.jpg)',
+    ],
+    ['.a5vh { color: red; }', '.a5vh { color: red; }'],
+    ['.hero-100vh { color: red; }', '.hero-100vh { color: red; }'],
+  ])(
+    'preserves digits embedded in a URL or class name (%s)',
+    (input, expected) => {
+      expect(convertViewportUnits(input)).toBe(expected);
+    },
+  );
+
+  it.each([
+    ['height: 100vhx', 'height: 100vhx'],
+    ['height: 100svhx', 'height: 100svhx'],
+  ])(
+    'preserves a unit-like suffix that continues past a real unit (%s)',
+    (input, expected) => {
+      expect(convertViewportUnits(input)).toBe(expected);
+    },
+  );
+
+  it('leaves input with no viewport units completely unchanged', () => {
+    const css = 'display: flex; padding: 10px 1rem; color: #fff;';
+    expect(convertViewportUnits(css)).toBe(css);
+  });
+
+  // Known, documented limitation (inherited from the source fork): the
+  // regex has no notion of CSS string quoting, so text that happens to
+  // look like a viewport dimension inside a string literal gets rewritten
+  // too. Pinning this down so it's a deliberate, visible trade-off instead
+  // of a surprise if someone "fixes" it later without noticing why it was
+  // this way.
+  it('also converts inside a string literal (documented limitation, not a bug to fix here)', () => {
+    expect(convertViewportUnits('content: "100vh"')).toBe('content: "100cqh"');
+  });
+});

--- a/src/components/frame/viewport-units.ts
+++ b/src/components/frame/viewport-units.ts
@@ -1,0 +1,77 @@
+// Part of #132 stage 1 — porting the internal GitLab fork's autoHeight
+// height-measurement redesign into this repo, one verifiable stage at a
+// time (see the issue for the full plan and why the current `updateHeight`
+// implementation needs replacing: folding the iframe to 0px before
+// measuring permanently collapses `vh`-sized content to 0, since `vh`
+// units resolve against the iframe's own height).
+//
+// The fork's fix replaces the iframe height as `vh`'s reference point with
+// a fixed-size CSS containment context (`html { container-type: size;
+// height: <probe>px }`) — see stage 2. That only works if the document's
+// own `vh`/`svh`/`lvh`/`dvh`/`vmin`/`vmax` usages are first rewritten to
+// the matching container-query unit (`cqh`/`cqmin`/`cqmax`), since a size
+// container doesn't retroactively change what `vh` itself resolves
+// against. `vw`/`vi` are deliberately left alone: they resolve against
+// width, which this measurement never touches, so rewriting them would
+// only add risk with no corresponding bug to fix.
+const UNIT_MAP: Record<string, string> = {
+  vh: 'cqh',
+  svh: 'cqh',
+  lvh: 'cqh',
+  dvh: 'cqh',
+  vmin: 'cqmin',
+  vmax: 'cqmax',
+};
+
+// Longest-unit-first so `svh`/`lvh`/`dvh` aren't shadowed by a shorter
+// alternative matching a prefix of them first.
+const UNITS_PATTERN = Object.keys(UNIT_MAP)
+  .sort((a, b) => b.length - a.length)
+  .join('|');
+
+// A CSS dimension token: optional sign, then digits with an optional
+// fractional part on either side of the decimal point (`100`, `50.5`,
+// `-10`, `.5` all match; a bare `-` or `.` alone does not).
+const NUMBER_PATTERN = '-?(?:\\d+\\.?\\d*|\\.\\d+)';
+
+// Requires the matched number not to be immediately preceded by a letter,
+// digit, underscore, `.`, or `-` — this is what keeps `url(a5vh.png)`,
+// `.a5vh{}`, and `.hero-100vh{}` untouched (in all three, the digits
+// before `vh` are part of a larger filename/class-name token, not a
+// standalone CSS number) without needing any special-casing for
+// `url(...)`/selectors specifically. `-` has to be excluded too, not just
+// `\w`/`.`, since a kebab-case identifier like `hero-100vh` uses it as a
+// word separator the same way `a5vh` uses no separator at all — otherwise
+// the number pattern's own optional leading `-?` would happily treat that
+// hyphen as a negative sign instead. This doesn't break real negative
+// values (`margin-top: -10vh`): there the character *before* the `-` is
+// whatever precedes the whole declaration (a space, in practice), so the
+// lookbehind still passes and the leading `-` is captured as part of the
+// number, same as before.
+//
+// Separately, `--my-vh: 10px` was never a candidate to begin with: there's
+// no digit immediately before `vh` there at all (the `y` in `-vh` is a
+// letter, not a number), so the pattern doesn't even try to match it.
+const VIEWPORT_UNIT_RE = new RegExp(
+  `(?<![\\w.-])(${NUMBER_PATTERN})(${UNITS_PATTERN})(?![a-zA-Z0-9_-])`,
+  'gi',
+);
+
+// Rewrites vh/svh/lvh/dvh/vmin/vmax to their cqh/cqmin/cqmax equivalent
+// wherever they appear as an actual CSS dimension — including nested
+// inside calc()/var() fallbacks, since this is a plain text substitution
+// rather than a CSS-aware parse. `vw` is left as-is (see UNIT_MAP above).
+//
+// Known limitation, inherited from the source fork and not fixed here:
+// this can't distinguish a real dimension from the same text sitting
+// inside a CSS string literal, e.g. `content: "100vh"` — the regex has no
+// concept of quoting, so that string's contents get rewritten too. In
+// practice this is rare (a `content` value that's coincidentally shaped
+// like a viewport dimension) and doesn't affect layout, since `content`
+// strings aren't parsed as CSS values.
+export const convertViewportUnits = (css: string): string =>
+  css.replace(
+    VIEWPORT_UNIT_RE,
+    (_match, number: string, unit: string) =>
+      number + UNIT_MAP[unit.toLowerCase()],
+  );


### PR DESCRIPTION
## 배경

#132(autoHeight iframe 높이 측정 재설계, 사내 GitLab 포크 이식)의 4단계 진행 계획 중 **Stage 1**. 이 PR은 CSS 단위 변환기만 이식하고, `iframe.tsx`의 실제 측정 로직은 아직 건드리지 않음 (Stage 2/3에서 진행).

`vh`/`svh`/`lvh`/`dvh`/`vmin`/`vmax`는 자기 자신을 담는 iframe의 높이를 참조점으로 삼기 때문에, Stage 2가 도입할 고정 크기 CSS containment(`html { container-type: size; height: <probe>px }`)로 참조점을 분리하려면, 문서 안의 이 단위들을 먼저 매칭되는 container-query 단위(`cqh`/`cqmin`/`cqmax`)로 치환해둬야 함. `vw`는 폭 기준이라 순환 참조가 없어 그대로 둠.

## 변경

- `convertViewportUnits()` — 정규식 기반 텍스트 치환. `calc()`/`var()` 내부까지 변환, URL/클래스명에 박힌 숫자·커스텀 프로퍼티명·`vw`·`100vhx` 같은 유사 단위는 보존
- 포크의 18개 케이스 매트릭스 + 이식 중 직접 찾아낸 케이스 1개, 총 25개 테스트

## 이식 중 발견한 버그 (포크에 없던 케이스)

`.hero-100vh { ... }`(하이픈으로 구분된 식별자, `.a5vh`처럼 구분자 없는 형태와 다름)가 1차 정규식에서 **잘못 변환됨** — `100vh` 앞의 `-`를 숫자의 음수 부호로 오인. Lookbehind에서 `\w`/`.` 뿐 아니라 `-`도 제외하도록 고쳐서 해결했고, `margin-top: -10vh` 같은 진짜 음수 값은 (하이픈 앞이 공백이라 lookbehind가 그대로 통과하므로) 영향 없음. 포크는 테스트 인프라가 없어 이 케이스가 검증된 적이 없었음 — 이슈가 언급한 "테스트로 고정하는 것이 이식의 가장 큰 이득"이라는 부분이 실제로 작동한 사례.

## 알려진 한계 (의도적으로 안 고침)

`content: "100vh"` 같은 CSS 문자열 리터럴 내부도 변환됨 — 정규식이 따옴표 컨텍스트를 구분 못 함. 포크 주석에는 없던 내용이라 테스트로 명시.

## 검증

`pnpm test`(197개, 기존 172 + 신규 25), `pnpm lint`, `pnpm check-types` 모두 통과.

## 남은 단계

- **Stage 2** — `updateHeight`를 probe 방식(0px 접기 없이, 고정 크기 컨테이너로 측정)으로 교체. 이 저장소의 `useResizeObserver`/`useMutationObserver` 훅 기반 구조에 맞게 재작성 필요
- **Stage 3** — 가시성 검사(`visibility:hidden`/`opacity:0` 제외) + 전체 서브트리 순회 + 오버레이 상한 처리. **Stage 2와 같은 PR로 묶어야 함**(Stage 2만 들어가면 숨은 오버레이 문제가 드러남 — 이슈 본문 참고)
- **Stage 4** — transition 동결 / 스크롤바 숨김 / `settled*` 조기 종료 등 부수 개선

Refs #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)