### PR TITLE
🐛 fix(frame): hide inner scrollbar of autoHeight iframes

### DIFF
--- a/.changeset/fix-autoheight-iframe-scrollbar.md
+++ b/.changeset/fix-autoheight-iframe-scrollbar.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Hide the inner scrollbar of `autoHeight` iframes. Because `autoHeight` sets the iframe's height to `Math.ceil(contentHeight)`, sub-pixel content or a rounding remainder could leave the document a fraction taller than its viewport — enough for the browser to draw a vertical scrollbar inside the iframe. In Dnd mode, where every section renders its own `autoHeight` iframe, this showed up as a stray scrollbar on each stacked section. A persistent `scrollbar-width: none` / `::-webkit-scrollbar { display: none }` style now hides only the chrome (not scrolling itself, so content that ever genuinely exceeds the measured height stays reachable), and is removed again if `autoHeight` is turned off.

--- a/src/components/frame/iframe.tsx
+++ b/src/components/frame/iframe.tsx
@@ -282,6 +282,19 @@ const IFrame = ({
   // else about the document.
   const CONTAINER_STYLE_ID = 'autoheight-container';
 
+  // Permanently hides the iframe document's own scrollbar chrome while
+  // autoHeight is sizing the iframe to its content. autoHeight sets the
+  // iframe's height to `Math.ceil(contentHeight)`, so sub-pixel content or
+  // a rounding remainder can leave the inner document a fraction taller
+  // than its viewport — enough for the browser to draw a vertical
+  // scrollbar inside every section's iframe (visual noise once several Dnd
+  // sections stack). Unlike the measurement-only override above (toggled
+  // off after each read), this one stays on: `scrollbar-width`/
+  // `::-webkit-scrollbar` hide only the *chrome*, not scrolling itself, so
+  // content that ever genuinely exceeds the measured height is still
+  // reachable by wheel/keyboard rather than clipped.
+  const HIDE_SCROLLBAR_STYLE_ID = 'autoheight-hide-scrollbar';
+
   // Ties `cqh`/`cqmin`/`cqmax` (what convertViewportUnits rewrote every
   // vh/svh/lvh/dvh/vmin/vmax to) to a *fixed* reference height instead of
   // the iframe's own height — this is what breaks the old approach's
@@ -482,6 +495,35 @@ const IFrame = ({
       ?.getElementById(CONTAINER_STYLE_ID)
       ?.remove();
   }, [shouldAutoHeight]);
+
+  // Keyed on mountNode (not just shouldAutoHeight) so it re-runs once the
+  // iframe's document exists — before load there's no head to inject into.
+  useEffect(() => {
+    const doc = iframeRef.current?.contentDocument;
+
+    if (!doc?.head) {
+      return;
+    }
+
+    const existing = doc.getElementById(HIDE_SCROLLBAR_STYLE_ID);
+
+    if (!shouldAutoHeight) {
+      existing?.remove();
+      return;
+    }
+
+    if (existing) {
+      return;
+    }
+
+    const styleEl = doc.createElement('style');
+    styleEl.id = HIDE_SCROLLBAR_STYLE_ID;
+    styleEl.textContent = [
+      'html, body { scrollbar-width: none !important; }',
+      'html::-webkit-scrollbar, body::-webkit-scrollbar { display: none !important; }',
+    ].join('\n');
+    doc.head.appendChild(styleEl);
+  }, [shouldAutoHeight, mountNode]);
 
   useEffect(() => {
     updateHeight();


### PR DESCRIPTION
## 문제
Dnd 모드에서 섹션이 여러 개일 때 각 섹션 iframe에 세로 스크롤바가 노출됨.

## 원인
`autoHeight`가 iframe 높이를 `Math.ceil(contentHeight)`로 설정하면서, 서브픽셀/반올림 잔여만큼 내부 문서가 뷰포트보다 아주 살짝 커져 브라우저가 iframe마다 세로 스크롤바를 그림. Dnd는 섹션마다 `autoHeight` iframe이 생겨 스택마다 스크롤바가 보였음.

## 수정
- iframe 내부 문서에 `scrollbar-width: none` + `::-webkit-scrollbar { display: none }` 스타일을 영구 주입해 스크롤바 크롬만 숨김
- 측정 전용 오버라이드(측정 후 off)와 달리 상시 유지 — 크롬만 숨기고 스크롤 기능은 유지하므로, 혹시 측정 높이를 넘는 콘텐츠도 휠/키보드로 접근 가능
- `autoHeight`가 꺼지면(또는 명시적 height 전달 시) 스타일 자동 제거

## 검증
- tsc / eslint / frame 테스트(43) 통과
- changeset(patch) 추가