### PR TITLE
🐛 fix: forward `code` into Client so `frame` isn't ignored

### DIFF
--- a/.changeset/fix-preview-frame-with-code.md
+++ b/.changeset/fix-preview-frame-with-code.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Dynamic Tailwind CSS is now supported in the preview, allowing for real-time styling updates.

--- a/src/components/preview/client.tsx
+++ b/src/components/preview/client.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useError, usePreview } from '~/components/context/states';
 import LiveError from '~/components/error';
 import Frame, { type FrameProps } from '~/components/frame';
 import { baseModules, cn, compile } from '~/utils';
+import { generateTailwindCSS } from '~/utils/tailwind';
 
 import { type Props } from './preview';
 
@@ -16,6 +17,7 @@ const Client = ({
   props = {},
   modules = {},
   frame,
+  dynamicTailwind = false,
   provider,
 }: Props) => {
   const { code } = usePreview();
@@ -26,6 +28,26 @@ const Client = ({
 
   const mergedModules = { ...baseModules, ...modules };
   const effectiveCode = _code || code;
+
+  const [dynamicCSS, setDynamicCSS] = useState('');
+
+  useEffect(() => {
+    if (!effectiveCode || !dynamicTailwind) {
+      return;
+    }
+
+    let cancelled = false;
+
+    generateTailwindCSS(effectiveCode).then(css => {
+      if (!cancelled) {
+        setDynamicCSS(css);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [effectiveCode, dynamicTailwind]);
 
   let module = null;
 
@@ -81,6 +103,9 @@ const Client = ({
                 {renderProvider(
                   <LiveError.Guard onError={e => setError(e.message)}>
                     <Component {...componentProps} container={container} />
+                    {dynamicTailwind && dynamicCSS && (
+                      <style>{dynamicCSS}</style>
+                    )}
                   </LiveError.Guard>,
                 )}
               </LiveError.Boundary>
@@ -106,6 +131,7 @@ const Client = ({
             {renderProvider(
               <LiveError.Guard onError={e => setError(e.message)}>
                 <Component {...componentProps} />
+                {dynamicTailwind && dynamicCSS && <style>{dynamicCSS}</style>}
               </LiveError.Guard>,
             )}
           </LiveError.Boundary>

--- a/src/components/preview/preview.tsx
+++ b/src/components/preview/preview.tsx
@@ -1,8 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import type React from 'react';
 
-import { baseModules, compile } from '../../utils';
-import { generateTailwindCSS } from '../../utils/tailwind';
-import LiveError from '../error';
 import type { FrameProps } from '../frame';
 import Client from './client';
 
@@ -17,6 +14,12 @@ export interface Props extends React.ComponentPropsWithRef<'div'> {
   provider?: (children: React.ReactNode) => React.ReactNode;
 }
 
+// A thin wrapper around Client, which does the actual compiling, error
+// handling, and frame wrapping. This used to have its own duplicate
+// compile-and-render branch for the `code` prop that never wrapped its
+// output in <Frame>, so `frame` was silently ignored whenever `code` was
+// passed — see #187. Client already handles `code` (falling back to
+// context when absent) and `frame`, so there is only one render path now.
 const Preview = ({
   code,
   props = {},
@@ -25,104 +28,12 @@ const Preview = ({
   provider,
   ...restProps
 }: Props) => {
-  const [runtimeError, setRuntimeError] = useState<string | null>(null);
-  const [dynamicCSS, setDynamicCSS] = useState('');
-  // "Adjusting state when a prop changes" pattern (React docs) rather than
-  // a useEffect: resets synchronously within the same render `code`
-  // changes in, before Guard/Component render at all, so there's no
-  // passive-effect-ordering window where a genuinely new runtime error
-  // could get wiped back out right after Guard's onError sets it.
-  const [prevCode, setPrevCode] = useState(code);
-
-  if (code !== prevCode) {
-    setPrevCode(code);
-    setRuntimeError(null);
-  }
-
-  const renderProvider = (component: React.ReactNode) => {
-    return provider ? provider(component) : component;
-  };
-
-  useEffect(() => {
-    if (!code || !dynamicTailwind) {
-      return;
-    }
-
-    let cancelled = false;
-
-    generateTailwindCSS(code).then(css => {
-      if (!cancelled) {
-        setDynamicCSS(css);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [code, dynamicTailwind]);
-
-  if (runtimeError) {
-    return (
-      <LiveError
-        title="Runtime Error"
-        message={runtimeError}
-        className="mx-5 mt-25"
-        onReset={() => setRuntimeError(null)}
-      />
-    );
-  }
-
-  if (code) {
-    let module;
-
-    try {
-      module = compile(code, { ...baseModules, ...modules });
-    } catch (e) {
-      module = {
-        exports: {},
-        error: e instanceof Error ? e.message : 'Module transformation error',
-      };
-    }
-
-    if (module.error) {
-      return (
-        <LiveError
-          title="Compile Error"
-          message={module.error}
-          className="mx-5 mt-25"
-        />
-      );
-    }
-
-    const Component = module.exports.default;
-
-    if (!Component) {
-      return (
-        <LiveError message="Component not found." className="mx-5 mt-25" />
-      );
-    }
-
-    return (
-      <LiveError.Boundary
-        resetKeys={[code]}
-        fallback={message => (
-          <LiveError title="Rendering Error" message={message} />
-        )}
-      >
-        {renderProvider(
-          <LiveError.Guard onError={e => setRuntimeError(e.message)}>
-            <Component {...props} />
-            {dynamicTailwind && dynamicCSS && <style>{dynamicCSS}</style>}
-          </LiveError.Guard>,
-        )}
-      </LiveError.Boundary>
-    );
-  }
-
   return (
     <Client
+      code={code}
       props={props}
       modules={modules}
+      dynamicTailwind={dynamicTailwind}
       provider={provider}
       {...restProps}
     />


### PR DESCRIPTION
## Summary
- `Preview` had two mutually exclusive render paths: a `code`-truthy branch that compiled and rendered inline (never wrapping in `<Frame>`), and a fallback to `Client` (which does handle `frame`) only reached when `code` was falsy — so `<Live.Preview code={...} frame={{mode: 'iframe'}}/>` silently isolated nothing
- The Preview Modes docs page and its demo (`demos/preview-modes/PreviewModesDemo.tsx`) both always pass `code`, so neither ever isolated anything despite claiming to demonstrate iframe/shadow isolation
- `Client` already compiles `code` (falling back to context when absent) and wraps output in `<Frame>` when `frame` is set, so `Preview` is now a thin wrapper forwarding everything to `Client` — one render path instead of two divergent ones
- Moved `dynamicTailwind`'s effect/state from `Preview` into `Client` (keyed off `effectiveCode`), since it only existed on the old code-only branch — `dynamicTailwind` and `frame` were mutually exclusive before this fix

## Deliberate behavior change (documented, not silent)
The old code branch had its own local runtime-error state that unconditionally replaced the tree with a full-page error message. That's **not** carried over — `Client` already has an equivalent mechanism (shared error context + `LiveError.Runtime`), gated by `showError` like every other `Client` consumer. This makes error-display behavior consistent across both paths rather than preserving a divergence that was itself part of the bug. The two current `code`-prop call sites (preview-modes docs/demo) render a static sample with no expected runtime error, so this isn't a visible change in practice today.

## Not included
A rendering regression test (`frame` renders an `<iframe>`), which the issue suggested. This repo currently has no React component-rendering test infrastructure — vitest is configured `node`-only, `.test.ts` files only, no jsdom/testing-library. `Frame`/`IFrame` also depend on `ResizeObserver`/`MutationObserver`/iframe `load` events that would need polyfilling in that environment. Worth adding, but it's a larger, separate piece of infrastructure work rather than something to bolt onto this fix.

Fixes #187

## Test plan
- [x] `pnpm lint` / `tsc -b` / `pnpm run test` (217 tests) / `pnpm run build` / `pnpm run build:demos` — all pass