### PR TITLE
chore: remove auto-drafted changeset for mobile docs fix

### DIFF
--- a/.changeset/fix-docs-mobile-responsive-layout.md
+++ b/.changeset/fix-docs-mobile-responsive-layout.md
@@ -1,5 +1,0 @@
----
-'@jbpark/live-editor': minor
----
-
-The Live Editor now features a collapsible navigation menu with a mobile-friendly drawer, allowing users to easily access and manage layout options.


### PR DESCRIPTION
## Summary
- #142 only touched `src/pages/docs/*`, which is demo-app-only (not in `files: ["dist"]`) — no published-package impact.
- The changeset-draft bot doesn't account for that and auto-drafted a changeset on the PR branch anyway. Removing it here rather than fighting the bot pre-merge (it just re-drafts on every push).