### PR TITLE
🐛 fix(website): point canonical url/homepage at the Vercel deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "jbpark",
   "license": "MIT",
-  "homepage": "https://pjb0811.github.io/live-editor",
+  "homepage": "https://live-editor.vercel.app",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pjb0811/live-editor.git"

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -13,7 +13,10 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://pjb0811.github.io',
+  // Vercel is the live deploy target (see vercel.json); GitHub Pages was
+  // retired in bff287d. `url` + `baseUrl` must match it, since canonical
+  // <link> tags, sitemap.xml, and Open Graph URLs are all derived from them.
+  url: 'https://live-editor.vercel.app',
   baseUrl: '/',
 
   organizationName: 'pjb0811',


### PR DESCRIPTION
## Overview

The docs site's `url`, `package.json` `homepage`, and the actual deploy target disagreed. Vercel is the only live deploy (`vercel.json`); GitHub Pages was retired in `bff287d`, yet `docusaurus.config.ts` still claimed `url: 'https://pjb0811.github.io'` and `package.json` `homepage` used the `/live-editor` project-site path form. Anything derived from `url` + `baseUrl` — canonical `<link>` tags, `sitemap.xml`, Open Graph URLs — shipped wrong, and silently, since `onBrokenLinks` is path-based and never catches it.

## Decision

**Vercel is canonical** (matches the only live deploy config, `vercel.json`), served from the root domain `https://live-editor.vercel.app`.

> Note: I picked the clean Vercel alias `https://live-editor.vercel.app` (verified it serves the site). If a custom domain is the intended canonical, it's a one-line swap of `url` + `homepage`.

## Changes

- `docusaurus.config.ts` `url` → `https://live-editor.vercel.app` (`baseUrl` stays `'/'`, correct for a root-domain deploy)
- `package.json` `homepage` → `https://live-editor.vercel.app`

`organizationName` / `projectName` are left as-is — they feed only `docusaurus deploy` (the unused Pages path), and `editUrl` is a hard-coded GitHub URL, so neither affects the canonical URLs.

## Verification

Against the production build (`pnpm --dir website build`, `onBrokenLinks: 'throw'`):

- `sitemap.xml` → `https://live-editor.vercel.app/...`
- canonical `<link>` and `og:url` → `https://live-editor.vercel.app/docs/...`
- no `pjb0811.github.io` left anywhere in `build/`

Closes #166
