### PR TITLE
🐛 fix(frame): convert vh units in inline styles and in-preview <style> tags

### DIFF
--- a/.changeset/fix-autoheight-inline-viewport-units.md
+++ b/.changeset/fix-autoheight-inline-viewport-units.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+The live editor now correctly handles viewport units in inline styles and author <style> elements, ensuring they resolve against the fixed probe height rather than the iframe's own height.

--- a/src/components/frame/iframe.tsx
+++ b/src/components/frame/iframe.tsx
@@ -12,7 +12,10 @@ import {
   estimatePositionedElementHeight,
   isVisuallyHidden,
 } from './measure';
-import { convertViewportUnits } from './viewport-units';
+import {
+  convertViewportUnits,
+  rewriteInlineViewportUnits,
+} from './viewport-units';
 
 export interface Props {
   title?: string;
@@ -437,6 +440,14 @@ const IFrame = ({
 
     withMeasurementOverrides(doc, () => {
       ensureContainerStyle(doc, probeHeight);
+
+      // Rewrite vh-family units the container context can't otherwise reach —
+      // inline `style` attributes and in-preview `<style>` tags — so they too
+      // resolve against the fixed probe height rather than the iframe's own
+      // (see rewriteInlineViewportUnits). Must run after ensureContainerStyle
+      // and before the reads below; it's idempotent, so the extra observer
+      // pass its first-render rewrites trigger converges immediately.
+      rewriteInlineViewportUnits(mountNode);
 
       // No 0px fold before measuring (that was the source of problem 1)
       // — with cq*-unit content now sized against the fixed probe height

--- a/src/components/frame/viewport-units.test.ts
+++ b/src/components/frame/viewport-units.test.ts
@@ -96,3 +96,25 @@ describe('convertViewportUnits (#132 stage 1)', () => {
     expect(convertViewportUnits('content: "100vh"')).toBe('content: "100cqh"');
   });
 });
+
+// #163: the container-context fix only reaches CSS *text* this component
+// injects. `rewriteInlineViewportUnits` extends it to two paths that carry a
+// viewport unit into the preview document directly — inline `style` attributes
+// and in-preview `<style>` tags — both of which convert via this same helper.
+// Applying the rewrite over the live DOM is thin glue (like `updateHeight`
+// itself) and, matching this repo's node test environment, is left untested at
+// that layer; these lock in the string transform each path depends on, using
+// the exact payloads the issue observed shipping unconverted.
+describe('convertViewportUnits — #163 embedded-unit payloads', () => {
+  it('converts an inline style attribute value (panel-edited hero)', () => {
+    expect(convertViewportUnits('height: 100vh; background: salmon;')).toBe(
+      'height: 100cqh; background: salmon;',
+    );
+  });
+
+  it('converts a rule inside an in-preview <style> tag', () => {
+    expect(convertViewportUnits('.hero{height:100vh;background:salmon}')).toBe(
+      '.hero{height:100cqh;background:salmon}',
+    );
+  });
+});

--- a/src/components/frame/viewport-units.ts
+++ b/src/components/frame/viewport-units.ts
@@ -75,3 +75,61 @@ export const convertViewportUnits = (css: string): string =>
     (_match, number: string, unit: string) =>
       number + UNIT_MAP[unit.toLowerCase()],
   );
+
+// `convertViewportUnits` only ever runs over CSS *text* that this component
+// controls the injection of — the parent-document `<style>` copies (syncStyle)
+// and the `styles` prop (see iframe.tsx). Two paths carry a viewport unit into
+// the preview document without passing through either, so the container-context
+// fix (#132) never reaches them and their `vh` still resolves against the
+// iframe's own height — re-creating the exact circularity #132 removed:
+//
+//   1. inline `style` attributes — the visual editor's panel edits produce
+//      these, so they're a common path here, not an edge case; and
+//   2. author `<style>` elements rendered *inside* the previewed component by
+//      React, which never pass through `applyStyle`/`styles`.
+//
+// This rewrites both in place, walking only nodes that could carry a match so
+// the pass stays cheap. It's meant to be called from `updateHeight` right after
+// the container style is (re)applied and before any height is read.
+//
+// Idempotent, and specifically non-perturbing once converted: a rewritten value
+// contains `cqh`/`cqmin`/`cqmax`, none of which match the `vh`/`vmin`/`vmax`
+// attribute selectors, so a second pass re-selects nothing; and each node is
+// written back only when its text actually changed, so an already-converted
+// document isn't mutated — which matters because the write itself would
+// otherwise re-trip the MutationObserver in iframe.tsx and loop.
+export const rewriteInlineViewportUnits = (root: HTMLElement): void => {
+  // `vh` as a substring already covers `svh`/`lvh`/`dvh`; `vmin`/`vmax` need
+  // their own terms. Case-insensitive so `100VH` inline is caught too.
+  const inlineTargets = root.querySelectorAll<HTMLElement>(
+    '[style*="vh" i], [style*="vmin" i], [style*="vmax" i]',
+  );
+
+  inlineTargets.forEach(el => {
+    const current = el.getAttribute('style');
+
+    if (current == null) {
+      return;
+    }
+
+    const converted = convertViewportUnits(current);
+
+    if (converted !== current) {
+      el.setAttribute('style', converted);
+    }
+  });
+
+  root.querySelectorAll<HTMLStyleElement>('style').forEach(styleEl => {
+    const current = styleEl.textContent;
+
+    if (!current) {
+      return;
+    }
+
+    const converted = convertViewportUnits(current);
+
+    if (converted !== current) {
+      styleEl.textContent = converted;
+    }
+  });
+};


### PR DESCRIPTION
## Overview

Follow-up to #132. The container-context approach (`html { container-type: size; height: <probe>px }`) only fixes viewport units in CSS *text* this component injects — the `syncStyle` copies and the `styles` prop, both of which run through `convertViewportUnits`. Two paths carry a viewport unit into the preview document **without** passing through either, so their `vh` still resolved against the iframe's own height, re-creating the exact circularity #132 removed:

- **inline `style` attributes** — the visual editor's panel edits produce these, so a `100vh` hero set inline latched onto whatever height it started at (150px in the repro) with no event to correct it; and
- **author `<style>` elements** rendered inside the previewed component by React, which never reach `applyStyle` / `styles`.

## Change

Add `rewriteInlineViewportUnits(root)` (in `viewport-units.ts`) and call it from `updateHeight`, right after `ensureContainerStyle` and before any height is read.

- Walks only nodes that could carry a match — `[style*="vh" i], [style*="vmin" i], [style*="vmax" i]` and `<style>` tags — so the pass stays cheap.
- Reuses `convertViewportUnits` for the transform.
- Writes a node back **only when its text actually changed**, so it's idempotent and doesn't perturb an already-converted document — which matters because the write itself would otherwise re-trip the `MutationObserver` in `iframe.tsx` and loop. The one extra observer pass its first-render rewrites trigger converges immediately (second pass selects `cqh`/`cqmin`/`cqmax`, which match none of the `vh`/`vmin`/`vmax` selectors).

The issue raised the in-preview `<style>` case as an explicit decision — it's **handled** here in the same pass rather than only documented, since it's the same root cause and the same transform.

## Tests

Extended `viewport-units.test.ts` with the exact inline-attribute and `<style>`-tag payloads the issue observed shipping unconverted (`height: 100vh; background: salmon;` → `…100cqh…`, `.hero{height:100vh;…}` → `…100cqh…`).

Applying the rewrite over a live DOM is thin glue (like `updateHeight` itself) and, matching this repo's `environment: 'node'` test setup (pure-function coverage only — e.g. `measure.ts`), is left untested at that layer. A DOM-application test would need introducing a DOM env (jsdom/happy-dom), which the repo doesn't currently use — happy to do that as a follow-up if you'd like it.

## Verification

- `pnpm test` → 217 passed (incl. 2 new cases)
- `pnpm exec tsc -b` → clean · `pnpm run lint` → clean · `pnpm run build` → complete

Live in-app visual check (the 150px→container-height repro) wasn't run: the automation browser here blocks localhost, so the Vite dev server couldn't be loaded. Verified by the unit/type/lint/build gates and the idempotency reasoning above.

Closes #163
