### PR TITLE
🔧 chore: fix pnpm version/config inconsistencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       # v6+ is required for npm's OIDC "Trusted Publishing" used below.
       # No built-in `cache: 'pnpm'` here on purpose — this job skips

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -20,9 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "engines": {
     "node": ">=20",
-    "pnpm": ">=9"
+    "pnpm": ">=10"
   },
   "packageManager": "pnpm@10.29.3",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -141,10 +141,5 @@
       "bash -c 'pnpm lint'",
       "bash -c 'tsc -b'"
     ]
-  },
-  "pnpm": {
-    "overrides": {
-      "@codemirror/state": "^6.7.1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  '@codemirror/state': ^6.7.1

--- a/website/package.json
+++ b/website/package.json
@@ -48,7 +48,5 @@
   "engines": {
     "node": ">=20.0"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": ["@swc/core", "core-js"]
-  }
+  "packageManager": "pnpm@10.29.3"
 }

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - '@swc/core'
+  - core-js


### PR DESCRIPTION
## Summary
- `publish.yml`/`version.yml` still pinned pnpm 9 via `pnpm/action-setup@v2` while `ci.yml` already moved to the version-less v4 form that follows `packageManager` (#168) — now all three workflows are consistent, with `packageManager` as the single source of truth
- `package.json`'s `"pnpm"` field (overrides/onlyBuiltDependencies) is no longer read by pnpm 10.29+; moved both to `pnpm-workspace.yaml` (root) and `website/pnpm-workspace.yaml` (website keeps its own separate lockfile/install boundary)
- Added `packageManager` to `website/package.json` so the pnpm major used there isn't left to whatever is on PATH
- Bumped `engines.pnpm` from `>=9` to `>=10` to match what's actually pinned

Fixes #185, Fixes #186

## Test plan
- [x] Clean `pnpm install` (root) and `pnpm --dir website install` — no "ignored pnpm field" warnings, no stray scaffolded files, `pnpm-lock.yaml`/`website/pnpm-lock.yaml` unchanged
- [x] `pnpm why @codemirror/state` confirms the `^6.7.1` override still applies across every dependent
- [x] `@swc/core`/`core-js` build scripts run without needing `pnpm approve-builds`
- [x] `pnpm lint` / `pnpm exec tsc -b` / `pnpm run build` / `pnpm --dir website typecheck` / `pnpm --dir website build` all pass