### PR TITLE
✨ feat(dnd): expose panel bindings data instead of FieldEditor

### DIFF
--- a/.changeset/feat-custom-panel-bindings.md
+++ b/.changeset/feat-custom-panel-bindings.md
@@ -1,0 +1,7 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Let a custom `renderPanel` build its own field controls. `PanelRenderData` now includes `bindings` — the selected section's editable `data-binding` fields flattened to one entry per bound property, each carrying its `type`, current `value`, `options` (when present), and an `onChange` wired straight into the same AST-update pipeline the built-in panel uses (including the error Toast on a bad edit). Consumers switch on `binding.type` to render their own `<input>` / `<textarea>` / `<select>` (or any control) instead of being handed a fixed field editor.
+
+This replaces the earlier `fields` / `onFieldChange` / `FieldEditor` render-prop shape from the same unreleased cycle: rather than exposing the built-in `FieldEditor` component (and the raw `DataAttrNode[]` behind it), `renderPanel` now hands over plain, ready-to-render binding data, so a custom panel never has to touch `DataAttrNode` / `parseBinding` / `getCurrentValue` itself. The field-extraction logic still lives in `Dnd` (moved up out of `Panel`), so the built-in panel and a custom `renderPanel` share one implementation.

--- a/.changeset/feat-custom-panel-field-editor.md
+++ b/.changeset/feat-custom-panel-field-editor.md
@@ -1,7 +1,0 @@
----
-'@jbpark/live-editor': minor
----
-
-Add `Dnd.FieldEditor` (exported alongside `Dnd.DraggableItem`) so a custom `renderPanel` can render a selected section's editable `data-binding` fields — color pickers, rich text, selects, and everything else `Field` already handles — without reimplementing that logic. `PanelRenderData` now includes `fields` (the section's extracted, ready-to-render binding nodes), `onFieldChange` (commits an edit through the same AST-update pipeline the built-in panel uses, including the error Toast on a bad edit), and `FieldEditor` itself. The `dnd-custom-render` docs demo now uses these instead of a placeholder message, so the "Custom Palette & Panel" page's panel is actually functional.
-
-This also moves the field-extraction logic (previously computed inside `Panel`) up into `Dnd`, so the built-in panel and a custom `renderPanel` share one implementation instead of the custom path needing its own copy.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -26,9 +26,13 @@ import { v4 as uuidv4 } from 'uuid';
 import { DRAGGABLE_ITEMS } from '~/constants';
 import type { Section } from '~/types';
 import {
+  type BindingOption,
+  type BindingType,
   type DataAttrNode,
   extract,
   fillIds,
+  getCurrentValue,
+  parseBinding,
   replaceIds,
   update,
 } from '~/utils/ast';
@@ -46,7 +50,7 @@ import { type FrameProps } from '../frame';
 import DraggableItem, { DefaultDraggableItem } from './draggable';
 import Droppable from './droppable';
 import Overlay from './overlay';
-import Panel, { FieldEditor } from './panel';
+import Panel from './panel';
 import Renderer from './renderer';
 import Sortable from './sortable';
 
@@ -74,16 +78,39 @@ export interface PanelRenderData {
   onMoveDown: () => void;
   canMoveUp: boolean;
   canMoveDown: boolean;
-  // `item`'s editable data-binding fields, already extracted and ready to
-  // render — one entry per element carrying a `data-binding` attribute,
-  // filtered down to non-<section> descendants (mirrors what the built-in
-  // Panel shows). Render each with FieldEditor (or your own UI reading
-  // `.bindings`/`.dataAttributes`) and wire its onChange to onFieldChange,
-  // which handles the underlying AST update — including showing an error
-  // Toast on a bad edit — the same way the built-in Panel does.
-  fields: DataAttrNode[];
-  onFieldChange: (params: { id: string; label: string; value: string }) => void;
-  FieldEditor: typeof FieldEditor;
+  // `item`'s editable data-binding fields, already flattened to one entry
+  // per bound property (across every non-<section> descendant carrying a
+  // `data-binding` attribute). Each entry carries the binding's `type` and
+  // current `value` plus an `onChange` wired straight into the same
+  // AST-update pipeline the built-in panel uses — including the error Toast
+  // on a bad edit. Switch on `type` to render your own control (an
+  // `<input>`, `<textarea>`, `<select>`, ...) instead of the built-in one.
+  bindings: PanelBinding[];
+}
+
+// One editable data-binding, flattened out of the selected section for a
+// custom renderPanel. Exposes just what a consumer needs to render its own
+// control — the declared `type`, the current `value`, and an `onChange`
+// that commits through Dnd's AST-update pipeline — so it never has to touch
+// DataAttrNode/parseBinding/getCurrentValue itself.
+export interface PanelBinding {
+  // `data-id` of the owning element — stable across edits.
+  id: string;
+  // Human-readable label from the binding definition.
+  label: string;
+  // The bound prop/attribute name (e.g. `children`, `src`, `color`).
+  property: string;
+  // The declared data-binding type — switch on this to pick a control
+  // (`string`/`url` -> <input>, `jsx`/`richtext` -> <textarea>, `boolean`
+  // -> checkbox, ...). `undefined` means a plain string binding.
+  type?: BindingType;
+  // Present when the binding defines a fixed option set (render a <select>).
+  options?: BindingOption[];
+  // Current serialized value — the same string the built-in field receives.
+  value: string;
+  // Commit a new value through the same AST-update pipeline the built-in
+  // panel uses (including the error Toast on a bad edit).
+  onChange: (value: string) => void;
 }
 
 export interface Props extends Omit<
