### PR TITLE
📝 docs: fix docs/API mismatches found in a full pass over website/docs

### DIFF
--- a/.changeset/docs-api-accuracy-sweep.md
+++ b/.changeset/docs-api-accuracy-sweep.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+New backward-compatible features and exports are added to the UI editor.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,10 +3,16 @@ import '@jbpark/ui-kit/style.css';
 import './index.css';
 
 import Context from './components/context';
-import LiveDnd from './components/dnd';
-import LiveEditor from './components/editor';
+import LiveDnd, {
+  type PaletteRenderData,
+  type PanelBinding,
+  type PanelRenderData,
+} from './components/dnd';
+import LiveEditor, { type EditorRenderData } from './components/editor';
 import LiveError from './components/error';
+import { type FrameProps } from './components/frame';
 import LivePreview from './components/preview';
+import type { Section } from './types';
 
 const App = ({ children }: { children?: React.ReactNode }) => {
   return <Context>{children}</Context>;
@@ -22,6 +28,15 @@ export {
   LiveRenderer,
   App as LiveProvider,
   //
+};
+
+export type {
+  PaletteRenderData,
+  PanelBinding,
+  PanelRenderData,
+  EditorRenderData,
+  FrameProps,
+  Section,
 };
 
 App.Preview = LivePreview;

--- a/website/docs/custom-editor.mdx
+++ b/website/docs/custom-editor.mdx
@@ -41,6 +41,16 @@ export default function CustomEditor() {
 }
 ```
 
-The `renderEditor` render prop receives the current `value` and an `onChange`
-callback. Wire those into any editing surface you like (a `<textarea>`, Monaco,
-your own component) — the shared preview stays in sync through `Live`'s context.
+The `renderEditor` render prop receives an `EditorRenderData` object with
+three fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `value` | `string` | Current code. |
+| `onChange` | `(value: string) => void` | Commit an edit — wire this into your editing surface's own change handler. |
+| `formatCode` | `(code: string) => Promise<string>` | The same prettier-based formatting the built-in editor's Cmd+S uses. Call it to offer format-on-save without reimplementing prettier wiring yourself. |
+
+Wire `value`/`onChange` into any editing surface you like (a `<textarea>`,
+Monaco, your own component) — the shared preview stays in sync through
+`Live`'s context. `formatCode` is entirely optional; the example above skips
+it and just does a raw `<textarea>` with no formatting.

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -15,8 +15,14 @@ drag-and-drop and field editing keep working exactly as before.
 
 ## Custom palette
 
-`renderPalette` receives the palette `items`, an `onAdd` callback, the
-`DraggableItem` component that owns the drag wiring, and `isMobile`:
+`renderPalette` receives a `PaletteRenderData` object:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `items` | `Section[]` | The palette's available sections. |
+| `onAdd` | `(item: Section) => void` | Add a section to the canvas. |
+| `DraggableItem` | component | Owns the drag wiring — wrap your own markup in it so items stay draggable. |
+| `isMobile` | `boolean` | `true` when the palette is rendering inside the mobile Drawer, where a tap can't be a failed drag attempt (there's nothing to drag onto — the canvas is stacked behind the Drawer) and native dblclick synthesis from double-tap is unreliable on touch. Treat a single click/tap as "add" here instead of relying on `onDoubleClick`, as the example below does.
 
 ```tsx
 <Live.Dnd
@@ -46,19 +52,47 @@ drag-and-drop and field editing keep working exactly as before.
 
 ## Custom panel
 
-`renderPanel` hands you `bindings` — the selected section's editable
-`data-binding` fields, flattened to one entry per bound property. Each entry
-carries its `type`, current `value`, `options` (when present), and an
-`onChange` wired straight into the same AST-update pipeline the built-in panel
-uses. Switch on `binding.type` to render your own control:
+`renderPanel` receives a `PanelRenderData` object:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `item` | `Section?` | The currently selected section, or `undefined` if none is selected. |
+| `bindings` | `PanelBinding[]` | The selected section's editable `data-binding` fields, flattened to one entry per bound property. See the table below. |
+| `onChange` | `(next: Partial<Section>) => void` | Update fields of the selected section directly (not through a binding). |
+| `onDelete` | `(id: string) => void` | Delete a section by id. |
+| `onMoveUp` | `() => void` | Move the selected section up. Alternative to drag-reordering — needed because the canvas sits behind the mobile Drawer this panel renders in, so there's nothing visible to drag onto there. |
+| `onMoveDown` | `() => void` | Move the selected section down, same rationale as `onMoveUp`. |
+| `canMoveUp` | `boolean` | Whether `onMoveUp` would do anything right now — disable your move-up control when `false`. |
+| `canMoveDown` | `boolean` | Whether `onMoveDown` would do anything right now — disable your move-down control when `false`. |
+
+`bindings` carries each field's `type`, current `value`, `options` (when
+present), and an `onChange` wired straight into the same AST-update pipeline
+the built-in panel uses. Switch on `binding.type` to render your own control:
 
 ```tsx
 <Live.Dnd
   value={value}
   onChange={setValue}
-  renderPanel={({ item, bindings, onDelete }) => (
+  renderPanel={({
+    item,
+    bindings,
+    onDelete,
+    onMoveUp,
+    onMoveDown,
+    canMoveUp,
+    canMoveDown,
+  }) => (
     <div>
-      <header>{item?.name}</header>
+      <header>
+        {item?.name}
+        <button disabled={!canMoveUp} onClick={onMoveUp}>
+          Up
+        </button>
+        <button disabled={!canMoveDown} onClick={onMoveDown}>
+          Down
+        </button>
+        {item && <button onClick={() => onDelete(item.id)}>Delete</button>}
+      </header>
       {bindings.map(binding => (
         <label key={`${binding.id}-${binding.property}`}>
           <span>{binding.label}</span>
@@ -98,7 +132,19 @@ uses. Switch on `binding.type` to render your own control:
 | `id` | `string` | `data-id` of the owning element (stable across edits). |
 | `label` | `string` | Human-readable label from the binding definition. |
 | `property` | `string` | The bound prop/attribute name. |
-| `type` | `BindingType?` | `string` / `url` / `jsx` / `richtext` / `boolean` / `color` / `date` / … — switch on this to pick a control. |
+| `type` | `BindingType?` | The declared data-binding type — switch on this to pick a control. `undefined` means a plain string binding. See the full list below. |
 | `options` | `BindingOption[]?` | Present when the binding defines a fixed option set (render a `<select>`). |
 | `value` | `string` | Current serialized value. |
 | `onChange` | `(value: string) => void` | Commit an edit through the same AST-update pipeline (including the error toast on a bad edit). |
+
+`BindingType` is a closed union of 12 values, since a `renderPanel` is
+expected to switch on it exhaustively: `array`, `object`, `string`, `number`,
+`boolean`, `color`, `jsx`, `richtext`, `date`, `url`, `icon-picker`,
+`asset-picker`.
+
+`BindingType` and `BindingOption` aren't exported from the package root —
+import them from the `utils/ast` subpath instead:
+
+```ts
+import type { BindingOption, BindingType } from '@jbpark/live-editor/utils/ast';
+```

--- a/website/docs/editor-mode.mdx
+++ b/website/docs/editor-mode.mdx
@@ -8,8 +8,9 @@ import DemoFrame from '@site/src/components/DemoFrame';
 # Editor Mode
 
 `Live.Editor` and `Live.Preview` share code through `Live`'s context — edit
-either side, the other updates automatically. No manual wiring between them is
-needed.
+in the editor and the preview updates automatically. No manual wiring between
+them is needed. (The preview itself isn't an editing surface — only
+`Live.Editor` writes to the shared code.)
 
 <DemoFrame src="demos/editor-mode/" title="Live Editor — Editor Mode demo" height={620} />
 
@@ -47,7 +48,13 @@ export default function EditorMode() {
 ```
 
 - `Live.Editor` is a controlled CodeMirror surface — pass `value` / `onChange`.
