### PR TITLE
fix(ci): make changeset-draft dedup diff-based, exclude demo site from scope

### DIFF
--- a/.github/scripts/draft-changeset.mjs
+++ b/.github/scripts/draft-changeset.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 // Drafts a .changeset/<branch-slug>.md file by asking an LLM to summarize
-// this PR's diff to src/ as a semver bump + one-paragraph description, in
-// changesets' own file format. Runs once per PR (the calling workflow skips
-// this script entirely if a changeset file for this branch already
-// exists), so it never overwrites something a human already wrote or
-// edited.
+// this PR's diff to the published package's source (src/, minus the demo
+// site — see PACKAGE_EXCLUDE_DIRS) as a semver bump + one-paragraph
+// description, in changesets' own file format. Runs once per PR (the
+// calling workflow skips this script entirely if a changeset was already
+// added in this PR), so it never overwrites something a human already
+// wrote or edited.
 //
 // Uses NVIDIA's OpenAI-compatible API Catalog endpoint (not Gemini/GitHub
 // Models — both have hit sustained outages/retirement before this).
@@ -17,6 +18,15 @@ const API_URL = 'https://integrate.api.nvidia.com/v1/chat/completions';
 const MAX_DIFF_CHARS = 12000;
 const PACKAGE_NAME = '@jbpark/live-editor';
 const PACKAGE_DIR = 'src';
+
+// The published package builds from src/index.tsx + src/utils/** (see
+// tsdown.config.ts's entry list) — src/pages/** is the docs/demo site's
+// own routes (main.tsx's router), never imported by the library entry
+// points, and has zero effect on what ships (files: ["dist"]). Excluded
+// deterministically rather than relying on the model to recognize
+// "this is demo-only, don't draft" — that judgment call was unreliable
+// in practice (see #142/#144's cleanup).
+const PACKAGE_EXCLUDE_DIRS = ['src/pages', 'src/main.tsx'];
 
 // The API occasionally returns 503/429 for a few minutes at a time — retry
 // those with backoff instead of failing the required "draft" check
