### PR TITLE
🐛 fix: add CORS header so sandboxed docs demo iframes can load

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,13 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm --dir website build",
   "outputDirectory": "website/build",
-  "installCommand": "pnpm install && pnpm --dir website install"
+  "installCommand": "pnpm install && pnpm --dir website install",
+  "headers": [
+    {
+      "source": "/demos/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- `DemoFrame` sandboxes the demo iframe with `sandbox="allow-scripts"` (no `allow-same-origin`, per #164), which drops it into an opaque origin
- The demo bundles boot via `<script type="module">`, which is always fetched in CORS mode — from an opaque origin that goes out as `Origin: null`, and the static host served `/demos/assets/*` with no `Access-Control-Allow-Origin` header, so the browser blocked the entry script
- Every embedded demo on the docs site (`dnd`, `editor-mode`, `preview-modes`, `custom-editor`, `custom-palette-panel`) rendered as a blank box
- Adds `Access-Control-Allow-Origin: *` for `/demos/(.*)` in `vercel.json` — scoped to just the public demo bundles, sandbox attribute unchanged

Fixes #184

## Test plan
- [x] `pnpm build:demos` / `pnpm --dir website build` / `pnpm --dir website typecheck` / `pnpm lint` / `tsc -b` — all pass
- [x] Verified the header rule's mechanism locally: served `website/build` through a static server that applies the same `/demos/*` → `Access-Control-Allow-Origin: *` rule, and confirmed with `curl -H "Origin: null"` that the header is present on `/demos/assets/*` responses and absent elsewhere (e.g. `/docs/intro/`) — this is the exact condition the browser checks before allowing the opaque-origin module script fetch