+  It only pushes to the shared preview code `debounce` ms after you stop
+  typing (default `1000`) — a full second of lag is expected, not a bug.
+  Pass `debounce={0}` for immediate updates.
 - `Live.Preview` compiles the shared code and renders it; `showError` surfaces
   compile/runtime errors inline.
 - `frame.syncStyle` copies the host document's stylesheets into the iframe so
   the preview looks like the rest of your app.
+
+See [Overview](./intro.md#props-reference) for the full prop list on both
+components.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -63,6 +63,93 @@ export default function Example() {
 }
 ```
 
+## How Tailwind reaches the preview
+
+Every sample on this site uses Tailwind utility classes
+(`className="p-6 space-y-2"`), and none of them work for free — the code a
+reader types is compiled and rendered at runtime, so there's no build step
+that could have generated CSS for classes that don't exist yet when the app
+first loads. There are two ways to make them actually apply:
+
+**`dynamicTailwind` (simplest)** — pass it to `Live.Preview` and it scans the
+current code for `className`/`cn(...)` usages, compiles just those utilities
+with the real `tailwindcss` engine, and injects the result as a `<style>` tag
+next to the rendered output. Works with or without `frame`:
+
+```tsx
+<Live.Preview dynamicTailwind frame={{ mode: 'iframe' }} />
+```
+
+**`frame.scripts` + a Tailwind runtime (what this site's own demos use)** —
+load a standalone Tailwind runtime script into the iframe via `frame.scripts`
+so the iframe's own document processes its own classes live:
+
+```tsx
+<Live.Preview
+  frame={{
+    mode: 'iframe',
+    syncStyle: true,
+    scripts: ['/path/to/tailwindcss-runtime.js'],
+  }}
+/>
+```
+
+`frame.syncStyle` alone does **not** do this — it only copies the host page's
+_already-compiled_ stylesheet into the iframe, which by definition can't
+contain utilities that only appear in code the reader types at runtime.
+`scripts`/`dynamicTailwind` are unrelated to and unaffected by `syncStyle`.
+
+Neither approach works under `frame.mode: 'shadow'` — see
+[Preview Modes](./preview-modes.mdx) for what does and doesn't apply there.
+
+## Props reference
+
+### `Live.Preview`
+
+| Prop              | Type                                  | Description                                                                                                                                                                                                                                                                |
+| ----------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `code`            | `string?`                             | Explicit code to compile and render. Omit it to render whatever's in `Live`'s shared context instead (the usual `Live.Editor` + `Live.Preview` pairing).                                                                                                                   |
+| `showError`       | `boolean?`                            | Show compile/runtime errors inline instead of failing silently.                                                                                                                                                                                                            |
+| `frame`           | `boolean \| FrameProps?`              | Isolation strategy — see [Preview Modes](./preview-modes.mdx).                                                                                                                                                                                                             |
+| `dynamicTailwind` | `boolean?`                            | Generate Tailwind CSS for the current code at runtime — see [How Tailwind reaches the preview](#how-tailwind-reaches-the-preview) above.                                                                                                                                   |
+| `modules`         | `Record<string, unknown>?`            | Extra specifiers resolvable from compiled code's `import` statements, merged with the built-in `baseModules`. Every sample's `import * as ui from 'ui-kit'` resolves through `baseModules` — pass your own map here to make additional specifiers resolvable the same way. |
+| `props`           | `Record<string, unknown>?`            | Props forwarded to the compiled code's default-exported component.                                                                                                                                                                                                         |
+| `provider`        | `(children: ReactNode) => ReactNode?` | Wrap the rendered output in your own context providers.                                                                                                                                                                                                                    |
+| `container`       | `HTMLElement \| null?`                | Currently unused — reserved for future use, has no effect today.                                                                                                                                                                                                           |
+
+### `Live.Editor`
+
+| Prop              | Type                                        | Description                                                                                                                                                                            |
+| ----------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`           | `string`                                    | Current code (controlled).                                                                                                                                                             |
+| `onChange`        | `(value: string) => void?`                  | Called on every edit.                                                                                                                                                                  |
+| `defaultValue`    | `string?`                                   | Falls back to this (or a built-in template) when `value` is empty.                                                                                                                     |
+| `debounce`        | `number?`                                   | Milliseconds to wait after the last keystroke before pushing to the shared preview code. Default `1000` — a full second of lag is expected, not a bug. Pass `0` for immediate updates. |
+| `height`          | `string?`                                   | Editor height (CSS value).                                                                                                                                                             |
+| `theme`           | `Extension \| 'light' \| 'dark' \| 'none'?` | CodeMirror theme — a preset name or your own CodeMirror `Extension`.                                                                                                                   |
+| `prettierOptions` | `Record<string, unknown>?`                  | Overrides for the built-in prettier config used on save.                                                                                                                               |
+| `fragment`        | `boolean?`                                  | Format the code as a JSX fragment (`<>...</>`) before/after prettier — for editing a snippet that has no single root element, rather than a whole component.                           |
+| `raw`             | `boolean?`                                  | Skip prettier formatting on save entirely; commit the value verbatim.                                                                                                                  |
+| `renderEditor`    | `(data: EditorRenderData) => ReactNode?`    | Replace the built-in CodeMirror surface — see [Custom Editor](./custom-editor.mdx).                                                                                                    |
+
+### Other exports
+
+- **`Live.Error`** (`LiveError`) — the error display component `Live.Preview`'s `showError` renders compile/runtime errors through internally (`title`, `message`, `onReset` props). Exposed in case you want to render the same error UI yourself. (Unrelated to `renderPanel`'s own edit-validation errors, which surface through a `ui-kit` `Toast` instead.)
+- **`LiveRenderer`** — an alias of `Live.Preview`/`LivePreview`, same component, same props.
+- **`LiveProvider`** — the named export for what `Live` itself is (the shared-context provider). `import Live from '@jbpark/live-editor'` and `import { LiveProvider } from '@jbpark/live-editor'` are the same component.
+
+### Types
+
+`PaletteRenderData`, `PanelRenderData`, `PanelBinding`, `EditorRenderData`,
+`FrameProps`, and `Section` are all importable from the package root:
+
+```ts
+import type { PanelRenderData, Section } from '@jbpark/live-editor';
+```
+
+`BindingType`/`BindingOption` live under a subpath instead — see
+[Custom Palette & Panel](./custom-palette-panel.mdx#panelbinding).
+
 ## Features
 
 | Page                                                 | What it covers                                                        |

--- a/website/docs/preview-modes.mdx
+++ b/website/docs/preview-modes.mdx
@@ -7,13 +7,22 @@ import DemoFrame from '@site/src/components/DemoFrame';
 
 # Preview Modes
 
-`frame.mode` controls how the preview renders:
+`frame.mode` is the switch that gates isolation entirely — every other
+`frame` option below is inert until it's set. Without `mode`, `Live.Preview`
+renders straight into the host document, regardless of any other `frame`
+options passed.
 
 - **`iframe`** — isolates the preview in a real iframe document. Note this is
   **not a security sandbox**: the code still executes in the host page's JS
-  realm. It exists for DOM/CSS isolation.
+  realm (the `sandbox` option below controls the iframe's `sandbox`
+  attribute, which is DOM/CSS isolation, not a security boundary either).
+  Supports every option in the table below.
 - **`shadow`** — isolates styles via a shadow DOM host in the same document,
-  without an iframe boundary.
+  without an iframe boundary. Only `mode` itself applies here — `syncStyle`,
+  `scripts`, `styles`, `stylesheets`, and `autoHeight` are all silently
+  ignored, since there's no separate document to inject them into. The shadow
+  host only gets whatever CSS naturally inherits across the shadow boundary
+  (font, color, and similar inherited properties) — not utility classes.
 
 <DemoFrame src="demos/preview-modes/" title="Live Editor — Preview Modes demo" height={340} />
 
@@ -33,22 +42,38 @@ const App = () => (
 export default App;
 `;
 
-// iframe isolation
-<Live>
-  <Live.Preview code={SAMPLE} frame={{ mode: 'iframe', syncStyle: true }} />
-</Live>;
+export default function PreviewModes() {
+  return (
+    <>
+      {/* iframe isolation */}
+      <Live>
+        <Live.Preview
+          code={SAMPLE}
+          frame={{ mode: 'iframe', syncStyle: true }}
+        />
+      </Live>
 
-// shadow DOM isolation
-<Live>
-  <Live.Preview code={SAMPLE} frame={{ mode: 'shadow' }} />
-</Live>;
+      {/* shadow DOM isolation */}
+      <Live>
+        <Live.Preview code={SAMPLE} frame={{ mode: 'shadow' }} />
+      </Live>
+    </>
+  );
+}
 ```
 
 ## `frame` options
 
-| Option | Type | Description |
-| --- | --- | --- |
-| `mode` | `'iframe' \| 'shadow'` | Isolation strategy for the preview. |
-| `syncStyle` | `boolean` | Copy the host document's stylesheets into the preview. |
-| `scripts` | `string[]` | External scripts to load into the preview (e.g. a Tailwind runtime). |
-| `autoHeight` | `boolean` | Size the iframe to its content instead of a fixed height. |
+`FrameProps` (importable from `@jbpark/live-editor`) is this shape:
+
+| Option | Type | Applies to | Description |
+| --- | --- | --- | --- |
+| `mode` | `'iframe' \| 'shadow'` | both | Isolation strategy. Omit it and nothing else in this table has any effect. |
+| `title` | `string` | iframe | The iframe's `title` attribute (accessibility). |
+| `sandbox` | `string` | iframe | Forwarded to the iframe's `sandbox` attribute, for DOM/CSS isolation only — **not** a security boundary (see the note above). |
+| `syncStyle` | `boolean` | iframe | Copy the host document's *already-compiled* stylesheets into the iframe. Can't include utility classes that only appear in code typed at runtime — see [How Tailwind reaches the preview](./intro.md#how-tailwind-reaches-the-preview). |
+| `scripts` | `string[]` | iframe | External script URLs to load into the iframe document (e.g. a Tailwind runtime). |
+| `styles` | `string[]` | iframe | Raw CSS strings to inject as `<style>` tags into the iframe. |
+| `stylesheets` | `string[]` | iframe | External stylesheet URLs to `<link>` into the iframe. |
+| `autoHeight` | `boolean` | iframe | Size the iframe to its content instead of a fixed height. |
+| `onLoaded` | `() => void` | iframe | Called once the iframe has finished its initial load. |

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -49,7 +49,7 @@ function Feature({ title, icon, description }: FeatureItem) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center">
-        <div className={styles.featureIcon} role="img" aria-label={title}>
+        <div className={styles.featureIcon} aria-hidden="true">
           {icon}
         </div>
       </div>


### PR DESCRIPTION
## Summary
Collected from comparing every page under `website/docs/` against the actual props, types, and built `dist/`. The `frame`-is-ignored bug and install command are already fixed separately (#187, #188); this is documentation plus the small export additions needed to make some of it true.

- **preview-modes.mdx**: `frame` options table now marks which apply to `iframe` vs `shadow` (most are iframe-only — shadow only honors `mode` itself), states `mode` as the gating switch rather than one knob among four, adds the previously-missing `title`/`sandbox`/`onLoaded` options, and fixes the snippet to be one complete component instead of two bare top-level JSX expressions
- **custom-editor.mdx**: `renderEditor`'s `EditorRenderData` documented as the 3-field object it actually is (`value`/`onChange`/`formatCode`) — `formatCode` existed and was invisible
- **custom-palette-panel.mdx**: adds `PaletteRenderData`/`PanelRenderData` reference tables (previously only inferable from the example); `BindingType`'s truncated "`string` / `url` / `jsx` / …" list replaced with the actual closed union of 12; notes `BindingType`/`BindingOption` import from the `utils/ast` subpath
- **intro.md**: new "How Tailwind reaches the preview" section (`dynamicTailwind` vs `frame.scripts`, and why `syncStyle` alone doesn't do it) plus a full props reference for `Live.Preview` and `Live.Editor` covering `modules`/`props`/`container`/`provider`/`dynamicTailwind` and `defaultValue`/`debounce`/`height`/`theme`/`prettierOptions`/`fragment`/`raw`, and a one-line mention each of `Live.Error`/`LiveRenderer`/`LiveProvider`
- **editor-mode.mdx**: fixes the "edit either side" wording that read as bidirectional when only `Live.Editor` writes to the shared code, and documents `debounce`'s 1000ms default so the lag isn't mistaken for a bug
- **HomepageFeatures**: decorative emoji icons now use `aria-hidden` instead of `role="img"` + `aria-label` duplicating the adjacent heading text, so screen readers don't announce each feature title twice

### Also needed (to make the above true rather than aspirational)
`src/index.tsx` now re-exports `PaletteRenderData`, `PanelRenderData`, `PanelBinding`, `EditorRenderData`, `FrameProps`, and `Section` from the package root — these were already exported from their own component `index.ts` (`dnd`, `editor`) or `frame/index.ts`, just never re-exported from the root entry, so the docs could name them but consumers couldn't import them. Verified in `dist/index.d.ts` after building.

### One correction made while writing this
`Live.Preview`'s `container` prop is genuinely unused anywhere in the implementation (grepped the whole `preview/` directory). Documented that honestly instead of describing invented behavior for it — worth a follow-up decision on whether to wire it up or remove it.

Fixes #189

## Test plan
- [x] `pnpm lint` / `tsc -b` / `pnpm run test` (217 tests) / `pnpm run build` / `pnpm --dir website typecheck` / `pnpm --dir website build` — all pass
- [x] `onBrokenLinks: throw` is set in `docusaurus.config.ts`, so the successful `website` build confirms every new cross-reference/anchor link (`#how-tailwind-reaches-the-preview`, `#props-reference`, `#panelbinding`) actually resolves
- [x] Verified `dist/index.d.ts` exports all 6 new types after `pnpm run build`