### PR TITLE
✨ feat: declare sideEffects in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "sideEffects": ["**/*.css"],
   "description": "Interactive UI editor with real-time preview and drag-and-drop. Syncs canvas edits back to source code via AST transforms and renders the preview in an iframe for DOM/CSS isolation (not a security sandbox).",
   "keywords": [
     "live-editor",


### PR DESCRIPTION
## Summary
`package.json` declared no `"sideEffects"` field, so bundlers had to conservatively assume every module in the package has side effects and keep them — even for a consumer that only destructures one export. This is what the repo's own demo comments describe as the reason they bypass the public entry and reach into `src/` directly: the default namespace statically pulls in the whole CodeMirror/Prettier/TypeScript editor stack regardless of which piece is used.

Added `"sideEffects": ["**/*.css"]` — the glob is what keeps `dist/style.css` and the `@jbpark/ui-kit/style.css` import from being dropped; declaring the package fully side-effect-free (`false`) would let bundlers eliminate the stylesheet imports and silently break styling.

## Verification (real bundle, not a code read)
Used `pnpm pack` to build the actual tarball, installed it into a fixture project through normal `node_modules` resolution (so esbuild reads `package.json`'s `sideEffects` field the way a real consumer's bundler would), then bundled `export { LiveDnd } from '@jbpark/live-editor';`:

- `@jbpark/ui-kit/style.css` and the local `style.css` import both survive in the bundled output — confirms the CSS side-effect declaration works and styling isn't silently broken
- Importing only `{ LiveDnd }` still pulls in CodeMirror/tiptap/prettier today — **expected**, since `src/index.tsx` is still one monolithic entry that statically imports and re-exports all five feature areas together. This field is the *prerequisite* for #194 (subpath exports) to be effective, not something #194 duplicates — without it, even a perfectly split graph would stay pinned.

Fixes #193 (part of the #190 umbrella — #194/#195 remain, in that order)

## Test plan
- [x] `pnpm lint` / `tsc -b` / `pnpm run test` (220 tests) / `pnpm run build` / `pnpm --dir website build` — all pass
- [x] Real-bundle verification described above (esbuild + packed tarball fixture)