### PR TITLE
feat(dnd): add move up/down buttons to the section panel

### DIFF
--- a/.changeset/feat-panel-move-section-buttons.md
+++ b/.changeset/feat-panel-move-section-buttons.md
@@ -1,0 +1,7 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add Move up/Move down buttons to the section properties panel, next to Delete. Dragging to reorder doesn't work from inside the mobile Components/Properties Drawer — the canvas sits behind it, so there's nothing visible to drag onto — so this gives an explicit alternative that works regardless of layout. Added a matching `onMoveUp`/`onMoveDown`/`canMoveUp`/`canMoveDown` on `PanelRenderData` for custom `renderPanel` implementations.
+
+Also fixes a latent bug this surfaced: section `id`s are derived fresh from each section's position on every parse, not a stable identity, so reordering the selected section left `selectedId` pointing at whatever content ended up at its old position instead of following it. The new move buttons now correctly keep the moved section selected.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -61,6 +61,13 @@ export interface PanelRenderData {
   item?: Section;
   onChange: (next: Partial<Section>) => void;
   onDelete: (id: string) => void;
+  // Alternative to dragging a section to reorder it — needed since the
+  // canvas sits behind the mobile Drawer this panel renders in, so
+  // there's nothing visible to drag onto there.
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
 }
 
 export interface Props extends Omit<
