### PR TITLE
🐛 fix: drop Tailwind preflight leak from published style.css

### DIFF
--- a/.changeset/fix-index-css-preflight-leak.md
+++ b/.changeset/fix-index-css-preflight-leak.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Tailwind CSS is now imported without its global preflight layer, allowing host pages to maintain their own spacing and typography settings.

--- a/demos/shared.css
+++ b/demos/shared.css
@@ -1,3 +1,10 @@
+/*
+ * Unlike src/index.css, this keeps full `@import 'tailwindcss'` (preflight
+ * included). Each demo is a standalone document rendered inside its own
+ * iframe (see website/src/components/DemoFrame.tsx), so the reset only
+ * applies to that demo's own document — it never leaks onto a host page.
+ * Don't remove preflight here to "match" src/index.css.
+ */
 @import 'tailwindcss';
 
 /*

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,18 @@
-@import 'tailwindcss';
+/*
+ * Import Tailwind WITHOUT its global preflight (base) layer.
+ *
+ * `@import 'tailwindcss'` also pulls in preflight — a document-wide reset
+ * (`*, ::before, ::after { margin: 0; box-sizing: border-box; border: 0 }`,
+ * bare-tag resets on headings/lists/buttons/etc). Shipping that in
+ * `dist/style.css` flattens the spacing/typography of any host page that
+ * imports it (e.g. a Docusaurus/Infima site), which is a leak, not our job.
+ *
+ * Consumers that run their own Tailwind still get preflight from their own
+ * build, so this library's chrome is unaffected either way.
+ */
+@layer theme, base, components, utilities;
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/utilities.css' layer(utilities);
 
 @layer utilities {
   /* 편집 모드 기본 설정 */


### PR DESCRIPTION
## Summary
- `src/index.css` now imports `tailwindcss/theme.css` + `tailwindcss/utilities.css` individually instead of the bare `@import 'tailwindcss'`, which also pulled in preflight (a document-wide reset)
- Preflight was shipping in `dist/style.css` and the docs demo bundles, resetting the host page's typography for any consumer (e.g. a Docusaurus site)
- `demos/shared.css` keeps preflight (each demo is a standalone iframe document, so the reset is safe there) with a comment explaining why, to prevent it being "fixed" to match `src/index.css` by accident
- Follows the same pattern `@jbpark/ui-kit` already uses for this exact problem

Fixes #180

## Test plan
- [x] `pnpm build` — confirmed `dist/style.css` no longer contains preflight markers (`font-size: inherit`, `box-sizing: border-box`: 0 occurrences), while the library's own `[data-editor-mode]` utility rules are intact (8 occurrences)
- [x] `pnpm build:demos` — confirmed the demo bundle (`frame-*.css`) still contains preflight, as intended