### PR TITLE
🐛 fix(pkg): point exports/module/types at real tsdown output

### DIFF
--- a/.changeset/fix-package-exports.md
+++ b/.changeset/fix-package-exports.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fix the package `exports`, `module`, and `types` fields to point at the files the build actually emits. They still referenced a pre-`tsdown` layout (`./dist/index.js`, `./dist/utils.js`, `./dist/live-editor.css`, `.d.ts`), but the ESM build outputs `./dist/index.mjs`, per-entry `./dist/utils/index.mjs` / `./dist/utils/ast/index.mjs` / `./dist/utils/tailwind/index.mjs`, `./dist/style.css`, and `.d.mts` declarations. As a result, importing the package by name (`@jbpark/live-editor`, `/utils`, `/utils/ast`, `/utils/tailwind`, `/style.css`) failed to resolve for any consumer — the in-repo Vite demo only worked because it imports via the `~/.` source alias, sidestepping the package entry entirely. All five export subpaths now resolve against the real build output.

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   },
   "version": "1.12.0",
   "type": "module",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "description": "Interactive UI editor with real-time preview and drag-and-drop. Syncs canvas edits back to source code via AST transforms and renders the preview in an iframe for DOM/CSS isolation (not a security sandbox).",
   "keywords": [
     "live-editor",
@@ -41,22 +41,22 @@
   "packageManager": "pnpm@10.29.3",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
     },
     "./utils": {
-      "types": "./dist/utils.d.ts",
-      "import": "./dist/utils.js"
+      "types": "./dist/utils/index.d.mts",
+      "import": "./dist/utils/index.mjs"
     },
     "./utils/ast": {
-      "types": "./dist/utils/ast.d.ts",
-      "import": "./dist/utils/ast.js"
+      "types": "./dist/utils/ast/index.d.mts",
+      "import": "./dist/utils/ast/index.mjs"
     },
     "./utils/tailwind": {
-      "types": "./dist/utils/tailwind.d.ts",
-      "import": "./dist/utils/tailwind.js"
+      "types": "./dist/utils/tailwind/index.d.mts",
+      "import": "./dist/utils/tailwind/index.mjs"
     },
-    "./style.css": "./dist/live-editor.css"
+    "./style.css": "./dist/style.css"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## 문제
`exports` / `module` / `types`가 tsdown 이전 레이아웃을 가리켜, 패키지명으로 import하면 resolve 실패.

| 이전 (잘못됨) | 실제 산출물 |
|---|---|
| `./dist/index.js` / `.d.ts` | `./dist/index.mjs` / `.d.mts` |
| `./dist/utils.js` | `./dist/utils/index.mjs` |
| `./dist/utils/ast.js` | `./dist/utils/ast/index.mjs` |
| `./dist/utils/tailwind.js` | `./dist/utils/tailwind/index.mjs` |
| `./dist/live-editor.css` | `./dist/style.css` |

사내 Vite 데모는 `~/.` 소스 별칭으로 import해서 이 버그를 우회했지만, 패키지명으로 쓰는 실제 소비자(별도 docs 사이트 포함)는 전부 resolve 실패.

## 수정
5개 export 서브패스 + `module`/`types`를 실제 ESM 산출물에 매칭. `import.meta.resolve`로 `.` / `/utils` / `/utils/ast` / `/utils/tailwind` / `/style.css` 전부 정상 resolve 확인.

patch changeset 추가.