### PR TITLE
♻️ refactor(docs): use Space for section headers, refine sidebar nav

### DIFF
--- a/src/pages/docs/dnd-custom-render/index.tsx
+++ b/src/pages/docs/dnd-custom-render/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Button, Typography } from '@jbpark/ui-kit';
+import { Button, Space, Typography } from '@jbpark/ui-kit';
 import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 
 import Live from '~/.';
@@ -12,7 +12,7 @@ const DndCustomRenderDoc = () => {
 
   return (
     <div className="space-y-4">
-      <div>
+      <Space orientation="vertical" align="start">
         <Typography.Title level={1}>Custom Palette & Panel</Typography.Title>
         <Typography.Paragraph className="text-gray-500">
           <code>Live.Dnd</code> accepts <code>renderPalette</code> and{' '}
@@ -23,11 +23,11 @@ const DndCustomRenderDoc = () => {
           <code>FieldEditor</code> (both passed into the render props below) —
           only the surrounding markup is custom.
         </Typography.Paragraph>
-      </div>
+      </Space>
       <Live>
         <div
           className={cn(
-            'h-[550px] overflow-hidden rounded-lg',
+            'h-[550px] overflow-y-auto rounded-lg',
             'border border-gray-200',
           )}
         >

--- a/src/pages/docs/dnd/index.tsx
+++ b/src/pages/docs/dnd/index.tsx
@@ -11,18 +11,16 @@ const DndDoc = () => {
 
   return (
     <div className="space-y-4">
-      <div>
-        <Typography.Title level={1}>Drag & Drop</Typography.Title>
-        <Typography.Paragraph className="text-gray-500">
-          Drag a component from the left palette onto the canvas, then edit its
-          properties from the panel on the right. Powered by{' '}
-          <code>@dnd-kit</code>.
-        </Typography.Paragraph>
-      </div>
+      <Typography.Title level={1}>Drag & Drop</Typography.Title>
+      <Typography.Paragraph className="text-gray-500">
+        Drag a component from the left palette onto the canvas, then edit its
+        properties from the panel on the right. Powered by <code>@dnd-kit</code>
+        .
+      </Typography.Paragraph>
       <Live>
         <div
           className={cn(
-            'h-[550px] overflow-hidden rounded-lg',
+            'h-[550px] overflow-auto rounded-lg',
             'border border-gray-200',
           )}
         >

--- a/src/pages/docs/editor-custom-render/index.tsx
+++ b/src/pages/docs/editor-custom-render/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Typography } from '@jbpark/ui-kit';
+import { Space, Typography } from '@jbpark/ui-kit';
 
 import Live from '~/.';
 import { cn } from '~/utils';
@@ -25,7 +25,7 @@ const EditorCustomRenderDoc = () => {
 
   return (
     <div className="space-y-4">
-      <div>
+      <Space orientation="vertical" align="start">
         <Typography.Title level={1}>Custom Editor</Typography.Title>
         <Typography.Paragraph className="text-gray-500">
           <code>Live.Editor</code> accepts <code>renderEditor</code> to fully
@@ -34,11 +34,11 @@ const EditorCustomRenderDoc = () => {
           still syncs to the shared preview code automatically, same as the
           default.
         </Typography.Paragraph>
-      </div>
+      </Space>
       <Live>
         <div
           className={cn(
-            'grid h-[500px] grid-cols-1 gap-4 overflow-hidden rounded-lg',
+            'grid h-[500px] grid-cols-1 gap-4 overflow-y-auto rounded-lg',
             'border border-gray-200 md:grid-cols-2',
           )}
         >

--- a/src/pages/docs/editor-mode/index.tsx
+++ b/src/pages/docs/editor-mode/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Typography } from '@jbpark/ui-kit';
+import { Space, Typography } from '@jbpark/ui-kit';
 
 import Live from '~/.';
 import { cn } from '~/utils';
@@ -25,14 +25,14 @@ const EditorModeDoc = () => {
 
   return (
     <div className="space-y-4">
-      <div>
+      <Space orientation="vertical" align="start">
         <Typography.Title level={1}>Editor Mode</Typography.Title>
         <Typography.Paragraph className="text-gray-500">
           <code>Live.Editor</code> and <code>Live.Preview</code> share code
           through <code>Live</code>'s context — edit either side, the other
           updates automatically. No manual wiring between them is needed.
         </Typography.Paragraph>
-      </div>
+      </Space>
       <Live>
         <div
           className={cn(

--- a/src/pages/docs/layout.tsx
+++ b/src/pages/docs/layout.tsx
@@ -31,7 +31,8 @@ const DocsLayout = () => {
 
   const nav = (
     <Menu
-      mode="inline"
+      className="w-full shadow-none"
+      mode="vertical"
       items={NAV_ITEMS}
       selectedKeys={[location.pathname]}
       onSelect={handleSelect}
@@ -49,12 +50,12 @@ const DocsLayout = () => {
         breakpoint="md"
         collapsed={collapsed}
         onBreakpoint={setCollapsed}
-        className="bg-gray-50"
+        className="h-screen bg-gray-50"
       >
         <div className="p-4">
-          <span className="text-lg font-semibold">Live Editor</span>
+          <span className="block pb-4 text-lg font-semibold">Live Editor</span>
+          {nav}
         </div>
-        {nav}
       </Layout.Sider>
       <Layout.Content className="overflow-y-auto p-8">
         {collapsed && (

--- a/src/pages/docs/overview/index.tsx
+++ b/src/pages/docs/overview/index.tsx
@@ -57,45 +57,45 @@ const Overview = () => {
 
   return (
     <Space orientation="vertical" size="large" className="w-full">
-      <div>
+      <Space orientation="vertical" align="start">
         <Typography.Title level={1}>Live Editor</Typography.Title>
         <Typography.Paragraph className="text-lg text-gray-500">
           An interactive editor for building UIs with real-time preview and
           drag-and-drop. Canvas edits sync back to source code via AST
           transforms.
         </Typography.Paragraph>
-        <Space size="middle" wrap>
-          <Button
-            type="primary"
-            size="large"
-            icon={<SquarePlay />}
-            onClick={() => navigate('/editor')}
-          >
-            Open Full Editor
-          </Button>
-          <Button
-            size="large"
-            icon={<GithubIcon size={16} />}
-            onClick={() =>
-              window.open('https://github.com/pjb0811/live-editor', '_blank')
-            }
-          >
-            GitHub
-          </Button>
-          <Button
-            size="large"
-            icon={<ExternalLink />}
-            onClick={() =>
-              window.open(
-                'https://www.npmjs.com/package/@jbpark/live-editor',
-                '_blank',
-              )
-            }
-          >
-            npm
-          </Button>
-        </Space>
-      </div>
+      </Space>
+      <Space align="start" wrap>
+        <Button
+          type="primary"
+          size="large"
+          icon={<SquarePlay />}
+          onClick={() => navigate('/editor')}
+        >
+          Open Full Editor
+        </Button>
+        <Button
+          size="large"
+          icon={<GithubIcon size={16} />}
+          onClick={() =>
+            window.open('https://github.com/pjb0811/live-editor', '_blank')
+          }
+        >
+          GitHub
+        </Button>
+        <Button
+          size="large"
+          icon={<ExternalLink />}
+          onClick={() =>
+            window.open(
+              'https://www.npmjs.com/package/@jbpark/live-editor',
+              '_blank',
+            )
+          }
+        >
+          npm
+        </Button>
+      </Space>
 
       <div className="grid gap-4 sm:grid-cols-2">
         {HIGHLIGHTS.map(item => (

--- a/src/pages/docs/preview-modes/index.tsx
+++ b/src/pages/docs/preview-modes/index.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@jbpark/ui-kit';
+import { Space, Typography } from '@jbpark/ui-kit';
 
 import Live from '~/.';
 
@@ -20,7 +20,7 @@ export default App;
 const PreviewModesDoc = () => {
   return (
     <div className="space-y-4">
-      <div>
+      <Space orientation="vertical" align="start">
         <Typography.Title level={1}>Preview Modes</Typography.Title>
         <Typography.Paragraph className="text-gray-500">
           <code>frame.mode</code> controls how the preview renders:{' '}
@@ -29,7 +29,7 @@ const PreviewModesDoc = () => {
           realm), while <code>shadow</code> isolates styles via a shadow DOM
           host in the same document, without an iframe boundary.
         </Typography.Paragraph>
-      </div>
+      </Space>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div>
           <Typography.Title level={4}>iframe</Typography.Title>


### PR DESCRIPTION
## 개요
docs 데모 페이지들의 레이아웃을 다듬음.

## 변경 사항
- 각 docs 페이지 헤더의 raw `<div>` 래퍼를 ui-kit `Space`로 교체 (세로 정렬)
- `overview`: CTA 버튼 그룹을 헤더 밖 별도 `Space`로 분리
- `layout`: 사이더 `Menu`를 `inline`→`vertical`, nav를 타이틀 아래로 이동, `h-screen` 적용
- `dnd`/`editor` 데모 컨테이너 overflow `hidden`→`auto`/`y-auto`로 스크롤 허용

## 비고
- 데모 사이트(docs) 변경이라 changeset 불필요
- pre-commit 훅(prettier/lint/tsc) 통과