### PR TITLE
feat(dnd): expose FieldEditor for custom panels, wire into docs demo

### DIFF
--- a/.changeset/feat-custom-panel-field-editor.md
+++ b/.changeset/feat-custom-panel-field-editor.md
@@ -1,0 +1,7 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add `Dnd.FieldEditor` (exported alongside `Dnd.DraggableItem`) so a custom `renderPanel` can render a selected section's editable `data-binding` fields — color pickers, rich text, selects, and everything else `Field` already handles — without reimplementing that logic. `PanelRenderData` now includes `fields` (the section's extracted, ready-to-render binding nodes), `onFieldChange` (commits an edit through the same AST-update pipeline the built-in panel uses, including the error Toast on a bad edit), and `FieldEditor` itself. The `dnd-custom-render` docs demo now uses these instead of a placeholder message, so the "Custom Palette & Panel" page's panel is actually functional.
+
+This also moves the field-extraction logic (previously computed inside `Panel`) up into `Dnd`, so the built-in panel and a custom `renderPanel` share one implementation instead of the custom path needing its own copy.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -18,14 +18,20 @@ import {
   arrayMove,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { Button, Drawer, Space, Typography } from '@jbpark/ui-kit';
+import { Button, Drawer, Space, Toast, Typography } from '@jbpark/ui-kit';
 import { useResponsiveSize } from '@jbpark/use-hooks';
 import { LayoutGrid } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { DRAGGABLE_ITEMS } from '~/constants';
 import type { Section } from '~/types';
-import { replaceIds } from '~/utils/ast';
+import {
+  type DataAttrNode,
+  extract,
+  fillIds,
+  replaceIds,
+  update,
+} from '~/utils/ast';
 
 import { DEFAULT_TEMPLATE } from '../../constants';
 import {
@@ -40,7 +46,7 @@ import { type FrameProps } from '../frame';
 import DraggableItem, { DefaultDraggableItem } from './draggable';
 import Droppable from './droppable';
 import Overlay from './overlay';
-import Panel from './panel';
+import Panel, { FieldEditor } from './panel';
 import Renderer from './renderer';
 import Sortable from './sortable';
 
@@ -68,6 +74,16 @@ export interface PanelRenderData {
   onMoveDown: () => void;
   canMoveUp: boolean;
   canMoveDown: boolean;
+  // `item`'s editable data-binding fields, already extracted and ready to
+  // render — one entry per element carrying a `data-binding` attribute,
+  // filtered down to non-<section> descendants (mirrors what the built-in
+  // Panel shows). Render each with FieldEditor (or your own UI reading
+  // `.bindings`/`.dataAttributes`) and wire its onChange to onFieldChange,
+  // which handles the underlying AST update — including showing an error
+  // Toast on a bad edit — the same way the built-in Panel does.
+  fields: DataAttrNode[];
+  onFieldChange: (params: { id: string; label: string; value: string }) => void;
+  FieldEditor: typeof FieldEditor;
 }
 
 export interface Props extends Omit<
@@ -131,6 +147,10 @@ const Dnd = ({
 
   const value = _value || DEFAULT_TEMPLATE;
   const sections = useMemo(() => extractSections(value), [value]);
+  const selectedItem = useMemo(
+    () => sections.find(s => s.id === selectedId),
+    [sections, selectedId],
+  );
 
   // One cache per Dnd instance (lazy `useState` initializer, never
   // replaced) — see createSectionPreviewCache (#131). It's stateful by
@@ -314,6 +334,72 @@ const Dnd = ({
     setCode(nextCode);
   };
 
+  // Reads only the extracted `code` local, not `selectedItem`, so the
+  // compiler can verify this dependency array actually matches what the
+  // body reads — matches Panel's own former version of this same logic,
+  // now shared here so both the built-in Panel and a custom renderPanel
+  // get the same extraction/update pipeline instead of each needing it.
+  const selectedCode = selectedItem?.code;
+  const { fields, updatedCode, parseError } = useMemo(() => {
+    if (!selectedCode) {
+      return {
+        fields: [] as DataAttrNode[],
+        updatedCode: '',
+        parseError: false,
+      };
+    }
+
+    try {
+      const updated = fillIds(selectedCode);
+      const allNodes = extract(updated);
+      const filtered = allNodes.filter(node => node.tagName !== 'section');
+
+      return {
+        fields: filtered,
+        updatedCode: updated !== selectedCode ? updated : selectedCode,
+        parseError: false,
+      };
+    } catch (e) {
+      console.warn('⚠️ Parsing error', e);
+      return {
+        fields: [] as DataAttrNode[],
+        updatedCode: '',
+        parseError: true,
+      };
+    }
+  }, [selectedCode]);
+
+  useEffect(() => {
+    if (parseError) {
+      Toast.error('Failed to parse this section', {
+        description: 'Check the console for details.',
+      });
+    }
+  }, [parseError]);
+
+  const onFieldChange = ({
+    id,
+    label,
+    value: fieldValue,
+  }: {
+    id: string;
+    label: string;
+    value: string;
+  }) => {
+    const result = update(updatedCode, id, label, fieldValue);
+
+    if (!result.success) {
+      Toast.error('Failed to update this field', {
+        description: 'Check the console for details.',
+      });
+      return;
+    }
+
+    if (selectedItem) {
+      onChange({ ...selectedItem, code: result.code });
+    }
+  };
+
   useEffect(() => {
     if (frame?.scripts?.length) {
       preloadScripts(frame.scripts);
@@ -350,7 +436,6 @@ const Dnd = ({
   };
 
   const renderPanelContent = () => {
-    const selectedItem = sections.find(s => s.id === selectedId);
     const selectedIndex = sections.findIndex(s => s.id === selectedId);
     const canMoveUp = selectedIndex > 0;
     const canMoveDown =
@@ -365,18 +450,22 @@ const Dnd = ({
         onMoveDown: () => moveSection(selectedId, 'down'),
         canMoveUp,
         canMoveDown,
+        fields,
+        onFieldChange,
+        FieldEditor,
       });
     }
 
     return (
       <Panel
         item={selectedItem}
-        onChange={onChange}
         onDelete={onDelete}
         onMoveUp={() => moveSection(selectedId, 'up')}
         onMoveDown={() => moveSection(selectedId, 'down')}
         canMoveUp={canMoveUp}
         canMoveDown={canMoveDown}
+        fields={fields}
+        onFieldChange={onFieldChange}
       />
     );
   };

--- a/src/components/dnd/index.ts
+++ b/src/components/dnd/index.ts
@@ -7,21 +7,25 @@ import DraggableItem, {
   type DraggableItemDragState,
   type DraggableItemProps,
 } from './draggable';
+import { FieldEditor, type FieldEditorProps } from './panel';
 
 type DndComponent = typeof DndImpl & {
   DraggableItem: typeof DraggableItem;
+  FieldEditor: typeof FieldEditor;
 };
 
 const Dnd = DndImpl as DndComponent;
 
 Dnd.DraggableItem = DraggableItem;
+Dnd.FieldEditor = FieldEditor;
 
-export { DraggableItem };
+export { DraggableItem, FieldEditor };
 export type {
   Props,
   PaletteRenderData,
   PanelRenderData,
   DraggableItemProps,
   DraggableItemDragState,
+  FieldEditorProps,
 };
 export default Dnd;

--- a/src/components/dnd/panel/index.ts
+++ b/src/components/dnd/panel/index.ts
@@ -1,1 +1,2 @@
 export { default } from './panel';
+export { default as FieldEditor, type FieldEditorProps } from './node';

--- a/src/components/dnd/panel/node.tsx
+++ b/src/components/dnd/panel/node.tsx
@@ -2,12 +2,12 @@ import { type DataAttrNode, getCurrentValue, parseBinding } from '~/utils/ast';
 
 import Field from './field';
 
-interface Props {
+export interface FieldEditorProps {
   data: DataAttrNode;
   onChange?: (params: { id: string; label: string; value: string }) => void;
 }
 
-const Node = ({ data, onChange }: Props) => {
+const Node = ({ data, onChange }: FieldEditorProps) => {
   const idAttr = data.dataAttributes.find(a => a.name === 'data-id');
   const bindingAttr = data.dataAttributes.find(a => a.name === 'data-binding');
 

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -1,17 +1,14 @@
-import { useEffect, useMemo } from 'react';
-
-import { Button, Toast, Typography } from '@jbpark/ui-kit';
+import { Button, Typography } from '@jbpark/ui-kit';
 import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 
 import type { Section } from '~/types';
 import { cn } from '~/utils';
-import { extract, fillIds, update } from '~/utils/ast';
+import type { DataAttrNode } from '~/utils/ast';
 
 import Node from './node';
 
 interface Props {
   item?: Section;
-  onChange?: (next: Partial<Section>) => void;
   onDelete?: (id: string) => void;
   // Reordering by dragging a section on the canvas doesn't work from
   // inside this panel on mobile — the canvas sits behind the Drawer this
@@ -21,54 +18,23 @@ interface Props {
   onMoveDown?: () => void;
   canMoveUp?: boolean;
   canMoveDown?: boolean;
+  // `item`'s editable data-binding fields — extraction (and the AST
+  // update + error-toast handling behind onFieldChange) lives in Dnd, so
+  // it's shared with a custom renderPanel instead of computed here too.
+  fields: DataAttrNode[];
+  onFieldChange: (params: { id: string; label: string; value: string }) => void;
 }
 
 const Panel = ({
   item,
-  onChange,
   onDelete,
   onMoveUp,
   onMoveDown,
   canMoveUp = false,
   canMoveDown = false,
+  fields,
+  onFieldChange,
 }: Props) => {
-  const code = item?.code;
-
-  // Reads only the extracted `code` local, not `item`, so the compiler can
-  // verify this dependency array actually matches what the body reads —
-  // mixing `item?.code` (the guard) and `item.code` (post-guard reads)
-  // made that unprovable and widened the inferred dependency to `item`
-  // itself, which would recompute on unrelated `item` identity changes.
-  const { dataAttrNodes, updatedCode, parseError } = useMemo(() => {
-    if (!code) {
-      return { dataAttrNodes: [], updatedCode: '', parseError: false };
-    }
-
-    try {
-      const updatedCode = fillIds(code);
-
-      const allNodes = extract(updatedCode);
-      const filtered = allNodes.filter(node => node.tagName !== 'section');
-
-      return {
-        dataAttrNodes: filtered,
-        updatedCode: updatedCode !== code ? updatedCode : code,
-        parseError: false,
-      };
-    } catch (e) {
-      console.warn('⚠️ Parsing error', e);
-      return { dataAttrNodes: [], updatedCode: '', parseError: true };
-    }
-  }, [code]);
-
-  useEffect(() => {
-    if (parseError) {
-      Toast.error('Failed to parse this section', {
-        description: 'Check the console for details.',
-      });
-    }
-  }, [parseError]);
-
   if (!item) {
     return (
       <Typography.Paragraph
@@ -121,30 +87,16 @@ const Panel = ({
           )}
         </div>
       </div>
-      {!dataAttrNodes.length && (
+      {!fields.length && (
         <Typography.Text className="text-xs text-gray-400">
           No editable elements.
         </Typography.Text>
       )}
-      {dataAttrNodes.map((node, index) => (
+      {fields.map((node, index) => (
         <Node
           key={`${item.id}-${index}`}
           data={node}
-          onChange={({ id, label, value }) => {
-            const result = update(updatedCode, id, label, value);
-
-            if (!result.success) {
-              Toast.error('Failed to update this field', {
-                description: 'Check the console for details.',
-              });
-              return;
-            }
-
-            onChange?.({
-              ...item,
-              code: result.code,
-            });
-          }}
+          onChange={onFieldChange}
         />
       ))}
     </div>

--- a/src/pages/docs/dnd-custom-render/index.tsx
+++ b/src/pages/docs/dnd-custom-render/index.tsx
@@ -18,8 +18,10 @@ const DndCustomRenderDoc = () => {
           <code>Live.Dnd</code> accepts <code>renderPalette</code> and{' '}
           <code>renderPanel</code> to fully replace the built-in layouts.
           Drag-and-drop keeps working through the exported{' '}
-          <code>Live.Dnd.DraggableItem</code>, which owns the drag wiring — only
-          the visual markup below is custom.
+          <code>DraggableItem</code>, which owns the drag wiring, and editing a
+          section&apos;s <code>data-binding</code> fields keeps working through{' '}
+          <code>FieldEditor</code> (both passed into the render props below) —
+          only the surrounding markup is custom.
         </Typography.Paragraph>
       </div>
       <Live>
@@ -69,11 +71,14 @@ const DndCustomRenderDoc = () => {
               onMoveDown,
               canMoveUp,
               canMoveDown,
+              fields,
+              onFieldChange,
+              FieldEditor,
             }) => (
-              <div className="p-4">
+              <div className="space-y-3 p-4">
                 {item ? (
                   <>
-                    <div className="mb-2 flex items-center justify-between">
+                    <div className="flex items-center justify-between">
                       <span className="font-semibold">{item.name}</span>
                       <div className="flex items-center gap-1">
                         <Button
@@ -99,10 +104,24 @@ const DndCustomRenderDoc = () => {
                         />
                       </div>
                     </div>
-                    <p className="text-xs text-gray-400">
-                      This is a custom panel — swap this for your own field
-                      editor UI.
-                    </p>
+                    {fields.length ? (
+                      // FieldEditor owns rendering each data-binding field
+                      // (color pickers, rich text, selects, ...) — the
+                      // "custom" part here is just the surrounding layout;
+                      // swap this container for your own markup while
+                      // still getting the library's field editors for free.
+                      fields.map((field, index) => (
+                        <FieldEditor
+                          key={`${item.id}-${index}`}
+                          data={field}
+                          onChange={onFieldChange}
+                        />
+                      ))
+                    ) : (
+                      <p className="text-xs text-gray-400">
+                        No editable elements.
+                      </p>
+                    )}
                   </>
                 ) : (
                   <p className="text-sm text-gray-500">


### PR DESCRIPTION
## Summary

The "Custom Palette & Panel" docs page's `renderPanel` only ever showed the section name + delete button, with a placeholder comment saying to "swap this for your own field editor UI" — it never actually demonstrated editing a section's `data-binding` fields, unlike the built-in `Panel`.

- Moved the field-extraction/update logic (`fillIds` + `extract`, the parse-error `Toast`, and the `update()`-backed change handler — previously all internal to `Panel`) up into `Dnd`, and exposed it through `PanelRenderData` as `fields` + `onFieldChange`.
- Exposed the `Node` component itself as `Dnd.FieldEditor`, mirroring how `DraggableItem` is already exposed for `renderPalette`. A custom `renderPanel` can now render each field with `FieldEditor` and get the same color pickers, rich text, selects, etc. that `Field` already implements, without reimplementing any of it.
- `Panel` is simplified to a pure consumer of `fields`/`onFieldChange` instead of computing them itself, so the built-in panel and any custom `renderPanel` share one implementation.
- Updated the `dnd-custom-render` demo to actually render fields via `FieldEditor` instead of the placeholder text — the page is now functional, not just a layout example.

## Test plan
- [x] `pnpm lint` / `pnpm check-types` / `pnpm test` (215 tests) all pass
- [x] Verified end-to-end in a real Chromium session: selected a section on the custom-render demo, confirmed all 5 expected fields render (background color, title, description, button text, button size), edited the title field, confirmed the canvas updates immediately
- [x] Regression check: the built-in panel (`docs/dnd`) still renders/edits fields and move-up/down identically after the refactor