@@ -400,6 +427,44 @@ const Dnd = ({
     }
   };
 
+  // Flattens the extracted `fields` (one DataAttrNode per element) down to
+  // one PanelBinding per bound property — the same walk the built-in
+  // FieldEditor/Node does internally (data-id + parsed data-binding +
+  // current value), but handed to a custom renderPanel as plain data so it
+  // can render its own controls. Kept in a useMemo keyed on `fields` alone;
+  // `onFieldChange` closes over `updatedCode`/`selectedItem` but is stable
+  // enough per render, and rebuilding on every render would defeat the memo
+  // guarding renderPanel's children.
+  const bindings = useMemo<PanelBinding[]>(() => {
+    return fields.flatMap(node => {
+      const dataId = node.dataAttributes.find(a => a.name === 'data-id')?.value;
+      const bindingAttr = node.dataAttributes.find(
+        a => a.name === 'data-binding',
+      )?.value;
+
+      if (!dataId || !bindingAttr) {
+        return [];
+      }
+
+      const parsed = node.bindings ?? parseBinding(bindingAttr);
+
+      return parsed.map(binding => ({
+        id: dataId,
+        label: binding.label,
+        property: binding.property,
+        type: binding.type,
+        options: binding.options,
+        value: getCurrentValue(node, binding.property),
+        onChange: (value: string) =>
+          onFieldChange({ id: dataId, label: binding.label, value }),
+      }));
+    });
+    // onFieldChange is intentionally omitted — it's recreated every render
+    // but only ever called from a user event, so closing over the latest
+    // one via the render that produced these bindings is fine.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fields]);
+
   useEffect(() => {
     if (frame?.scripts?.length) {
       preloadScripts(frame.scripts);
@@ -450,9 +515,7 @@ const Dnd = ({
         onMoveDown: () => moveSection(selectedId, 'down'),
         canMoveUp,
         canMoveDown,
-        fields,
-        onFieldChange,
-        FieldEditor,
+        bindings,
       });
     }
 

--- a/src/components/dnd/index.ts
+++ b/src/components/dnd/index.ts
@@ -1,5 +1,6 @@
 import DndImpl, {
   type PaletteRenderData,
+  type PanelBinding,
   type PanelRenderData,
   type Props,
 } from './dnd';
@@ -7,25 +8,22 @@ import DraggableItem, {
   type DraggableItemDragState,
   type DraggableItemProps,
 } from './draggable';
-import { FieldEditor, type FieldEditorProps } from './panel';
 
 type DndComponent = typeof DndImpl & {
   DraggableItem: typeof DraggableItem;
-  FieldEditor: typeof FieldEditor;
 };
 
 const Dnd = DndImpl as DndComponent;
 
 Dnd.DraggableItem = DraggableItem;
-Dnd.FieldEditor = FieldEditor;
 
-export { DraggableItem, FieldEditor };
+export { DraggableItem };
 export type {
   Props,
   PaletteRenderData,
   PanelRenderData,
+  PanelBinding,
   DraggableItemProps,
   DraggableItemDragState,
-  FieldEditorProps,
 };
 export default Dnd;

--- a/src/components/dnd/panel/index.ts
+++ b/src/components/dnd/panel/index.ts
@@ -1,2 +1,1 @@
 export { default } from './panel';
-export { default as FieldEditor, type FieldEditorProps } from './node';

--- a/src/pages/docs/dnd-custom-render/index.tsx
+++ b/src/pages/docs/dnd-custom-render/index.tsx
@@ -18,10 +18,13 @@ const DndCustomRenderDoc = () => {
           <code>Live.Dnd</code> accepts <code>renderPalette</code> and{' '}
           <code>renderPanel</code> to fully replace the built-in layouts.
           Drag-and-drop keeps working through the exported{' '}
-          <code>DraggableItem</code>, which owns the drag wiring, and editing a
-          section&apos;s <code>data-binding</code> fields keeps working through{' '}
-          <code>FieldEditor</code> (both passed into the render props below) —
-          only the surrounding markup is custom.
+          <code>DraggableItem</code>, which owns the drag wiring. For the panel,{' '}
+          <code>renderPanel</code> hands you <code>bindings</code> — one entry
+          per editable <code>data-binding</code> field, each with its{' '}
+          <code>type</code>, current <code>value</code>, and an{' '}
+          <code>onChange</code> — so you can render your own <code>input</code>/
+          <code>textarea</code>/<code>select</code> and still commit through the
+          same AST-update pipeline.
         </Typography.Paragraph>
       </Space>
       <Live>
@@ -71,9 +74,7 @@ const DndCustomRenderDoc = () => {
               onMoveDown,
               canMoveUp,
               canMoveDown,
-              fields,
-              onFieldChange,
-              FieldEditor,
+              bindings,
             }) => (
               <div className="space-y-3 p-4">
                 {item ? (
@@ -104,19 +105,62 @@ const DndCustomRenderDoc = () => {
                         />
                       </div>
                     </div>
-                    {fields.length ? (
-                      // FieldEditor owns rendering each data-binding field
-                      // (color pickers, rich text, selects, ...) — the
-                      // "custom" part here is just the surrounding layout;
-                      // swap this container for your own markup while
-                      // still getting the library's field editors for free.
-                      fields.map((field, index) => (
-                        <FieldEditor
-                          key={`${item.id}-${index}`}
-                          data={field}
-                          onChange={onFieldChange}
-                        />
-                      ))
+                    {bindings.length ? (
+                      // `bindings` is plain data — switch on each entry's
+                      // `type` to render whatever control you want. Here a
+                      // long-form `jsx`/`richtext` binding gets a <textarea>,
+                      // a fixed option set gets a <select>, and everything
+                      // else falls back to a plain <input>. onChange commits
+                      // through the same AST pipeline as the built-in panel.
+                      bindings.map((binding, index) => {
+                        const isMultiline =
+                          binding.type === 'jsx' || binding.type === 'richtext';
+
+                        return (
+                          <label
+                            key={`${binding.id}-${binding.property}-${index}`}
+                            className="block space-y-1"
+                          >
+                            <span
+                              className="text-xs font-semibold text-gray-700"
+                            >
+                              {binding.label}
+                            </span>
+                            {binding.options ? (
+                              <select
+                                className="w-full rounded border border-gray-300
+                                  px-2 py-1 text-sm"
+                                value={binding.value}
+                                onChange={e => binding.onChange(e.target.value)}
+                              >
+                                {binding.options.map(option => (
+                                  <option
+                                    key={option.value}
+                                    value={option.value}
+                                  >
+                                    {option.label}
+                                  </option>
+                                ))}
+                              </select>
+                            ) : isMultiline ? (
+                              <textarea
+                                className="w-full rounded border border-gray-300
+                                  px-2 py-1 text-sm"
+                                rows={3}
+                                defaultValue={binding.value}
+                                onBlur={e => binding.onChange(e.target.value)}
+                              />
+                            ) : (
+                              <input
+                                className="w-full rounded border border-gray-300
+                                  px-2 py-1 text-sm"
+                                defaultValue={binding.value}
+                                onBlur={e => binding.onChange(e.target.value)}
+                              />
+                            )}
+                          </label>
+                        );
+                      })
                     ) : (
                       <p className="text-xs text-gray-400">
                         No editable elements.


### PR DESCRIPTION
## 요약
커스텀 `renderPanel`이 `FieldEditor` 컴포넌트 대신 **평탄화된 `bindings` 데이터**를 받도록 변경. 소비자가 각 필드의 data-binding 타입을 보고 자기 `<input>`/`<textarea>`/`<select>`를 직접 렌더할 수 있음.

## 변경 API
`PanelRenderData`에서 `fields` / `onFieldChange` / `FieldEditor` 제거 → `bindings: PanelBinding[]` 추가.

```ts
interface PanelBinding {
  id: string;            // data-id
  label: string;
  property: string;
  type?: BindingType;    // string | url | jsx | richtext | boolean | color | date | ...
  options?: BindingOption[];
  value: string;         // 현재 값
  onChange: (value: string) => void; // built-in 패널과 동일한 AST 업데이트 파이프라인
}
```

```tsx
renderPanel={({ item, bindings, onDelete, onMoveUp, onMoveDown, canMoveUp, canMoveDown }) =>
  bindings.map(b =>
    b.options
      ? <select value={b.value} onChange={e => b.onChange(e.target.value)}>...</select>
      : <input defaultValue={b.value} onBlur={e => b.onChange(e.target.value)} />,
  )
}
```

## 세부
- `Dnd.FieldEditor` 정적 export 및 `FieldEditor`/`FieldEditorProps` 타입 제거 — **전부 미릴리스 API**(#153의 pending changeset)라 published 호환성 영향 없음
- 필드 추출 로직은 여전히 `Dnd`에서 수행 → built-in 패널과 custom `renderPanel`이 구현 공유
- `dnd-custom-render` 데모/문서를 실제 input/textarea/select 기반으로 갱신
- 미릴리스 changeset을 최종 `bindings` API로 재작성 (사라진 `FieldEditor`를 changelog에 남기지 않도록)

## 검증
- tsc / eslint / 테스트 215개 / 패키지 빌드(dts에 `PanelBinding` 노출, `FieldEditor` 제거 확인) 통과