@@ -234,6 +241,31 @@ const Dnd = ({
     setCode(nextCode);
   };
 
+  const moveSection = (id: string | null, direction: 'up' | 'down') => {
+    const index = sections.findIndex(s => s.id === id);
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+
+    if (index < 0 || targetIndex < 0 || targetIndex >= sections.length) {
+      return;
+    }
+
+    const nextSections = arrayMove(sections, index, targetIndex);
+
+    const nextCode = replaceSections(
+      value,
+      nextSections.map(s => s.code),
+    );
+
+    _onChange?.(nextCode);
+    setCode(nextCode);
+    // Section ids are just the section's positional index, re-derived from
+    // scratch on every parse (getSections) rather than a stable identity —
+    // so once `sections` recomputes after this reorder, `selectedId`
+    // (unchanged) would silently point at whatever content now sits at its
+    // old position instead of following the section that actually moved.
+    setSelectedId(String(targetIndex));
+  };
+
   const onCopy = (id: string) => {
     const sectionIndex = sections.findIndex(s => s.id === id);
     const sectionToCopy = sections[sectionIndex];
@@ -319,13 +351,33 @@ const Dnd = ({
 
   const renderPanelContent = () => {
     const selectedItem = sections.find(s => s.id === selectedId);
+    const selectedIndex = sections.findIndex(s => s.id === selectedId);
+    const canMoveUp = selectedIndex > 0;
+    const canMoveDown =
+      selectedIndex >= 0 && selectedIndex < sections.length - 1;
 
     if (renderPanel) {
-      return renderPanel({ item: selectedItem, onChange, onDelete });
+      return renderPanel({
+        item: selectedItem,
+        onChange,
+        onDelete,
+        onMoveUp: () => moveSection(selectedId, 'up'),
+        onMoveDown: () => moveSection(selectedId, 'down'),
+        canMoveUp,
+        canMoveDown,
+      });
     }
 
     return (
-      <Panel item={selectedItem} onChange={onChange} onDelete={onDelete} />
+      <Panel
+        item={selectedItem}
+        onChange={onChange}
+        onDelete={onDelete}
+        onMoveUp={() => moveSection(selectedId, 'up')}
+        onMoveDown={() => moveSection(selectedId, 'down')}
+        canMoveUp={canMoveUp}
+        canMoveDown={canMoveDown}
+      />
     );
   };
 

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 
 import { Button, Toast, Typography } from '@jbpark/ui-kit';
-import { Trash } from 'lucide-react';
+import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 
 import type { Section } from '~/types';
 import { cn } from '~/utils';
@@ -13,9 +13,25 @@ interface Props {
   item?: Section;
   onChange?: (next: Partial<Section>) => void;
   onDelete?: (id: string) => void;
+  // Reordering by dragging a section on the canvas doesn't work from
+  // inside this panel on mobile — the canvas sits behind the Drawer this
+  // panel renders in, so there's nothing visible to drag onto. These give
+  // an explicit alternative that works regardless of layout.
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
 }
 
-const Panel = ({ item, onChange, onDelete }: Props) => {
+const Panel = ({
+  item,
+  onChange,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp = false,
+  canMoveDown = false,
+}: Props) => {
   const code = item?.code;
 
   // Reads only the extracted `code` local, not `item`, so the compiler can
@@ -78,9 +94,32 @@ const Panel = ({ item, onChange, onDelete }: Props) => {
         <Typography.Title className="text-lg font-semibold">
           {item.name}
         </Typography.Title>
-        {onDelete && (
-          <Button danger icon={<Trash />} onClick={() => onDelete(item.id)} />
-        )}
+        <div className="flex items-center gap-1">
+          {onMoveUp && (
+            <Button
+              icon={<ChevronUp />}
+              disabled={!canMoveUp}
+              onClick={onMoveUp}
+              aria-label="Move section up"
+            />
+          )}
+          {onMoveDown && (
+            <Button
+              icon={<ChevronDown />}
+              disabled={!canMoveDown}
+              onClick={onMoveDown}
+              aria-label="Move section down"
+            />
+          )}
+          {onDelete && (
+            <Button
+              danger
+              icon={<Trash />}
+              onClick={() => onDelete(item.id)}
+              aria-label="Delete section"
+            />
+          )}
+        </div>
       </div>
       {!dataAttrNodes.length && (
         <Typography.Text className="text-xs text-gray-400">

--- a/src/pages/docs/dnd-custom-render/index.tsx
+++ b/src/pages/docs/dnd-custom-render/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { Button, Typography } from '@jbpark/ui-kit';
-import { Trash } from 'lucide-react';
+import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 
 import Live from '~/.';
 import { DEFAULT_TEMPLATE } from '~/constants';
@@ -62,18 +62,42 @@ const DndCustomRenderDoc = () => {
                 ))}
               </div>
             )}
-            renderPanel={({ item, onDelete }) => (
+            renderPanel={({
+              item,
+              onDelete,
+              onMoveUp,
+              onMoveDown,
+              canMoveUp,
+              canMoveDown,
+            }) => (
               <div className="p-4">
                 {item ? (
                   <>
                     <div className="mb-2 flex items-center justify-between">
                       <span className="font-semibold">{item.name}</span>
-                      <Button
-                        danger
-                        size="small"
-                        icon={<Trash />}
-                        onClick={() => onDelete(item.id)}
-                      />
+                      <div className="flex items-center gap-1">
+                        <Button
+                          size="small"
+                          icon={<ChevronUp />}
+                          disabled={!canMoveUp}
+                          onClick={onMoveUp}
+                          aria-label="Move section up"
+                        />
+                        <Button
+                          size="small"
+                          icon={<ChevronDown />}
+                          disabled={!canMoveDown}
+                          onClick={onMoveDown}
+                          aria-label="Move section down"
+                        />
+                        <Button
+                          danger
+                          size="small"
+                          icon={<Trash />}
+                          onClick={() => onDelete(item.id)}
+                          aria-label="Delete section"
+                        />
+                      </div>
                     </div>
                     <p className="text-xs text-gray-400">
                       This is a custom panel — swap this for your own field


### PR DESCRIPTION
## Summary

- Dragging to reorder doesn't work from inside the mobile Components/Properties Drawer — the canvas sits behind it, so there's nothing visible to drag onto. Added explicit **Move up**/**Move down** buttons next to Delete in the section panel header, as an alternative that works regardless of layout (shows on desktop too, since `Panel` is shared between both contexts).
- Extended `PanelRenderData` with `onMoveUp`/`onMoveDown`/`canMoveUp`/`canMoveDown` so custom `renderPanel` implementations get the same capability — updated the `dnd-custom-render` docs demo to match.
- **Found and fixed a bug along the way**: `getSections()` assigns each section's `id` from its positional index in the parsed source, re-derived fresh on every parse rather than a stable identity. Moving the selected section left `selectedId` unchanged, so after the reorder it silently pointed at whatever content now occupied its *old* position instead of following the section that actually moved — confirmed via testing (moved "Hero" down, panel flipped to show "Features" instead). `moveSection()` now updates `selectedId` to the section's predicted new index after a move.

## Test plan
- [x] `pnpm lint` / `pnpm check-types` / `pnpm test` (215 tests) all pass
- [x] Verified end-to-end in a real Chromium mobile viewport: added two sections via the Components Drawer, selected the first, clicked Move down — panel correctly stayed on the moved section (title unchanged, Move up/down disabled states flipped correctly), and closing the drawer confirmed the canvas order actually swapped
- [x] Move up correctly disabled on the first section, Move down correctly disabled on the last section