### PR TITLE
chore: remove duplicate changeset from #149

### DIFF
--- a/.changeset/fix-babel-generator-import-and-shared-traverse.md
+++ b/.changeset/fix-babel-generator-import-and-shared-traverse.md
@@ -1,5 +1,0 @@
----
-'@jbpark/live-editor': minor
----
-
-The live editor now supports drag-and-drop, double-click, and canvas sync for document parsing, and Vitest's Node-based module resolution is unaffected.


### PR DESCRIPTION
## Summary
- #149's changeset-draft bot added a second changeset (\`fix-babel-generator-import-and-shared-traverse.md\`) for the same fix already covered by \`fix-babel-generator-import.md\` — conflicting bump level (minor vs. patch) and an inaccurate auto-generated description. Removing the duplicate.