### PR TITLE
📝 docs: refresh README tech stack and link the docs site

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -4,6 +4,8 @@
 
 실시간 프리뷰와 드래그 앤 드롭을 지원하는 인터랙티브 UI 에디터입니다. 캔버스에서의 편집 내용은 AST 변환을 통해 실제 소스 코드에 정확히 반영되며, 결과는 DOM/CSS 격리를 위해 iframe 안에서 렌더링됩니다. React 19와 TypeScript로 구현되었습니다. iframe은 보안 샌드박스가 아닙니다 — [보안 참고사항](#-보안-참고사항)을 확인하세요.
 
+📖 **문서 & 라이브 데모:** https://live-editor.vercel.app
+
 ## 📁 프로젝트 구조
 
 ```text
@@ -44,10 +46,10 @@ live-editor/
 
 ## 🧰 기술 스택
 
-- **Core**: React 19, TypeScript 5.8, Vite 7
+- **Core**: React 19, TypeScript 6, Vite 8
 - **DnD**: `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/modifiers`
 - **Editor**: `@uiw/react-codemirror` (VSCode 테마)
-- **UI/스타일**: Ant Design, Tailwind CSS 4
+- **UI/스타일**: `@jbpark/ui-kit`, `lucide-react`, Tailwind CSS 4
 - **변환**: Babel(standalone) 기반 브라우저 내 변환
 
 ## ⚙️ 요구 사항

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 An interactive editor for building UIs with real-time preview and drag‑and‑drop. Canvas edits are synced back to source code via AST transforms, and the result renders inside an iframe for DOM/CSS isolation. Built with React 19 and TypeScript. See [Security Notes](#-security-notes) — the iframe is not a security sandbox.
 
+📖 **Documentation & live demos:** https://live-editor.vercel.app
+
 ## 📁 Project Structure
 
 ```text
@@ -44,10 +46,10 @@ live-editor/
 
 ## 🧰 Tech Stack
 
-- **Core**: React 19, TypeScript 5.8, Vite 7
+- **Core**: React 19, TypeScript 6, Vite 8
 - **DnD**: `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/modifiers`
 - **Editor**: `@uiw/react-codemirror` with VSCode theme
-- **UI/Styling**: Ant Design, Tailwind CSS 4
+- **UI/Styling**: `@jbpark/ui-kit`, `lucide-react`, Tailwind CSS 4
 - **Transform**: Babel (standalone) for in-browser transforms
 
 ## ⚙️ Requirements


### PR DESCRIPTION
## Overview

The README tech-stack section still described the stack as it was before several recent changes, and the READMEs didn't link the docs site.

## Changes (both `README.md` and `README.ko.md`)

- **Tech stack corrected to match `package.json`:**
  - TypeScript 5.8 → **6** (`~6.0.3`)
  - Vite 7 → **8** (`^8.2.1`)
  - Ant Design → **`@jbpark/ui-kit` + `lucide-react`** — antd was dropped in `d10cb98` and is no longer a dependency at all, so listing it was the one entry that actively misled
- **Docs link added** at the top of both READMEs, pointing at the Docusaurus site using the canonical URL settled in #166 (`https://live-editor.vercel.app`).

pnpm version instructions in the same section were already fixed in #168.

Closes #169
