### PR TITLE
chore: remove duplicate changeset from #145

### DIFF
--- a/.changeset/fix-mobile-drawer-width-and-tap-to-add.md
+++ b/.changeset/fix-mobile-drawer-width-and-tap-to-add.md
@@ -1,5 +1,0 @@
----
-'@jbpark/live-editor': minor
----
-
-Custom renderPalette implementations can now handle mobile tap events as 'add' instead of relying on onDoubleClick, and the mobile Drawer's tap behavior has been adjusted to match this change.


### PR DESCRIPTION
## Summary
- #145's changeset-draft bot added a second changeset (\`fix-mobile-drawer-width-and-tap-to-add.md\`) describing the same tapToAdd/\`isMobile\` change already covered by \`fix-traverse-import-and-mobile-tap-to-add.md\` — at a conflicting bump level (minor vs. patch) for the same content. Removing the duplicate, keeping the accurate one.