### PR TITLE
fix(dnd): repair broken traverse import, mobile drawer add + width

### DIFF
--- a/.changeset/fix-mobile-drawer-width-and-tap-to-add.md
+++ b/.changeset/fix-mobile-drawer-width-and-tap-to-add.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Custom renderPalette implementations can now handle mobile tap events as 'add' instead of relying on onDoubleClick, and the mobile Drawer's tap behavior has been adjusted to match this change.

--- a/.changeset/fix-traverse-import-and-mobile-tap-to-add.md
+++ b/.changeset/fix-traverse-import-and-mobile-tap-to-add.md
@@ -1,0 +1,7 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fix a broken `@babel/traverse` import that made `parseDocument` throw on every call in the browser (`TypeError: traverse is not a function`), silently breaking drag-and-drop entirely — nothing could ever be added to the canvas. `@babel/traverse`'s CJS build re-exports itself as `{ default: traverse, ...rest }`, and Vite's dependency pre-bundling doesn't unwrap that inner `default` a second time when re-exporting for ESM, so the plain `import traverse from '@babel/traverse'` resolved to the whole exports object instead of the function. Vitest's Node-based module resolution didn't hit this, so it went undetected by the test suite despite being broken in every real browser build, dev and production alike.
+
+Also added a `tapToAdd` mode to the built-in drag palette (and a matching `isMobile` field on `PaletteRenderData` for custom `renderPalette` implementations): the mobile palette Drawer now adds a component on a single tap instead of requiring a double-tap. Double-click-to-add stays desktop-only, where it exists specifically to distinguish a deliberate add from an aborted drag attempt — a distinction that doesn't apply inside the Drawer, since there's nothing to drag onto there.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -48,6 +48,13 @@ export interface PaletteRenderData {
   items: Section[];
   onAdd: (item: Section) => void;
   DraggableItem: typeof DraggableItem;
+  // True when the palette is rendering inside the mobile Drawer, where a
+  // tap can't be a failed drag attempt (there's nothing to drag onto —
+  // the canvas is stacked behind the Drawer) and native dblclick synthesis
+  // from double-tap is unreliable on touch. Custom renderPalette
+  // implementations should treat a single click/tap as "add" here instead
+  // of relying on onDoubleClick.
+  isMobile: boolean;
 }
 
 export interface PanelRenderData {
@@ -281,17 +288,30 @@ const Dnd = ({
     }
   }, [frame?.scripts]);
 
