### PR TITLE
✨ feat: reclassify prettier from peerDependency to dependency

### DIFF
--- a/.changeset/feat-reclassify-prettier.md
+++ b/.changeset/feat-reclassify-prettier.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Moved `prettier` from `peerDependencies` to `dependencies`. It's an internal implementation detail (used for the editor's Cmd+S formatting), not something consumers were meant to supply their own version of — a missing peer previously made the whole package fail to load under package managers that don't auto-install peers (pnpm, yarn).

--- a/package.json
+++ b/package.json
@@ -114,12 +114,12 @@
     "@uiw/codemirror-theme-vscode": "^4.25.11",
     "@uiw/react-codemirror": "^4.25.11",
     "lucide-react": "^1.31.0",
+    "prettier": "^3.9.6",
     "tailwindcss": "^4.3.3",
     "uuid": "^14.0.1",
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "prettier": "^3.8.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
   },
@@ -141,7 +141,6 @@
     "globals": "^17.11.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.3.0",
-    "prettier": "^3.9.6",
     "prettier-plugin-classnames": "^0.10.4",
     "prettier-plugin-merge": "^0.10.1",
     "prettier-plugin-tailwindcss": "^0.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -123,9 +126,6 @@ importers:
       lint-staged:
         specifier: ^17.3.0
         version: 17.3.0
-      prettier:
-        specifier: ^3.9.6
-        version: 3.9.6
       prettier-plugin-classnames:
         specifier: ^0.10.4
         version: 0.10.4(prettier@3.9.6)

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -12,13 +12,14 @@ isolation.
 
 ## Install
 
-`@jbpark/ui-kit` is a regular dependency and gets installed automatically.
-`prettier`, `react`, and `react-dom` are peer dependencies — required, but
-not auto-installed by every package manager (npm 7+ does; pnpm and yarn
-don't by default):
+`@jbpark/ui-kit` and `prettier` (used internally for the editor's Cmd+S
+formatting) are regular dependencies and get installed automatically.
+`react` and `react-dom` are peer dependencies — required, but not
+auto-installed by every package manager (npm 7+ does; pnpm and yarn don't by
+default):
 
 ```bash
-npm install @jbpark/live-editor prettier react react-dom
+npm install @jbpark/live-editor react react-dom
 ```
 
 Import the stylesheet once, near your app root:


### PR DESCRIPTION
## Summary
`prettier` was a `peerDependency`, but `dist/index.js` imports it (and its babel/estree/typescript plugins) statically at the top level, reached from `src/index.tsx` -> `components/editor` -> `use-format-code.ts`. Since that import is static and in the entry graph, a missing `prettier` wasn't a degraded format-on-save — the module failed to *resolve*, so the whole package failed to load. npm 7+ auto-installs peers so this was invisible there, but pnpm/yarn don't by default.

`prettier` was never a "bring your own version" integration point — the library just uses it internally for Cmd+S formatting and the `formatCode` helper handed to `renderEditor`. Per the issue's **Option A** (recommended over keeping it an optional/lazy peer, which would leave `formatCode`'s contract silently varying):

- Moved `prettier` to `dependencies`, matching the version (`^3.9.6`) this repo actually builds/tests with — it was previously only present as a `devDependency` (now redundant there, removed)
- `react`/`react-dom` are now the **only** remaining `peerDependencies` — the correct end state per the issue, since they're the one thing that genuinely must be shared with the host app
- `website/docs/intro.md`'s install line no longer lists `prettier` separately, since it's automatic now like `@jbpark/ui-kit`

## Verified per the issue's suggested method, not a code read
- Packed the built tarball, installed it into an empty project with pnpm (strict — no peer auto-install) alongside only `react`/`react-dom`, and confirmed `prettier@3.9.6` was pulled in automatically with no extra install step
- Bundled `import Live from '@jbpark/live-editor'` through esbuild (CSS treated as empty, the way a real consumer's bundler config would) and confirmed a clean build with prettier's code present in the output — no missing-module resolution errors

Fixes #195 — closes out the #190 umbrella (#192/#193/#194 already landed)

## Test plan
- [x] `pnpm lint` / `tsc -b` / `pnpm run test` (220 tests) / `pnpm run build` / `pnpm --dir website build` — all pass
- [x] Real-install + real-bundle verification described above