### PR TITLE
🐛 fix(website): exclude generated static/demos from typecheck

### DIFF
--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -8,5 +8,5 @@
     "ignoreDeprecations": "6.0",
     "strict": true
   },
-  "exclude": [".docusaurus", "build"]
+  "exclude": [".docusaurus", "build", "static/demos"]
 }


### PR DESCRIPTION
## Overview

`website/tsconfig.json` only excluded the two Docusaurus-generated directories (`.docusaurus`, `build`). `tsc` also picked up `static/demos` — a `pnpm build:demos` output — and blew the stack whenever `typecheck` ran after a demo build:

```
$ cd website && npx tsc --noEmit
RangeError: Maximum call stack size exceeded
```

The failure is order-dependent (clean checkout passes, post-`build:demos` fails), which makes it easy to mistake for a machine-specific problem.

## Change

```json
"exclude": [".docusaurus", "build", "static/demos"]
```

`static/demos` is a generated bundle directory (already gitignored, not tracked), so it belongs in `exclude` alongside `build`.

## Verification

- `static/demos` present (post `build:demos`): `npx tsc --noEmit` → exit 0 (previously stack overflow)

Closes #167
