### PR TITLE
👷 ci: build website in CI and pin pnpm to 10 everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -40,3 +38,12 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Install website dependencies
+        run: pnpm --dir website install
+
+      - name: Type check website
+        run: pnpm --dir website run typecheck
+
+      - name: Build website
+        run: pnpm --dir website build

--- a/README.ko.md
+++ b/README.ko.md
@@ -54,23 +54,23 @@ live-editor/
 
 - Peer dependencies: `react >=19`, `react-dom >=19`
 - Node.js: 20.x 이상
-- **pnpm**: 9.x 이상 ([Corepack](https://nodejs.org/api/corepack.html)으로 관리)
+- **pnpm**: 10.x 이상 ([Corepack](https://nodejs.org/api/corepack.html)으로 관리)
 
 ## 🚀 시작하기
 
 ### pnpm 설정 (권장)
 
-본 프로젝트는 **pnpm@9**를 [Corepack](https://nodejs.org/api/corepack.html)으로 관리합니다. Corepack을 활성화하고 지정된 버전을 적용하세요:
+본 프로젝트는 **pnpm@10**을 [Corepack](https://nodejs.org/api/corepack.html)으로 관리합니다. Corepack을 활성화하고 지정된 버전을 적용하세요:
 
 ```bash
 corepack enable
-corepack prepare pnpm@9.0.0 --activate
+corepack prepare pnpm@10.29.3 --activate
 ```
 
 또는 수동으로 설치:
 
 ```bash
-npm install -g pnpm@9
+npm install -g pnpm@10
 ```
 
 ### 설치

--- a/README.md
+++ b/README.md
@@ -54,23 +54,23 @@ live-editor/
 
 - Peer deps: `react >=19`, `react-dom >=19`
 - Node.js: 20.x or higher
-- **pnpm**: 9.x or higher (managed via [Corepack](https://nodejs.org/api/corepack.html))
+- **pnpm**: 10.x or higher (managed via [Corepack](https://nodejs.org/api/corepack.html))
 
 ## 🚀 Getting Started
 
 ### pnpm Setup (Recommended)
 
-This project uses **pnpm@9** with [Corepack](https://nodejs.org/api/corepack.html) for reproducibility. Enable Corepack and activate the specified pnpm version:
+This project uses **pnpm@10** with [Corepack](https://nodejs.org/api/corepack.html) for reproducibility. Enable Corepack and activate the specified pnpm version:
 
 ```bash
 corepack enable
-corepack prepare pnpm@9.0.0 --activate
+corepack prepare pnpm@10.29.3 --activate
 ```
 
 Or, if you prefer a manual install:
 
 ```bash
-npm install -g pnpm@9
+npm install -g pnpm@10
 ```
 
 ### Install

--- a/website/package.json
+++ b/website/package.json
@@ -47,5 +47,8 @@
   },
   "engines": {
     "node": ">=20.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["@swc/core", "core-js"]
   }
 }


### PR DESCRIPTION
## Overview

The docs site was added in `149ddd4`/`1a7ec1a`, but CI still only built the library — nothing installed or built `website/`. A broken docs build (or a regression like #167) could reach `main` unnoticed, since Vercel was the only thing exercising the site, i.e. after merge. On top of that, the declared pnpm version disagreed across the repo (`packageManager` `10.29.3` vs `pnpm/action-setup` `9` vs README `9.x`), which made `website/` installs fail in some environments.

## Changes

**Build `website/` in CI** (`.github/workflows/ci.yml`)

Added install + typecheck + build steps for `website/`, mirroring `vercel.json` so CI and the real deploy stay honest with each other:

```yaml
- name: Install website dependencies
  run: pnpm --dir website install
- name: Type check website
  run: pnpm --dir website run typecheck
- name: Build website
  run: pnpm --dir website build
```

**Pin pnpm to 10 everywhere**

- `pnpm/action-setup` bumped `v2` → `v4` with no explicit `version:`, so it inherits `packageManager` (`pnpm@10.29.3`) instead of hard-coding a conflicting `9`.
- `README.md` / `README.ko.md` updated to `pnpm@10` / `10.29.3`.

**Non-interactive installs on pnpm 10** (`website/package.json`)

```json
"pnpm": { "onlyBuiltDependencies": ["@swc/core", "core-js"] }
```

`@swc/core` and `core-js` come in transitively via `@docusaurus/faster`; without this, pnpm 10 ignores their build scripts (`ERR_PNPM_IGNORED_BUILDS`), which previously broke the website build.

## Verification

Local, pnpm 10.29.3:

- `pnpm --dir website install` → runs `@swc/core` / `core-js` postinstall without prompting; lockfile unchanged
- `pnpm --dir website run typecheck` → passes
- `pnpm --dir website build` → `[SUCCESS] Generated static files`

Closes #168
