### PR TITLE
✨ feat: freeze transitions and hide scrollbar chrome while measuring (#132 stage 4)

### DIFF
--- a/.changeset/fix-iframe-autoheight-polish.md
+++ b/.changeset/fix-iframe-autoheight-polish.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+The live editor now correctly measures the height of nested overlays and position:fixed/absolute elements, avoiding previously introduced issues with content being invisible or clipped.

--- a/src/components/frame/iframe.tsx
+++ b/src/components/frame/iframe.tsx
@@ -307,6 +307,64 @@ const IFrame = ({
     styleEl.textContent = `html { container-type: size !important; height: ${probeHeight}px !important; }`;
   };
 
+  // A second, separate style — inert (`media="not all"`) except for the
+  // brief window updateHeight actually measures in, toggled on right
+  // before and off right after (#132 stage 4). Two things it guards
+  // against:
+  //
+  // - transitions: if any rule in the preview (or a browser default)
+  //   gives `html`/an ancestor a `transition` on a property this
+  //   measurement touches, changing ensureContainerStyle's `height` would
+  //   animate instead of applying instantly, and a read taken right after
+  //   would catch a mid-transition value instead of the settled one.
+  // - scrollbar chrome: applying a new probe height can make a scrollbar
+  //   appear/disappear for exactly this measurement pass; on platforms
+  //   where it takes up layout width (Windows, unlike macOS's overlay
+  //   scrollbars), that narrows content and skews the height reading.
+  //   `scrollbar-width: none`/`::-webkit-scrollbar { display: none }`
+  //   only hides the *chrome* — unlike `overflow: hidden`, scrolling
+  //   itself still works, so content that ends up taller than its probe
+  //   height is still reachable rather than silently clipped.
+  //
+  // A single style element (not two, and never added/removed) so
+  // toggling it can't itself trip the MutationObserver watching for
+  // *content* changes.
+  const MEASUREMENT_OVERRIDE_STYLE_ID = 'autoheight-measurement-overrides';
+
+  const withMeasurementOverrides = (doc: Document, measure: () => void) => {
+    let styleEl = doc.getElementById(
+      MEASUREMENT_OVERRIDE_STYLE_ID,
+    ) as HTMLStyleElement | null;
+
+    if (!styleEl) {
+      styleEl = doc.createElement('style');
+      styleEl.id = MEASUREMENT_OVERRIDE_STYLE_ID;
+      styleEl.media = 'not all';
+      styleEl.textContent = [
+        '*, *::before, *::after { transition: none !important; }',
+        'html, body { scrollbar-width: none !important; }',
+        'html::-webkit-scrollbar, body::-webkit-scrollbar { display: none !important; }',
+      ].join('\n');
+      doc.head?.appendChild(styleEl);
+    }
+
+    styleEl.media = 'all';
+    measure();
+    styleEl.media = 'not all';
+  };
+
+  // Not ported from #132 stage 4: a "settled scrollHeight + settled probe
+  // height both unchanged -> skip" guard, meant to avoid redundant re-runs
+  // from updateHeight's own `iframe.style.height` write looping back
+  // through the ResizeObserver below (a real path — the iframe's own box
+  // size determines its *internal* viewport size, so this can genuinely
+  // fire again). Left out deliberately: `scrollHeight` only reflects
+  // normal document flow, but a position:fixed/absolute overlay opening or
+  // closing (its whole reason for needing the full-subtree walk above)
+  // often doesn't touch `scrollHeight` at all. A guard keyed on it would
+  // silently skip exactly the kind of update stage 3 exists to catch —
+  // reintroducing a narrower version of the bug this file just fixed
+  // would be a worse trade than the redundant-recompute cost it'd save.
   const updateHeight = useCallback(() => {
     if (!shouldAutoHeight || !mountNode || !iframeRef.current) {
       return;
@@ -362,41 +420,45 @@ const IFrame = ({
       probeHeight = computed;
     }
 
-    ensureContainerStyle(doc, probeHeight);
+    let contentHeight = 0;
 
-    // No 0px fold before measuring (that was the source of problem 1) —
-    // with cq*-unit content now sized against the fixed probe height
-    // instead of the iframe's own, a direct read is already stable.
-    let contentHeight = mountNode.scrollHeight;
+    withMeasurementOverrides(doc, () => {
+      ensureContainerStyle(doc, probeHeight);
 
-    // Full subtree, not just direct children (a popup/overlay nested a
-    // few components deep was previously invisible to this walk
-    // entirely — problem 2's "중첩된 오버레이는 아예 누락됩니다").
-    const descendants = mountNode.querySelectorAll<HTMLElement>('*');
+      // No 0px fold before measuring (that was the source of problem 1)
+      // — with cq*-unit content now sized against the fixed probe height
+      // instead of the iframe's own, a direct read is already stable.
+      contentHeight = mountNode.scrollHeight;
 
-    descendants.forEach(el => {
-      const style = win.getComputedStyle(el);
+      // Full subtree, not just direct children (a popup/overlay nested a
+      // few components deep was previously invisible to this walk
+      // entirely — problem 2's "중첩된 오버레이는 아예 누락됩니다").
+      const descendants = mountNode.querySelectorAll<HTMLElement>('*');
 
-      // visibility:hidden/opacity:0 elements (a closed bottom sheet,
-      // a not-yet-faded-in overlay) keep a non-zero offsetHeight —
-      // display:none doesn't need checking here since the browser
-      // already zeroes *its* offsetHeight on its own.
-      if (isVisuallyHidden(style)) {
-        return;
-      }
+      descendants.forEach(el => {
+        const style = win.getComputedStyle(el);
 
-      if (
-        (style.position === 'fixed' || style.position === 'absolute') &&
-        el.offsetHeight > 0
-      ) {
-        const estimatedHeight = estimatePositionedElementHeight(
-          el.offsetHeight,
-          style.transform,
-          probeHeight,
-        );
+        // visibility:hidden/opacity:0 elements (a closed bottom sheet,
+        // a not-yet-faded-in overlay) keep a non-zero offsetHeight —
+        // display:none doesn't need checking here since the browser
+        // already zeroes *its* offsetHeight on its own.
+        if (isVisuallyHidden(style)) {
+          return;
+        }
 
-        contentHeight = Math.max(contentHeight, estimatedHeight);
-      }
+        if (
+          (style.position === 'fixed' || style.position === 'absolute') &&
+          el.offsetHeight > 0
+        ) {
+          const estimatedHeight = estimatePositionedElementHeight(
+            el.offsetHeight,
+            style.transform,
+            probeHeight,
+          );
+
+          contentHeight = Math.max(contentHeight, estimatedHeight);
+        }
+      });
     });
 
     if (contentHeight > 0) {


### PR DESCRIPTION
## 배경

#132 Stage 4 — Stage 2/3(#137, 머지됨)의 부수 개선 항목.

## 변경

- **transition 동결**: 측정 순간에만 `media="not all"→"all"`로 토글되는 별도 style로 문서 전체 `transition: none` 강제 — `ensureContainerStyle`이 `html`의 height를 바꿀 때 어떤 규칙이든 해당 속성에 transition을 걸어뒀으면 애니메이션으로 처리돼 직후 읽는 값이 중간값이 될 수 있음
- **스크롤바 크롬 숨김**: `overflow:hidden`이 아니라 `scrollbar-width:none`/`::-webkit-scrollbar{display:none}`만 적용 — 새 probe 높이 적용으로 스크롤바가 나타나거나 사라지면서 폭을 차지하는 플랫폼(Windows 등)에서 콘텐츠 폭이 좁아져 측정값이 흔들리는 걸 방지. 스크롤 자체는 살아있어 probe 높이보다 콘텐츠가 크면 여전히 스크롤로 확인 가능
- style 엘리먼트 하나를 재사용(추가/삭제 없이 `media`만 토글) — 그 자체로 콘텐츠 변경 감시용 MutationObserver를 건드리지 않음

## 의도적으로 뺀 항목 — "자기 유발 콜백 차단"

이슈가 제안한 `settledScrollHeight`+`settledProbeHeight` 이중 비교로 스킵하는 가드는 **넣지 않았습니다.** 검토해보니 회귀 위험이 있습니다: `scrollHeight`는 일반 문서 흐름만 반영하는데, `position:fixed/absolute` 오버레이가 열리고 닫히는 것(Stage 3이 전체 서브트리 순회를 도입한 바로 그 이유)은 종종 `scrollHeight`에 전혀 영향을 안 줍니다. `scrollHeight` 기준으로 스킵을 판단하면 Stage 3이 잡으려던 바로 그 업데이트를 조용히 건너뛸 수 있어, 방금 고친 버그를 더 좁은 형태로 재도입하는 셈입니다. 절약되는 재계산 비용보다 이 위험이 더 크다고 판단해 코드에 이유를 문서화하고 스킵했습니다.

## 검증

실제 Chromium(`playwright-core`, 임시 설치 후 커밋 전 제거)으로 확인 — jsdom엔 transition/애니메이션 타이밍이 없어서 검증 불가:

- `transition: height 0.5s`인 요소가 평소 `transitionDuration: 0.5s` → 동결 스타일 활성화 시 `0s` → 해제 후 다시 `0.5s`로 정확히 복원
- `scrollbar-width:none`/`::-webkit-scrollbar{display:none}`이 스크롤바의 레이아웃 폭 기여를 제거하면서도 페이지는 여전히 스크롤 가능함(실제 `scrollTo()` + `scrollY` 확인)

`pnpm lint`/`check-types`/`test`(215개, 이번 단계는 신규 순수 로직 없음) 모두 통과.

Refs #132 (Stage 1~4 모두 반영, 단 "자기 유발 콜백 차단"은 위 이유로 의도적 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)