### PR TITLE
🔧 chore: correct changeset severity for preflight fix to patch

### DIFF
--- a/.changeset/fix-index-css-preflight-leak.md
+++ b/.changeset/fix-index-css-preflight-leak.md
@@ -1,5 +1,5 @@
 ---
-'@jbpark/live-editor': minor
+'@jbpark/live-editor': patch
 ---
 
 Tailwind CSS is now imported without its global preflight layer, allowing host pages to maintain their own spacing and typography settings.


### PR DESCRIPTION
## Summary
- The preflight-leak fix in #182 was auto-classified as a `minor` changeset, but it's a backward-compatible bug fix (no new API/feature), so it should be `patch` per this repo's existing convention (e.g. 1.8.1's ErrorBoundary stale-error fix)

## Test plan
- N/A — changeset metadata only, no code change