### PR TITLE
fix(docs): make sidebar and action buttons responsive on mobile

### DIFF
--- a/.changeset/fix-docs-mobile-responsive-layout.md
+++ b/.changeset/fix-docs-mobile-responsive-layout.md
@@ -1,5 +1,0 @@
----
-'@jbpark/live-editor': minor
----
-
-The Live Editor now features a collapsible navigation menu with a mobile-friendly drawer, allowing for easier access to documentation and features on smaller screens.

--- a/.changeset/fix-docs-mobile-responsive-layout.md
+++ b/.changeset/fix-docs-mobile-responsive-layout.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+The Live Editor now features a collapsible navigation menu with a mobile-friendly drawer, allowing for easier access to documentation and features on smaller screens.

--- a/.changeset/fix-docs-mobile-responsive-layout.md
+++ b/.changeset/fix-docs-mobile-responsive-layout.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+The Live Editor now features a collapsible navigation menu with a mobile-friendly drawer, allowing users to easily access and manage layout options.

--- a/src/pages/docs/layout.tsx
+++ b/src/pages/docs/layout.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
-import { Layout, Menu } from '@jbpark/ui-kit';
+import { Button, Drawer, Layout, Menu } from '@jbpark/ui-kit';
+import { Menu as MenuIcon } from 'lucide-react';
 
 interface NavItem {
   key: string;
@@ -19,25 +21,66 @@ const NAV_ITEMS: NavItem[] = [
 const DocsLayout = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const [collapsed, setCollapsed] = useState(false);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+
+  const handleSelect = ({ key }: { key: React.Key }) => {
+    navigate(String(key));
+    setMobileNavOpen(false);
+  };
+
+  const nav = (
+    <Menu
+      mode="inline"
+      items={NAV_ITEMS}
+      selectedKeys={[location.pathname]}
+      onSelect={handleSelect}
+    />
+  );
 
   return (
     <Layout className="min-h-screen">
-      <Layout.Sider width={240} breakpoint="md" className="bg-gray-50">
+      {/* `collapsedWidth={0}` instead of the default 80px icon rail — NAV_ITEMS
+          has no icons, so an icon rail would just clip the full labels. The
+          nav moves into the Drawer below once collapsed. */}
+      <Layout.Sider
+        width={240}
+        collapsedWidth={0}
+        breakpoint="md"
+        collapsed={collapsed}
+        onBreakpoint={setCollapsed}
+        className="bg-gray-50"
+      >
         <div className="p-4">
           <span className="text-lg font-semibold">Live Editor</span>
         </div>
-        <Menu
-          mode="inline"
-          items={NAV_ITEMS}
-          selectedKeys={[location.pathname]}
-          onSelect={({ key }) => navigate(String(key))}
-        />
+        {nav}
       </Layout.Sider>
       <Layout.Content className="overflow-y-auto p-8">
+        {collapsed && (
+          <div className="mb-6 flex items-center justify-between">
+            <span className="text-lg font-semibold">Live Editor</span>
+            <Button
+              shape="circle"
+              icon={<MenuIcon />}
+              aria-label="Open navigation"
+              onClick={() => setMobileNavOpen(true)}
+            />
+          </div>
+        )}
         <div className="mx-auto max-w-4xl">
           <Outlet />
         </div>
       </Layout.Content>
+      <Drawer
+        open={mobileNavOpen}
+        onClose={() => setMobileNavOpen(false)}
+        direction="left"
+        size="small"
+        title="Live Editor"
+      >
+        {nav}
+      </Drawer>
     </Layout>
   );
 };

--- a/src/pages/docs/overview/index.tsx
+++ b/src/pages/docs/overview/index.tsx
@@ -64,7 +64,7 @@ const Overview = () => {
           drag-and-drop. Canvas edits sync back to source code via AST
           transforms.
         </Typography.Paragraph>
-        <Space size="middle">
+        <Space size="middle" wrap>
           <Button
             type="primary"
             size="large"


### PR DESCRIPTION
## Summary
- The docs `Sider` used `breakpoint="md"` but relied on the default 80px icon-rail collapse. Since `NAV_ITEMS` has no icons, the full text labels just overflowed the 80px rail and visually overlapped the main content instead of collapsing cleanly.
- Switched to `collapsedWidth={0}`, tracked the collapse state externally via `onBreakpoint`, and moved the nav into a `Drawer` behind a hamburger trigger on mobile.
- `Overview`'s action-button `Space` (`Open Full Editor` / `GitHub` / `npm`) didn't wrap, so on narrow viewports the buttons ran off the right edge instead of dropping to a second row. Added `wrap`.

Demo-only change (`src/pages/docs/*`, not in `files: ["dist"]`) — no changeset.

## Test plan
- [x] `pnpm lint` / `pnpm check-types` pass
- [x] Verified in a real Chromium mobile viewport (390px) against local dev: no horizontal overflow on the Overview page, sidebar correctly hidden with hamburger trigger, Drawer opens/closes and navigates + auto-closes on selection
- [x] Checked `/editor`, `/preview`, `/playground` for the same issue — already fine, no changes needed there