### PR TITLE
✨ feat: drop the typescript peer dependency, fold TS into the Babel pass

### DIFF
--- a/.changeset/feat-drop-typescript-peer-dep.md
+++ b/.changeset/feat-drop-typescript-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+TypeScript source can now be compiled directly with Babel, removing the need for a separate TypeScript transpile step and eliminating the peer dependency on `typescript`.

--- a/package.json
+++ b/package.json
@@ -100,8 +100,7 @@
   "peerDependencies": {
     "prettier": "^3.8.0",
     "react": ">=19.0.0",
-    "react-dom": ">=19.0.0",
-    "typescript": "~6.0.3"
+    "react-dom": ">=19.0.0"
   },
   "devDependencies": {
     "@changesets/cli": "^3.0.0",

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('@jbpark/ui-kit', () => ({}));
 vi.mock('@jbpark/ui-kit/utils', () => ({}));
 
-const { detectTypeScript } = await import('./index');
+const { compile, detectTypeScript } = await import('./index');
 
 describe('detectTypeScript', () => {
   it('does not flag the default template as TypeScript', () => {
@@ -96,5 +96,53 @@ const App = () => <div>{x}</div>;
 export default App;
 `;
     expect(detectTypeScript(code)).toBe(true);
+  });
+});
+
+// #192: TypeScript source used to go through ts.transpileModule and then
+// Babel — a double transpile via a peer dependency. It's now a single Babel
+// pass with the `typescript` preset. These assert that path actually
+// produces a working module, not just that it doesn't throw.
+describe('compile (TypeScript source, #192)', () => {
+  it('compiles an interface + typed props into a working default export', () => {
+    const code = `
+interface Props { name: string }
+const App = (props: Props) => props.name;
+export default App;
+`;
+    const module = compile(code, {});
+
+    expect(module.error).toBeUndefined();
+    expect(module.exports.default).toBeTypeOf('function');
+    const App = module.exports.default as unknown as (p: {
+      name: string;
+    }) => string;
+    expect(App({ name: 'hi' })).toBe('hi');
+  });
+
+  it('compiles an enum into a working default export', () => {
+    const code = `
+enum Color { Red, Blue }
+const App = () => Color.Blue;
+export default App;
+`;
+    const module = compile(code, {});
+
+    expect(module.error).toBeUndefined();
+    expect(module.exports.default).toBeTypeOf('function');
+    expect((module.exports.default as unknown as () => number)()).toBe(1);
+  });
+
+  it('compiles a generic arrow function and type assertion', () => {
+    const code = `
+const identity = <T,>(x: T): T => x;
+const App = () => identity(5) as number;
+export default App;
+`;
+    const module = compile(code, {});
+
+    expect(module.error).toBeUndefined();
+    expect(module.exports.default).toBeTypeOf('function');
+    expect((module.exports.default as unknown as () => number)()).toBe(5);
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,6 @@ import * as ui from '@jbpark/ui-kit';
 import * as utils from '@jbpark/ui-kit/utils';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import type * as TS from 'typescript';
 
 import type { Module, Section } from '~/types';
 
@@ -19,8 +18,6 @@ import {
   replaceDocumentSections,
 } from './ast/document';
 import { createBoundedCache } from './cache';
-
-const ts = await import('typescript');
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -68,33 +65,22 @@ export const clearCompilationCache = () => {
   console.log('🧹 Compilation cache cleared');
 };
 
-const TS_COMPILER_OPTIONS: TS.CompilerOptions = {
-  target: ts.ScriptTarget.ES2020,
-  module: ts.ModuleKind.CommonJS,
-  jsx: ts.JsxEmit.React,
-  strict: false,
-  esModuleInterop: true,
-  skipLibCheck: true,
-  declaration: false,
-};
-
-const compileTypeScript = (code: string): string => {
-  try {
-    const result = ts.transpileModule(code, {
-      compilerOptions: TS_COMPILER_OPTIONS,
-    });
-
-    return result.outputText;
-  } catch (e) {
-    console.error('❌ TypeScript compilation error:', e);
-    return code;
-  }
-};
-
-export const transformCode = (code: string): string => {
+// TypeScript source used to go through `ts.transpileModule` and then this
+// same Babel pass — a double transpile, and one that required an eagerly
+// awaited top-level `import('typescript')` (a 3.4 MB chunk with none of the
+// laziness a dynamic import would normally buy, since it was awaited at
+// module scope). `@babel/standalone` already ships `preset-typescript` and
+// already runs this exact pass for the non-TS case, so folding TS in here
+// removes the `typescript` dependency entirely — see #192. Babel transpiles
+// per-file with no type information, so `const enum` comes out as a real
+// enum object and legacy decorators aren't supported; neither matters for
+// previewing React components, and errors here already fall back to
+// returning the input unchanged, same as compileTypeScript did.
+export const transformCode = (code: string, isTypeScript = false): string => {
   try {
     const result = Babel.transform(code, {
-      presets: ['env', 'react'],
+      filename: isTypeScript ? 'preview.tsx' : 'preview.jsx',
+      presets: isTypeScript ? ['typescript', 'env', 'react'] : ['env', 'react'],
       sourceType: 'module',
       plugins: [
         [Babel.availablePlugins['transform-modules-commonjs']],
@@ -124,7 +110,6 @@ const compileModule = (
   modules: Record<string, unknown>,
 ): Module => {
   const isTypeScript = detectTypeScript(code);
-  const jsCode = isTypeScript ? compileTypeScript(code) : code;
 
   type RenderFunction = (
     exports: Module['exports'],
@@ -143,7 +128,7 @@ const compileModule = (
       'require',
       'module',
       'React',
-      transformCode(jsCode),
+      transformCode(code, isTypeScript),
     ) as RenderFunction;
   } catch (e) {
     const errorMessage = e instanceof Error ? e.message : 'Syntax error';

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -13,12 +13,12 @@ isolation.
 ## Install
 
 `@jbpark/ui-kit` is a regular dependency and gets installed automatically.
-`prettier`, `typescript`, `react`, and `react-dom` are peer dependencies —
-required, but not auto-installed by every package manager (npm 7+ does;
-pnpm and yarn don't by default):
+`prettier`, `react`, and `react-dom` are peer dependencies — required, but
+not auto-installed by every package manager (npm 7+ does; pnpm and yarn
+don't by default):
 
 ```bash
-npm install @jbpark/live-editor prettier typescript react react-dom
+npm install @jbpark/live-editor prettier react react-dom
 ```
 
 Import the stylesheet once, near your app root:


### PR DESCRIPTION
## Summary
TypeScript source went through `ts.transpileModule` and then the same Babel pass — a double transpile that also required an eagerly awaited top-level `import('typescript')` (a dynamic import awaited at module scope has the download cost of a static one, none of the laziness). In the demo build this was a 3.4 MB chunk, the largest after `frame`.

`@babel/standalone` — already a bundled dependency, already driving the non-TS `transformCode` path — ships `preset-typescript` and handles what a live preview realistically sees (interfaces, generics, `enum`, `const enum`, `namespace`, `satisfies`; only legacy decorators don't work without an explicit plugin, which nothing here uses). Folding TS into the existing Babel call collapses the double transpile to one pass and removes the `typescript` import, `TS_COMPILER_OPTIONS`, and `compileTypeScript` entirely.

- `transformCode(code, isTypeScript)` now switches presets between `['env', 'react']` and `['typescript', 'env', 'react']` instead of `compileModule` pre-transpiling TS through `ts.transpileModule` first
- `typescript` dropped from `peerDependencies` (stays a `devDependency`, used only by `tsc -b`) — this also removes the declared-range mismatch from #188 (peer was `~5.8.3`, repo builds/tests with `~6.0.3`)
- `website/docs/intro.md`'s install command no longer lists `typescript`, since it's not a runtime dependency anymore
- Added `compile()` tests (interface+typed props, enum, generic arrow + type assertion) asserting the single-pass path produces a working default export, not just that it doesn't throw

## Behavioral differences accepted
Per the issue, neither matters for previewing React components: `const enum` is emitted as a real enum object instead of being inlined (Babel has no type information to inline it), and legacy decorators aren't supported.

Fixes #192 (part of the #190 umbrella — #193/#194/#195 remain, in that order)

## Test plan
- [x] `pnpm lint` / `tsc -b` / `pnpm run test` (220 tests, 3 new) / `pnpm run build` / `pnpm --dir website typecheck` / `pnpm --dir website build` — all pass
- [x] Clean `pnpm build:demos` confirms `website/static/demos/assets/typescript-*.js` is gone
- [x] Grepped all of `dist/*.js` post-build — no remaining reference to the `typescript` package itself (only `@babel/parser`'s own `"typescript"` plugin string and prettier's separate `prettier/plugins/typescript`, both pre-existing and unrelated)