-  const renderPaletteItems = (onAdd: (item: Section) => void) => {
+  const renderPaletteItems = (
+    onAdd: (item: Section) => void,
+    forMobileDrawer = false,
+  ) => {
     const paletteItems = items?.length ? items : DRAGGABLE_ITEMS;
 
     if (renderPalette) {
-      return renderPalette({ items: paletteItems, onAdd, DraggableItem });
+      return renderPalette({
+        items: paletteItems,
+        onAdd,
+        DraggableItem,
+        isMobile: forMobileDrawer,
+      });
     }
 
     return (
       <Space orientation="vertical" align="start">
         {paletteItems.map(item => (
-          <DefaultDraggableItem key={item.id} item={item} onAdd={onAdd} />
+          <DefaultDraggableItem
+            key={item.id}
+            item={item}
+            onAdd={onAdd}
+            tapToAdd={forMobileDrawer}
+          />
         ))}
       </Space>
     );
@@ -419,7 +439,7 @@ const Dnd = ({
             {renderPaletteItems(item => {
               addItem(item);
               setMobilePaletteOpen(false);
-            })}
+            }, true)}
           </Drawer>
           <Drawer
             open={isMobile && Boolean(selectedId)}

--- a/src/components/dnd/draggable.tsx
+++ b/src/components/dnd/draggable.tsx
@@ -39,11 +39,20 @@ const DraggableItem = ({ item, children }: DraggableItemProps) => {
 export interface DefaultDraggableItemProps {
   item: Section;
   onAdd?: (item: Section) => void;
+  // Double-click is the desktop convenience shortcut alongside drag — a
+  // single click there would fire on every aborted/failed drag attempt.
+  // On mobile there's nowhere to drag *to* (the palette lives in a Drawer
+  // stacked over the canvas), so a tap can't be a failed drag, and
+  // double-tap-to-dblclick synthesis from touch is unreliable anyway
+  // (iOS Safari inconsistently fires it, and it can compete with the
+  // browser's native double-tap-to-zoom gesture). Tapping just adds there.
+  tapToAdd?: boolean;
 }
 
 export const DefaultDraggableItem = ({
   item,
   onAdd,
+  tapToAdd = false,
 }: DefaultDraggableItemProps) => (
   <DraggableItem item={item}>
     {({ ref, dragProps, isDragging }) => (
@@ -57,6 +66,7 @@ export const DefaultDraggableItem = ({
           'hover:border-blue-300 hover:shadow-md',
           isDragging && 'opacity-50',
         )}
+        onClick={tapToAdd && onAdd ? () => onAdd(item) : undefined}
         onDoubleClick={onAdd ? () => onAdd(item) : undefined}
       >
         {item.name}

--- a/src/pages/docs/dnd-custom-render/index.tsx
+++ b/src/pages/docs/dnd-custom-render/index.tsx
@@ -37,7 +37,7 @@ const DndCustomRenderDoc = () => {
               syncStyle: true,
               scripts: ['/js/tailwindcss.js'],
             }}
-            renderPalette={({ items, onAdd, DraggableItem }) => (
+            renderPalette={({ items, onAdd, DraggableItem, isMobile }) => (
               <div className="space-y-2 p-2">
                 {items.map(item => (
                   <DraggableItem key={item.id} item={item}>
@@ -45,6 +45,7 @@ const DndCustomRenderDoc = () => {
                       <div
                         ref={ref}
                         {...dragProps}
+                        onClick={isMobile ? () => onAdd(item) : undefined}
                         onDoubleClick={() => onAdd(item)}
                         className={cn(
                           'cursor-grab rounded-lg',

--- a/src/pages/docs/layout.tsx
+++ b/src/pages/docs/layout.tsx
@@ -76,7 +76,7 @@ const DocsLayout = () => {
         open={mobileNavOpen}
         onClose={() => setMobileNavOpen(false)}
         direction="left"
-        size="small"
+        size="75%"
         title="Live Editor"
       >
         {nav}

--- a/src/utils/ast/document.ts
+++ b/src/utils/ast/document.ts
@@ -1,10 +1,24 @@
 import { parse } from '@babel/parser';
-import traverse from '@babel/traverse';
+import _traverse from '@babel/traverse';
 import * as t from '@babel/types';
 
 import { CONFIG } from '../../constants';
 import type { Section } from '../../types';
 import { createBoundedCache } from '../cache';
+
+// @babel/traverse's own CJS build re-exports itself as `{ default: traverse,
+// ...everything else }` for ESM interop. Vite's dev-server dependency
+// pre-bundling (esbuild) doesn't unwrap that inner `.default` when it
+// re-exports the CJS module for ESM consumption, so `import traverse from
+// '@babel/traverse'` resolves to that whole object instead of the function
+// in the browser — "traverse is not a function" at runtime, silently
+// breaking every feature that parses a document (add via drag-and-drop,
+// double-click, or the Editor's canvas sync). Vitest's Node-based module
+// resolution doesn't hit this, so this went undetected by the test suite.
+const traverse =
+  typeof _traverse === 'function'
+    ? _traverse
+    : (_traverse as unknown as { default: typeof _traverse }).default;
 
 const APP_CONTAINER_ID = 'app-container';
 const SECTION_TAG = 'section';


### PR DESCRIPTION
## Summary

Investigated two mobile reports: the docs nav Drawer rendering too narrow, and double-clicking a component in the drag-and-drop palette not adding it.

- **Root cause found for the add bug, and it's serious**: `import traverse from '@babel/traverse'` resolves incorrectly under Vite's browser bundling (dev *and* production). `@babel/traverse`'s own CJS build re-exports itself as `{ default: traverse, ...rest }` for ESM interop, and Vite's dependency pre-bundling doesn't unwrap that inner `default` again — so `traverse` in the browser was the whole exports object, not a function. Every `parseDocument` call threw `TypeError: traverse is not a function`, so `sections` was always empty and **nothing could ever be added to the canvas**, via double-click or drag-and-drop, in the actual deployed app. Vitest's Node-based resolution doesn't hit this interop bug, which is exactly why the test suite (215 passing) never caught it.
- Also added a `tapToAdd` mode for the mobile palette Drawer: a single tap now adds reliably instead of relying on double-tap → native `dblclick` synthesis, which is inconsistent on touch (and there's nothing to drag onto from inside the Drawer anyway, so a tap there can never be a failed drag attempt the way a desktop click can be). Added a matching `isMobile` field to `PaletteRenderData` for custom `renderPalette` implementations.
- Docs nav Drawer was `size="small"` (30% width) — under 120px on a real phone. Bumped to `75%`.

## Test plan
- [x] `pnpm lint` / `pnpm check-types` / `pnpm test` (215 tests) all pass
- [x] Verified the traverse fix against **both** the dev server and a `build:demo` production build (matching what's actually deployed) in a real Chromium mobile viewport — adding a section via a single tap in the Components Drawer now correctly renders it on the canvas, confirmed via screenshot in both cases
- [x] Verified nav Drawer width visually (292px on a 390px viewport, was ~117px)

Note: I did not chase down an intermittent "3rd rapid add via automated tap+reopen cycles doesn't register" signal further — repeated CDP-simulated interactions on this exact dnd-kit-wired component are a known-unreliable test signal here (see prior investigation), so I stopped once the actual reported bug (broken traverse import; nothing could ever be added) was confirmed root-caused and fixed. Flagging in case sequential adds still misbehave on a real device — happy to dig further if so.