### PR TITLE
📝 docs: fix install instructions and typescript peer range

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "prettier": "^3.8.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
-    "typescript": "~5.8.3"
+    "typescript": "~6.0.3"
   },
   "devDependencies": {
     "@changesets/cli": "^3.0.0",

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -12,8 +12,13 @@ isolation.
 
 ## Install
 
+`@jbpark/ui-kit` is a regular dependency and gets installed automatically.
+`prettier`, `typescript`, `react`, and `react-dom` are peer dependencies —
+required, but not auto-installed by every package manager (npm 7+ does;
+pnpm and yarn don't by default):
+
 ```bash
-npm install @jbpark/live-editor @jbpark/ui-kit
+npm install @jbpark/live-editor prettier typescript react react-dom
 ```
 
 Import the stylesheet once, near your app root:


### PR DESCRIPTION
## Summary
- `website/docs/intro.md` told readers to install `@jbpark/ui-kit` (already a regular `dependency`, installed automatically) while omitting `prettier` and `typescript` — both `peerDependencies` that `dist/index.js` imports statically at the top level, so a missing one isn't a degraded feature, the whole package fails to load
- npm 7+ auto-installs peers so this was invisible there, but pnpm and yarn (default settings) don't
- `peerDependencies.typescript` was pinned to `~5.8.3`, excluding the `~6.0.3` this repo actually builds/tests with — corrected to `~6.0.3` so the install line can now document it accurately (documenting an install command with a range this repo doesn't itself satisfy would've been its own kind of surprising, per the issue)
- Install line now lists `prettier`/`typescript`/`react`/`react-dom` explicitly, with a note on why they're not auto-installed everywhere

## Not included
A tarball-install smoke test (installs the built package into an empty project with a strict package manager) that the issue suggested as a "worth adding" way to catch this class of bug automatically. Left for #190, which restructures the dependency architecture this touches (dropping the `typescript` peer, subpath exports, `sideEffects`) — a more natural place to add it once the export shape settles.

Fixes #188

## Test plan
- [x] `pnpm lint` / `tsc -b` / `pnpm run test` (217 tests) / `pnpm --dir website build` — all pass, no lockfile changes from the peer range correction