### PR TITLE
fix(ast): repair broken @babel/generator import, share traverse binding

### DIFF
--- a/.changeset/fix-babel-generator-import-and-shared-traverse.md
+++ b/.changeset/fix-babel-generator-import-and-shared-traverse.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+The live editor now supports drag-and-drop, double-click, and canvas sync for document parsing, and Vitest's Node-based module resolution is unaffected.

--- a/.changeset/fix-babel-generator-import.md
+++ b/.changeset/fix-babel-generator-import.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fix the same `@babel/*` CJS/ESM interop bug (#145) in `@babel/generator`: `import generate from '@babel/generator'` resolved to the whole `{ default, generate, CodeGenerator }` exports object instead of the function under Vite's browser bundling. `extractAttributes()` silently swallowed the resulting `TypeError` into a `null` attribute value, so any JSX-expression-valued attribute (e.g. `data-binding={[...]}`) came back empty — selecting a section on the canvas showed no editable fields (or an error toast, when the failure surfaced elsewhere in the update path). Also moved `extract.ts`/`update.ts` off their own direct `@babel/traverse` imports to share `document.ts`'s already-fixed binding, instead of each carrying the same fix independently.

--- a/src/utils/ast/document.ts
+++ b/src/utils/ast/document.ts
@@ -15,7 +15,10 @@ import { createBoundedCache } from '../cache';
 // breaking every feature that parses a document (add via drag-and-drop,
 // double-click, or the Editor's canvas sync). Vitest's Node-based module
 // resolution doesn't hit this, so this went undetected by the test suite.
-const traverse =
+//
+// Exported so extract.ts/update.ts share this same safe binding instead of
+// each re-importing '@babel/traverse' directly and re-triggering the bug.
+export const traverse =
   typeof _traverse === 'function'
     ? _traverse
     : (_traverse as unknown as { default: typeof _traverse }).default;

--- a/src/utils/ast/extract.ts
+++ b/src/utils/ast/extract.ts
@@ -1,11 +1,11 @@
 import { parse } from '@babel/parser';
-import traverse from '@babel/traverse';
 import * as t from '@babel/types';
 import { nanoid } from 'nanoid';
 
 import { BINDING_PROP, CONFIG, DATA_ATTR } from '../../constants';
 import { createBoundedCache } from '../cache';
 import { parseBinding } from './binding';
+import { traverse } from './document';
 import { attrValue, generateCode, wrap } from './helpers';
 import type { Attribute, BindingItem, DataAttrNode } from './types';
 

--- a/src/utils/ast/helpers.ts
+++ b/src/utils/ast/helpers.ts
@@ -1,9 +1,22 @@
-import generate from '@babel/generator';
+import _generate from '@babel/generator';
 import { parseExpression } from '@babel/parser';
 import * as t from '@babel/types';
 
 import { REGEX } from '../../constants';
 import type { Attribute } from './types';
+
+// Same @babel/* CJS/ESM interop issue as document.ts's traverse import:
+// @babel/generator's CJS build re-exports itself as `{ default: generate,
+// generate, CodeGenerator }`, and Vite's browser dependency pre-bundling
+// doesn't unwrap that inner `.default` again — `generate` resolved to the
+// whole exports object, not the function. Every generateCode() call threw,
+// which extract.ts's extractAttributes() silently swallows into a `null`
+// attribute value, and update.ts's callers surface as "Failed to parse/
+// update this section" toasts.
+const generate =
+  typeof _generate === 'function'
+    ? _generate
+    : (_generate as unknown as { default: typeof _generate }).default;
 
 export const wrap = (code: string) => {
   return `<>${code}</>`;

--- a/src/utils/ast/update.ts
+++ b/src/utils/ast/update.ts
@@ -1,10 +1,11 @@
 import { parse } from '@babel/parser';
-import traverse, { NodePath } from '@babel/traverse';
+import type { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
 import { nanoid } from 'nanoid';
 
 import { BINDING_PROP, DATA_ATTR, REGEX } from '../../constants';
 import { parseBinding } from './binding';
+import { traverse } from './document';
 import { nodeToJSX } from './extract';
 import { attrValue, generateCode, unwrap, wrap } from './helpers';
 import type { DataAttrNode } from './types';


### PR DESCRIPTION
## Summary

Follow-up to #145. That PR fixed `@babel/traverse` throwing `TypeError: traverse is not a function` under Vite's browser bundling, which broke adding sections. Same investigation, next bug in the chain: **`@babel/generator` has the identical CJS/ESM interop issue**, and selecting a section that got past the traverse fix hit it next.

- `import generate from '@babel/generator'` resolves to `{ default: generate, generate, CodeGenerator }` in the browser, not the function.
- `extractAttributes()` in `extract.ts` catches the resulting `TypeError` and silently maps it to a `null` attribute value — so any attribute with a JSX expression value (`data-binding={[...]}`, common on `Space`/`Card`/etc. in the demo template) came back empty.
- `Node` (panel/node.tsx) then sees no usable `data-binding` value and renders nothing for that section → **no editable fields show up when you select a section**. Other call sites that don't swallow the error the same way surface it as `Toast.error('Failed to parse/update this section', ...)` instead — matching what was reported.
- Also had `extract.ts`/`update.ts` stop importing `@babel/traverse` directly (each had its own copy of the same bug) and instead import the already-fixed `traverse` binding from `document.ts`, so there's one fix, not three.

## Test plan
- [x] `pnpm lint` / `pnpm check-types` / `pnpm test` (215 tests) all pass
- [x] Verified end-to-end in a real Chromium session against the dev server: add a Hero section → select it → panel shows all 6 expected fields (background color picker, title/description/button-text textareas, button size/variant selects) → edited the title field → canvas updates to reflect the edit. No console errors, no error toast at any step.