### PR TITLE
📝 docs: changeset 요약 내용 정확하게 수정

### DIFF
--- a/.changeset/chore-bump-deps.md
+++ b/.changeset/chore-bump-deps.md
@@ -2,4 +2,4 @@
 '@jbpark/live-editor': minor
 ---
 
-Added a custom GitHub icon to the documentation and updated the editor to use React's 'adjust state during render' pattern for undo/redo.
+전체 의존성 최신화(@jbpark/ui-kit 5.0→5.3, @jbpark/use-hooks 3.0→4.0.1, antd, @tiptap/_, react-router-dom, uuid, @codemirror/_ 등)와 그에 따른 호환성 수정. 공개 API 변경은 없음 — GitHub 아이콘을 인라인 SVG로 교체(lucide-react v1이 브랜드 아이콘 제거), 에디터 undo/redo 상태 동기화를 렌더 중 조정 패턴으로 전환.

--- a/.changeset/chore-bump-deps.md
+++ b/.changeset/chore-bump-deps.md
@@ -2,4 +2,4 @@
 '@jbpark/live-editor': minor
 ---
 
-전체 의존성 최신화(@jbpark/ui-kit 5.0→5.3, @jbpark/use-hooks 3.0→4.0.1, antd, @tiptap/_, react-router-dom, uuid, @codemirror/_ 등)와 그에 따른 호환성 수정. 공개 API 변경은 없음 — GitHub 아이콘을 인라인 SVG로 교체(lucide-react v1이 브랜드 아이콘 제거), 에디터 undo/redo 상태 동기화를 렌더 중 조정 패턴으로 전환.
+전체 의존성 최신화(`@jbpark/ui-kit` 5.0→5.3, `@jbpark/use-hooks` 3.0→4.0.1, antd, `@tiptap/*`, react-router-dom, uuid, `@codemirror/*` 등)와 그에 따른 호환성 수정. 공개 API 변경은 없음 — GitHub 아이콘을 인라인 SVG로 교체(lucide-react v1이 브랜드 아이콘 제거), 에디터 undo/redo 상태 동기화를 렌더 중 조정 패턴으로 전환.


### PR DESCRIPTION
## 요약
- 자동 생성된 changeset이 GitHub 아이콘 교체와 undo/redo 패턴 전환만 언급하고 실제 범위(`@jbpark/ui-kit`/`@jbpark/use-hooks` 등 전체 의존성 최신화)를 빠뜨려서 실제 변경 사항에 맞게 다시 작성
- prettier가 마크다운 강조 문법으로 오인해 `@tiptap/*`, `@codemirror/*`의 별표를 밑줄로 바꿔버린 것도 백틱으로 감싸 수정

## 테스트
- [x] changeset 파일 내용을 실제 PR #139 diff와 대조 확인