### PR TITLE
🐛 fix: replace autoHeight's fold-to-0px measurement with a probe (#132 stages 2-3)

### DIFF
--- a/.changeset/fix-iframe-autoheight-probe.md
+++ b/.changeset/fix-iframe-autoheight-probe.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Added support for cq*-unit content in preview iframe, enabling correct sizing against the viewport's height.

--- a/src/components/frame/iframe.tsx
+++ b/src/components/frame/iframe.tsx
@@ -6,6 +6,14 @@ import { useMutationObserver, useResizeObserver } from '@jbpark/use-hooks';
 
 import { getCachedScriptBlob } from '~/utils';
 
+import {
+  FALLBACK_PROBE_HEIGHT,
+  computeProbeHeight,
+  estimatePositionedElementHeight,
+  isVisuallyHidden,
+} from './measure';
+import { convertViewportUnits } from './viewport-units';
+
 export interface Props {
   title?: string;
   /** Forwarded to the iframe's `sandbox` attribute for DOM/CSS isolation only — not a security boundary, since preview code executes in the host window's realm (see `compileModule` in `~/utils`). */
@@ -101,7 +109,13 @@ const IFrame = ({
       const fragment = doc.createDocumentFragment();
       newStyles.forEach(content => {
         const style = doc.createElement('style');
-        style.textContent = content;
+        // Host styles can legitimately use vh/svh/etc themselves (e.g. a
+        // shared design-system stylesheet) — converted the same way as
+        // the styles/stylesheets props below, so they resolve against
+        // the preview's own probe height instead of the iframe's, once
+        // autoHeight's container context (see ensureContainerStyle) is
+        // active.
+        style.textContent = convertViewportUnits(content);
         fragment.appendChild(style);
       });
       doc.head.appendChild(fragment);
@@ -212,8 +226,13 @@ const IFrame = ({
         doc.head.appendChild(styleEl);
       }
 
-      if (styleEl.textContent !== css) {
-        styleEl.textContent = css;
+      // The primary source of vh/svh/etc in a real preview — compiled
+      // component CSS (e.g. Tailwind's `h-screen` -> `height: 100vh`).
+      // See ensureContainerStyle below for why this needs converting.
+      const convertedCss = convertViewportUnits(css);
+
+      if (styleEl.textContent !== convertedCss) {
+        styleEl.textContent = convertedCss;
       }
     });
 
@@ -256,89 +275,151 @@ const IFrame = ({
     prevStylesheetCountRef.current = stylesheets.length;
   }, [styles, stylesheets]);
 
+  // The <html> element's own container-context style — id'd so it can be
+  // found/updated/removed across calls without holding a ref to it. Scoped
+  // to `html` (not `:root`, which is equivalent but the fork's own
+  // convention) so this only ever affects cq*-unit resolution and nothing
+  // else about the document.
+  const CONTAINER_STYLE_ID = 'autoheight-container';
+
+  // Ties `cqh`/`cqmin`/`cqmax` (what convertViewportUnits rewrote every
+  // vh/svh/lvh/dvh/vmin/vmax to) to a *fixed* reference height instead of
+  // the iframe's own height — this is what breaks the old approach's
+  // circularity (#132 problem 1): folding the iframe to 0px before
+  // measuring made vh-sized content resolve to 0 and stay there forever,
+  // while measuring without folding never converges (vh content sized
+  // against the iframe's own just-grown height keeps growing it further).
+  // `container-type: size` requires an explicit height to size against,
+  // which `probeHeight` (the *scroll container's* available height, not
+  // the iframe's) provides — genuinely independent of whatever height this
+  // function goes on to set on the iframe itself.
+  const ensureContainerStyle = (doc: Document, probeHeight: number) => {
+    let styleEl = doc.getElementById(
+      CONTAINER_STYLE_ID,
+    ) as HTMLStyleElement | null;
+
+    if (!styleEl) {
+      styleEl = doc.createElement('style');
+      styleEl.id = CONTAINER_STYLE_ID;
+      doc.head?.appendChild(styleEl);
+    }
+
+    styleEl.textContent = `html { container-type: size !important; height: ${probeHeight}px !important; }`;
+  };
+
   const updateHeight = useCallback(() => {
     if (!shouldAutoHeight || !mountNode || !iframeRef.current) {
       return;
     }
 
     const iframe = iframeRef.current;
-
-    const scrollParent = iframe.closest(
-      '[data-frame-container]',
-    ) as HTMLElement | null;
-    const savedScrollTop = scrollParent?.scrollTop ?? 0;
-
-    iframe.style.height = '0px';
-
-    let childrenHeight = 0;
-
-    Array.from(mountNode.children).forEach(child => {
-      const el = child as HTMLElement;
-      childrenHeight = Math.max(childrenHeight, el.scrollHeight);
-    });
-
     const doc = iframe.contentDocument;
     const win = doc?.defaultView;
 
-    const popups = mountNode.querySelectorAll<HTMLElement>(
-      '[data-floating-ui-focusable]',
-    );
-
-    popups.forEach(popup => {
-      if (popup.offsetHeight > 0) {
-        let offsetY = 0;
-
-        const transform = popup.style.transform;
-        if (transform) {
-          const match = transform.match(
-            /translate\([^,]+,\s*([+-]?\d+(?:\.\d+)?)/,
-          );
-          if (match?.[1]) {
-            offsetY = parseFloat(match[1]);
-          }
-        }
-
-        const estimatedHeight = offsetY + popup.offsetHeight;
-        childrenHeight = Math.max(childrenHeight, estimatedHeight);
-      }
-    });
-
-    if (win) {
-      Array.from(mountNode.children).forEach(child => {
-        const el = child as HTMLElement;
-        const style = win.getComputedStyle(el);
-
-        if (style.position === 'fixed' || style.position === 'absolute') {
-          if (el.offsetHeight > 0) {
-            let offsetY = 0;
-
-            const transform = el.style.transform;
-            if (transform) {
-              const match = transform.match(
-                /translate\([^,]+,\s*([+-]?\d+(?:\.\d+)?)/,
-              );
-              if (match?.[1]) {
-                offsetY = parseFloat(match[1]);
-              }
-            }
-
-            const estimatedHeight = offsetY + el.offsetHeight;
-            childrenHeight = Math.max(childrenHeight, estimatedHeight);
-          }
-        }
-      });
+    if (!doc || !win) {
+      return;
     }
 
-    const contentHeight = Math.max(mountNode.scrollHeight, childrenHeight);
+    const scrollParent = iframe.closest<HTMLElement>('[data-frame-container]');
+
+    let probeHeight: number;
+
+    if (!scrollParent) {
+      // No scroll container anywhere in the tree (Frame used directly,
+      // without Dnd) — fall back to a fixed default; see
+      // FALLBACK_PROBE_HEIGHT's own comment for why this differs from
+      // the "container exists but isn't laid out yet" case below.
+      probeHeight = FALLBACK_PROBE_HEIGHT;
+    } else {
+      let wrapperInsets = 0;
+      let node = iframe.parentElement;
+
+      while (node && node !== scrollParent) {
+        const style = win.getComputedStyle(node);
+
+        wrapperInsets +=
+          parseFloat(style.borderTopWidth) +
+          parseFloat(style.borderBottomWidth) +
+          parseFloat(style.paddingTop) +
+          parseFloat(style.paddingBottom);
+
+        node = node.parentElement;
+      }
+
+      const computed = computeProbeHeight(
+        scrollParent.clientHeight,
+        wrapperInsets,
+      );
+
+      if (computed === null) {
+        // Layout not ready yet (mid-transition, just mounted, etc) —
+        // skip this pass instead of guessing; the ResizeObserver/
+        // MutationObserver below will call this again once something
+        // actually changes, including the layout settling.
+        return;
+      }
+
+      probeHeight = computed;
+    }
+
+    ensureContainerStyle(doc, probeHeight);
+
+    // No 0px fold before measuring (that was the source of problem 1) —
+    // with cq*-unit content now sized against the fixed probe height
+    // instead of the iframe's own, a direct read is already stable.
+    let contentHeight = mountNode.scrollHeight;
+
+    // Full subtree, not just direct children (a popup/overlay nested a
+    // few components deep was previously invisible to this walk
+    // entirely — problem 2's "중첩된 오버레이는 아예 누락됩니다").
+    const descendants = mountNode.querySelectorAll<HTMLElement>('*');
+
+    descendants.forEach(el => {
+      const style = win.getComputedStyle(el);
+
+      // visibility:hidden/opacity:0 elements (a closed bottom sheet,
+      // a not-yet-faded-in overlay) keep a non-zero offsetHeight —
+      // display:none doesn't need checking here since the browser
+      // already zeroes *its* offsetHeight on its own.
+      if (isVisuallyHidden(style)) {
+        return;
+      }
+
+      if (
+        (style.position === 'fixed' || style.position === 'absolute') &&
+        el.offsetHeight > 0
+      ) {
+        const estimatedHeight = estimatePositionedElementHeight(
+          el.offsetHeight,
+          style.transform,
+          probeHeight,
+        );
+
+        contentHeight = Math.max(contentHeight, estimatedHeight);
+      }
+    });
 
     if (contentHeight > 0) {
       iframe.style.height = `${Math.ceil(contentHeight)}px`;
     }
-
-    if (scrollParent) {
-      scrollParent.scrollTop = savedScrollTop;
-    }
   }, [shouldAutoHeight, mountNode]);
+
+  // updateHeight only ever adds/refreshes the container-context style —
+  // if autoHeight is toggled off (or an explicit style.height is passed)
+  // at runtime, nothing else would ever remove or update it again,
+  // leaving cq*-unit content sized against a stale probe height instead
+  // of correctly falling back to real viewport-relative sizing (which
+  // cqh does on its own once nothing establishes a size container — see
+  // ensureContainerStyle's own comment).
+  useEffect(() => {
+    if (shouldAutoHeight) {
+      return;
+    }
+
+    iframeRef.current?.contentDocument
+      ?.getElementById(CONTAINER_STYLE_ID)
+      ?.remove();
+  }, [shouldAutoHeight]);
 
   useEffect(() => {
     updateHeight();
@@ -350,9 +431,10 @@ const IFrame = ({
   // own JSX (mountNode is the portal's imperatively-created container, not
   // something rendered here), so it's attached/detached imperatively
   // instead. Its reported size is intentionally unused - updateHeight's own
-  // walk (popups, position:fixed/absolute children) computes a more
-  // accurate height than mountNode's own content-box size would, so a
-  // change in `resizeSize` is only used as a trigger to recompute.
+  // walk (every descendant, position:fixed/absolute ones capped and offset
+  // by their transform) computes a more accurate height than mountNode's
+  // own content-box size would, so a change in `resizeSize` is only used
+  // as a trigger to recompute.
   useEffect(() => {
     if (!shouldAutoHeight || !mountNode) {
       return;

--- a/src/components/frame/measure.test.ts
+++ b/src/components/frame/measure.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeProbeHeight,
+  estimatePositionedElementHeight,
+  isVisuallyHidden,
+  parseTranslateY,
+} from './measure';
+
+describe('computeProbeHeight (#132 stage 2)', () => {
+  it('returns clientHeight minus wrapper insets when positive', () => {
+    expect(computeProbeHeight(600, 0)).toBe(600);
+    expect(computeProbeHeight(600, 20)).toBe(580);
+  });
+
+  it('returns null when the scroll container has not been laid out yet', () => {
+    expect(computeProbeHeight(0, 0)).toBeNull();
+  });
+
+  it('returns null when wrapper insets consume the entire client height', () => {
+    expect(computeProbeHeight(50, 50)).toBeNull();
+    expect(computeProbeHeight(50, 80)).toBeNull();
+  });
+});
+
+describe('isVisuallyHidden (#132 stage 3)', () => {
+  it('treats visibility:hidden as hidden', () => {
+    expect(isVisuallyHidden({ visibility: 'hidden', opacity: '1' })).toBe(true);
+  });
+
+  it('treats opacity:0 as hidden', () => {
+    expect(isVisuallyHidden({ visibility: 'visible', opacity: '0' })).toBe(
+      true,
+    );
+  });
+
+  it('treats a normally-visible element as not hidden', () => {
+    expect(isVisuallyHidden({ visibility: 'visible', opacity: '1' })).toBe(
+      false,
+    );
+  });
+
+  it('is not fooled by a partial opacity', () => {
+    expect(isVisuallyHidden({ visibility: 'visible', opacity: '0.01' })).toBe(
+      false,
+    );
+  });
+});
+
+describe('parseTranslateY (#132 stage 3)', () => {
+  it('reads the Y component of translate(x, y)', () => {
+    expect(parseTranslateY('translate(10px, 24px)')).toBe(24);
+  });
+
+  it('reads a negative Y offset', () => {
+    expect(parseTranslateY('translate(0px, -12px)')).toBe(-12);
+  });
+
+  it('reads translateY(y) alone', () => {
+    expect(parseTranslateY('translateY(40px)')).toBe(40);
+  });
+
+  it('reads the ty component of matrix(a, b, c, d, tx, ty)', () => {
+    expect(parseTranslateY('matrix(1, 0, 0, 1, 10, 50)')).toBe(50);
+  });
+
+  it('returns 0 for no transform', () => {
+    expect(parseTranslateY('none')).toBe(0);
+    expect(parseTranslateY('')).toBe(0);
+  });
+
+  it('returns 0 for an X-only translate rather than throwing', () => {
+    expect(parseTranslateY('translateX(10px)')).toBe(0);
+  });
+
+  it('returns 0 for an unrecognized transform rather than throwing', () => {
+    expect(parseTranslateY('rotate(45deg)')).toBe(0);
+    expect(parseTranslateY('scale(1.5)')).toBe(0);
+  });
+});
+
+describe('estimatePositionedElementHeight (#132 stage 3)', () => {
+  it('adds the translateY offset to offsetHeight', () => {
+    expect(
+      estimatePositionedElementHeight(100, 'translate(0px, 50px)', 1000),
+    ).toBe(150);
+  });
+
+  it('caps the estimate at probeHeight — a positioned element cannot inflate the document past one viewport', () => {
+    expect(
+      estimatePositionedElementHeight(2000, 'translate(0px, 500px)', 800),
+    ).toBe(800);
+  });
+
+  it('is unaffected by transform when there is none', () => {
+    expect(estimatePositionedElementHeight(300, 'none', 1000)).toBe(300);
+  });
+
+  it('does not cap when the estimate is already under probeHeight', () => {
+    expect(
+      estimatePositionedElementHeight(100, 'translate(0px, 20px)', 1000),
+    ).toBe(120);
+  });
+});

--- a/src/components/frame/measure.ts
+++ b/src/components/frame/measure.ts
@@ -1,0 +1,117 @@
+// Pure helpers behind iframe.tsx's autoHeight measurement (#132 stages
+// 2-3) — kept DOM-free so they're testable under this repo's node-
+// environment vitest setup; the DOM walking itself (getComputedStyle,
+// querySelectorAll, offsetHeight reads) has no real layout engine to run
+// against outside a real browser and stays in iframe.tsx, verified
+// separately with a real Chromium instance instead of a unit test.
+
+// A fallback used only when there's no `[data-frame-container]` scroll
+// container to measure against at all — e.g. `Frame` used directly by a
+// library consumer, without `Dnd`. There's no better reference height to
+// wait for in that case (unlike the "container exists but hasn't laid out
+// yet" case below, which defers instead), so this just needs to be *some*
+// reasonable default. Matches the source fork's own constant — a common
+// mobile viewport height, chosen there for the same reason.
+export const FALLBACK_PROBE_HEIGHT = 812;
+
+// The reference height for the preview's CSS containment context (see
+// ensureContainerStyle in iframe.tsx) — everything sized in `vh`-family
+// units (converted to `cqh` by convertViewportUnits) resolves against
+// this instead of the iframe's own height, which is what breaks the old
+// approach's fold-to-0px-then-measure circularity (#132 problem 1).
+//
+// `clientHeight` already excludes the scroll container's own border, but
+// not any padding/border on wrapper elements *between* the iframe and
+// that container (this codebase's own Sortable/Renderer/Frame don't add
+// any today, but a consumer's own `provider`/`renderPanel` wrapper
+// could) — `wrapperInsets` is the sum of those, added up by the caller
+// while walking from the iframe to the scroll container.
+//
+// Returns `null` (not a guessed fallback) when the container hasn't been
+// laid out yet (`clientHeight` still 0, e.g. mid-transition) — the
+// caller should skip this measurement pass rather than settle on a
+// number that has nothing to do with the actual available space and
+// that no future event would ever correct (see the issue's own
+// reasoning for why a `window.innerHeight` fallback here was wrong).
+export const computeProbeHeight = (
+  scrollContainerClientHeight: number,
+  wrapperInsets: number,
+): number | null => {
+  const usable = scrollContainerClientHeight - wrapperInsets;
+
+  return usable > 0 ? usable : null;
+};
+
+// `visibility:hidden` and `opacity:0` elements keep a non-zero
+// offsetHeight/scrollHeight (unlike `display:none`, which zeroes them
+// out on its own) — without this check, a closed bottom sheet or a
+// not-yet-faded-in overlay sitting in the DOM inflates the measured
+// height by however tall it would be if shown.
+export const isVisuallyHidden = (computed: {
+  visibility: string;
+  opacity: string;
+}): boolean => computed.visibility === 'hidden' || computed.opacity === '0';
+
+// `translate(Xpx, Ypx)` / `translateY(Ypx)` / `matrix(a,b,c,d,tx,ty)`'s Y
+// component — a positioned popup/overlay is commonly offset this way
+// (Radix/floating-ui do), so its *effective* bottom edge is `offsetY +
+// offsetHeight` from its positioned ancestor, not just `offsetHeight`
+// alone. Returns 0 for anything else (no transform, or an X-only/
+// unrecognized one) rather than throwing — an unparsed offset is safer
+// treated as "no extra offset" than as a measurement failure.
+//
+// iframe.tsx's only caller passes `getComputedStyle(el).transform`, which
+// every real browser normalizes to `matrix(...)` regardless of what
+// syntax (translate/translateY/none of the above) the original CSS used
+// — confirmed against a real Chromium instance, not assumed. The
+// translate()/translateY() branches mainly document intent and cover any
+// future caller that passes an *inline* style's transform instead (which
+// does preserve the author's original syntax).
+export const parseTranslateY = (transform: string): number => {
+  if (!transform || transform === 'none') {
+    return 0;
+  }
+
+  // translateY(y) is single-argument — tried first and separately from
+  // translate(x, y), since a naive "match the arg after a comma" pattern
+  // has no comma to find here at all and would silently fall through to 0.
+  const translateYMatch = transform.match(/translateY\(\s*([+-]?\d*\.?\d+)/);
+
+  if (translateYMatch?.[1]) {
+    return parseFloat(translateYMatch[1]);
+  }
+
+  const translateMatch = transform.match(
+    /translate\([^,]+,\s*([+-]?\d*\.?\d+)/,
+  );
+
+  if (translateMatch?.[1]) {
+    return parseFloat(translateMatch[1]);
+  }
+
+  const matrixMatch = transform.match(
+    /matrix\(\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*[^,]+,\s*([+-]?\d*\.?\d+)/,
+  );
+
+  return matrixMatch?.[1] ? parseFloat(matrixMatch[1]) : 0;
+};
+
+// A `position:fixed`/`absolute` element is placed relative to the
+// viewport (or the nearest positioned ancestor, which for this preview
+// content is effectively the same scale) — `offsetY + offsetHeight` can
+// legitimately exceed the probe height (e.g. an element deliberately
+// positioned to bleed off-screen), but letting an unbounded value drive
+// the *whole document's* measured height would make one runaway overlay
+// balloon everything below it. Capping at `probeHeight` treats "this
+// element's bottom edge is somewhere past the viewport" the same as "at
+// the viewport edge" for sizing purposes, without needing to know how far
+// past.
+export const estimatePositionedElementHeight = (
+  offsetHeight: number,
+  transform: string,
+  probeHeight: number,
+): number => {
+  const offsetY = parseTranslateY(transform);
+
+  return Math.min(offsetY + offsetHeight, probeHeight);
+};


### PR DESCRIPTION
## 배경

#132 Stage 2+3 (같은 PR로 묶어야 함 — Stage 2만 들어가면 Stage 3의 오버레이 문제가 드러남).

## 문제 1 — `100vh` 콘텐츠 영구 collapse (데이터 손실급)

`updateHeight()`가 측정 전에 iframe을 0px로 접었는데, `vh`는 iframe 자기 자신의 높이를 참조점으로 삼아서 `height: 100vh` 섹션이 0으로 측정되고 그대로 굳어버림 — 이슈의 재현 그대로 확인했고, 접지 않고 측정하면 이번엔 발산(iframe이 커질수록 vh 콘텐츠도 커져서 무한 증가)한다는 것도 실측으로 확인.

## 문제 2 — 숨은/중첩 오버레이 오측정

기존 코드는 직계 자식만 보고 가시성 검사가 없어서, 닫힌 `position:fixed; visibility:hidden` 바텀시트(실측 `offsetHeight` 600px, 0이 아님)가 짧은 섹션을 뷰포트 높이만큼 부풀릴 수 있었고, 컴포넌트 내부에 중첩된 오버레이는 순회에서 아예 누락됐음.

## 변경

- `ensureContainerStyle` — iframe에 `html { container-type: size; height: <probe>px }` 주입, cq* 단위 해석을 iframe 자기 높이에서 분리. Stage 1의 `convertViewportUnits`를 `styles` prop 주입과 `syncStyle` 호스트 스타일 복사(CSS 텍스트가 iframe에 들어가는 두 지점)에 실제로 연결
- probe 높이는 `[data-frame-container]`의 `clientHeight`에서 중간 래퍼 border/padding을 뺀 값 — 레이아웃이 아직 준비 안 됐으면(`computeProbeHeight`가 `null`) 이번 패스를 건너뛰고 다음 트리거를 기다림(추측 폴백 없음). `FALLBACK_PROBE_HEIGHT`는 스크롤 컨테이너 자체가 없는 별개 케이스(Dnd 없이 Frame 단독 사용)에만 적용
- 측정 자체는 더 이상 접지 않음 — `querySelectorAll('*')`로 전체 서브트리 순회, `visibility:hidden`/`opacity:0` 제외(`isVisuallyHidden`), `position:fixed/absolute` 요소는 probe 높이로 상한 처리(`estimatePositionedElementHeight`)
- `[data-floating-ui-focusable]` 전용 루프 제거 — 일반 fixed/absolute 전체 서브트리 순회가 이미 다 커버함(Radix/floating-ui 팝업은 둘 중 하나의 position을 씀)
- `autoHeight`가 꺼지면 container 스타일을 제거 — 방치하면 stale 높이에 갇힘 (제거 시 cqh가 실제 viewport 기준으로 정상 폴백하는 것도 실측 확인)

## 검증

순수 로직(`computeProbeHeight`/`isVisuallyHidden`/`parseTranslateY`/`estimatePositionedElementHeight`)은 `measure.ts`로 분리해 신규 테스트 17개(이 저장소 vitest는 DOM 없음). DOM 순회 자체는 레이아웃 엔진이 필요해 **실제 Chromium 인스턴스**(`playwright-core`, 임시 설치 후 커밋 전 제거)로 별도 검증:

- `height:100vh` 섹션 단독 → probe 높이(600px)로 측정, 0 아님
- `100vh` + 200px 추가 콘텐츠 → 800px 측정, 동일 probe로 재측정해도 800px 그대로(발산 없음)
- 닫힌 `visibility:hidden` 바텀시트 → 실측 `offsetHeight` 600px(검사 필요성 확인) 이지만 정확히 제외되어 50px 섹션이 50px로 유지
- container 스타일 없이 `100cqh` → iframe 실제 viewport 높이와 동일하게 폴백
- `getComputedStyle().transform`이 원본 문법과 무관하게 항상 `matrix(...)`로 나온다는 것도 실제 브라우저로 확인(추측 아님) — `measure.ts`에 문서화

`pnpm lint`/`check-types`/`test`(215개, +17 신규) 모두 통과.

## 포함 안 된 것 (이슈의 Stage 4)

측정 중 transition 동결, `settledScrollHeight`+`settledProbeHeight` 이중 비교로 자기유발 재측정 루프 방지, 프로브 중 스크롤바 숨김. 별도 후속 PR로 진행.

Refs #132 (Stage 2-3 완료, Stage 4 남음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)