### PR TITLE
🔒 fix(website): sandbox docs demo iframes to opaque origin

### DIFF
--- a/website/src/components/DemoFrame.tsx
+++ b/website/src/components/DemoFrame.tsx
@@ -30,5 +30,21 @@ export default function DemoFrame({
     background: 'var(--ifm-background-surface-color)',
   };
 
-  return <iframe src={url} title={title} loading="lazy" style={style} />;
+  // The demos are served from `static/demos/*` on the same origin as the docs
+  // site and run arbitrary reader-authored code (the Editor demo compiles and
+  // runs whatever is typed). Without a sandbox that makes the frame same-origin
+  // *and* unsandboxed, so demo code could reach `window.parent` and script the
+  // docs page. `sandbox="allow-scripts"` drops the frame into an opaque origin,
+  // which removes that parent access while still letting the self-contained
+  // bundles run. `allow-same-origin` is intentionally omitted — combined with
+  // `allow-scripts` it would hand the frame its origin back and defeat this.
+  return (
+    <iframe
+      src={url}
+      title={title}
+      loading="lazy"
+      style={style}
+      sandbox="allow-scripts"
+    />
+  );
 }


### PR DESCRIPTION
## Overview

`DemoFrame` embedded interactive demos in an `<iframe>` with no `sandbox` attribute. The demos are served from `static/demos/*` on the same origin as the docs site, so the framed document was same-origin **and** unsandboxed — code running in a demo could reach `window.parent` and script the docs page.

That matters here because the demos are exactly where arbitrary reader-authored code runs: the Editor demo compiles and runs whatever is typed. A reader pasting a snippet was enough to run it with full access to the parent docs page's DOM, `localStorage`, and cookies for that origin. It's also the one place the repo's own rule (`AGENTS.md`: run user code only inside the iframe) leans on the iframe for isolation while the iframe provided none.

## Change

```tsx
<iframe ... sandbox="allow-scripts" />
```

`allow-scripts` drops the frame into an opaque origin, which removes the `window.parent` access while still letting the self-contained bundles run. `allow-same-origin` is intentionally omitted — combined with `allow-scripts` it would hand the frame its origin back and defeat the fix.

The library's own `src/components/frame/iframe.tsx` is a different case — preview code there runs in the host window's realm, not inside the frame — and already documents that its `sandbox` prop is DOM/CSS isolation only, so it's left as-is.

## Verification

Against the production build (`pnpm --dir website build`):

- The emitted demo iframe carries `sandbox=allow-scripts`
- No demo bundle references `window.parent` / `window.top`, `document.cookie`, or `sessionStorage`
- The only `localStorage` use is `debug`'s `try { return localStorage } catch {}`, a no-op under an opaque origin — so no demo breaks

(Couldn't load the served build in a real browser here — the automation browser blocks localhost — so this was verified by static analysis of the build output.)

Closes #164
