### PR TITLE
🐛 fix(website): update canonical url to the live-editor-lab Vercel alias

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -4,7 +4,7 @@
 
 실시간 프리뷰와 드래그 앤 드롭을 지원하는 인터랙티브 UI 에디터입니다. 캔버스에서의 편집 내용은 AST 변환을 통해 실제 소스 코드에 정확히 반영되며, 결과는 DOM/CSS 격리를 위해 iframe 안에서 렌더링됩니다. React 19와 TypeScript로 구현되었습니다. iframe은 보안 샌드박스가 아닙니다 — [보안 참고사항](#-보안-참고사항)을 확인하세요.
 
-📖 **문서 & 라이브 데모:** https://live-editor.vercel.app
+📖 **문서 & 라이브 데모:** https://live-editor-lab.vercel.app
 
 ## 📁 프로젝트 구조
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An interactive editor for building UIs with real-time preview and drag‑and‑drop. Canvas edits are synced back to source code via AST transforms, and the result renders inside an iframe for DOM/CSS isolation. Built with React 19 and TypeScript. See [Security Notes](#-security-notes) — the iframe is not a security sandbox.
 
-📖 **Documentation & live demos:** https://live-editor.vercel.app
+📖 **Documentation & live demos:** https://live-editor-lab.vercel.app
 
 ## 📁 Project Structure
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "jbpark",
   "license": "MIT",
-  "homepage": "https://live-editor.vercel.app",
+  "homepage": "https://live-editor-lab.vercel.app",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pjb0811/live-editor.git"

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -16,7 +16,7 @@ const config: Config = {
   // Vercel is the live deploy target (see vercel.json); GitHub Pages was
   // retired in bff287d. `url` + `baseUrl` must match it, since canonical
   // <link> tags, sitemap.xml, and Open Graph URLs are all derived from them.
-  url: 'https://live-editor.vercel.app',
+  url: 'https://live-editor-lab.vercel.app',
   baseUrl: '/',
 
   organizationName: 'pjb0811',


### PR DESCRIPTION
## Overview

Follow-up to #166. The canonical docs URL is the **live-editor-lab** Vercel alias, not the plain `live-editor` one guessed in #166. Point every place that carries it at `https://live-editor-lab.vercel.app`:

- `website/docusaurus.config.ts` `url`
- `package.json` `homepage`
- `README.md` / `README.ko.md` docs link

## Verification

Against the production build (`pnpm --dir website build`):

- `sitemap.xml` and canonical `<link>` / `og:url` → `https://live-editor-lab.vercel.app/...`
- no `//live-editor.vercel.app` (old alias) left anywhere in `build/`

Refs #166