@@ -68,7 +78,13 @@ function extractJson(content) {
 function diffBetween(base, head) {
   return execFileSync(
     'git',
-    ['diff', `${base}...${head}`, '--', PACKAGE_DIR],
+    [
+      'diff',
+      `${base}...${head}`,
+      '--',
+      PACKAGE_DIR,
+      ...PACKAGE_EXCLUDE_DIRS.map(dir => `:!${dir}`),
+    ],
     { encoding: 'utf8', maxBuffer: 1024 * 1024 * 20 },
   );
 }
@@ -88,7 +104,9 @@ async function main() {
   }
 
   if (!diff.trim()) {
-    console.log(`No changes under ${PACKAGE_DIR} — skipping changeset draft.`);
+    console.log(
+      `No changes under ${PACKAGE_DIR} (outside the demo site) — skipping changeset draft.`,
+    );
     return;
   }
 

--- a/.github/workflows/changeset-draft.yml
+++ b/.github/workflows/changeset-draft.yml
@@ -32,32 +32,40 @@ jobs:
         with:
           node-version: 24.x
 
-      # Only draft once per PR — if a changeset already exists for *this
-      # branch* (hand-written, or from an earlier run of this workflow on
-      # this PR), leave it alone rather than overwriting a human's edits on
-      # every subsequent push. Keyed off the branch name (slugified: `/`
-      # and other unsafe characters become `-`) rather than PR number so
-      # the check itself doubles as a human-readable filename — matches
-      # ui-kit#197/use-hooks#138, which fixed a false positive elsewhere
-      # from checking "does any changeset file exist at all" instead of
-      # scoping to a specific PR/branch (an older, still-unreleased PR's
-      # changeset would otherwise make every PR merged after it silently
-      # skip drafting its own). This repo's check was already scoped
-      # per-PR (by number) and never had that bug — switching to a branch
-      # slug here is purely for the readable-filename benefit and
-      # consistency with the other two repos, not a bug fix.
+      # Only draft once per PR — if a changeset was already added in this
+      # PR (hand-written under any filename, or from an earlier run of
+      # this workflow on this PR), leave it alone rather than adding a
+      # second, possibly-conflicting one on every subsequent push.
+      #
+      # This checks the PR's actual diff (any new .changeset/*.md file
+      # between base and head) rather than matching a filename pattern.
+      # An earlier version matched only `.changeset/<branch-slug>*.md`,
+      # which missed any hand-written changeset not named after the
+      # branch — e.g. a descriptive name like `fix-foo-bug.md` on a
+      # branch called `fix/unrelated-slug` — so the bot drafted a second,
+      # duplicate changeset alongside it every time (this happened
+      # repeatedly in this repo — see #145, #149). An even earlier
+      # version (before the branch-slug scoping ui-kit#197/use-hooks#138
+      # introduced) checked for *any* changeset file anywhere in
+      # .changeset/, which had the opposite problem: an older, still-
+      # unreleased PR's changeset made every PR merged after it silently
+      # skip drafting its own. Scoping to *this PR's diff* avoids both
+      # failure modes — it only reacts to files this PR itself
+      # introduces, under any name.
       - name: Check for existing changeset
         id: existing
         env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BRANCH_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           slug=$(printf '%s' "$BRANCH_REF" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-')
           echo "slug=$slug" >> "$GITHUB_OUTPUT"
-          shopt -s nullglob
-          files=(".changeset/${slug}"*.md)
-          shopt -u nullglob
-          if [ "${#files[@]}" -gt 0 ]; then
+          added=$(git diff --name-only --diff-filter=A "$BASE_SHA...$HEAD_SHA" -- '.changeset/*.md')
+          if [ -n "$added" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Changeset(s) already added in this PR — skipping draft:"
+            echo "$added"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
@@ -81,5 +89,5 @@ jobs:
             git commit -m "📝 docs: draft changeset for PR #${{ github.event.pull_request.number }}"
             git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
           else
-            echo "No changeset produced (nothing under src/, or model found no user-facing change) — skipping commit."
+            echo "No changeset produced (no changes outside the demo app, or model found no user-facing change) — skipping commit."
           fi


### PR DESCRIPTION
## Summary

Mirrors use-hooks#173 and ui-kit#251 — two related bugs found while cleaning up duplicate/unwarranted changesets across this repo, use-hooks, and ui-kit this session.

1. **Duplicate drafting.** The "already has a changeset" check only matched `.changeset/<branch-slug>*.md`. A hand-written changeset under a different filename didn't match, so the bot drafted a *second* changeset on every push. Hit this repo specifically in #145 and #149, each needing a manual follow-up PR to remove the duplicate. Fixed: now checks whether this PR's diff added any `.changeset/*.md` file at all, regardless of name.
2. **Demo-only PRs getting changesets.** The diff sent to the model covered all of `src/`, including the docs/demo site (`src/pages/**`, `main.tsx`) — none of which is reachable from `tsdown.config.ts`'s entry points (`src/index.tsx`, `src/utils/**`) or affects the published package. #142's mobile-responsive-layout fix (demo-only) got a changeset drafted for it anyway, needing a manual cleanup PR (#144). Fixed: `src/pages` and `main.tsx` are now excluded from the diff before it reaches the model, so a demo-only PR produces an empty diff and drafting is skipped deterministically.

## Test plan
- [x] `node --check` on the modified script
- [x] Verified against #142's actual commit (`2d6dc8f`): `git diff 2d6dc8f~1...2d6dc8f -- src ':!src/pages' ':!src/main.tsx'` now produces an **empty** diff — exactly matching the manual "no changeset needed" call made for that PR at the time
- [x] Verified the new `--diff-filter=A` existence check against a real historical changeset-adding commit
- Not runnable locally end-to-end (needs a real PR event + `NVIDIA_API_KEY`) — will confirm behavior on the next real PR