### PR TITLE
♻️ refactor: resolve ui-kit's stylesheet at the CSS layer, not via a JS import

### DIFF
--- a/.changeset/refactor-remove-implicit-css.md
+++ b/.changeset/refactor-remove-implicit-css.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+`@jbpark/ui-kit`'s stylesheet is now pulled in via `@import` at the CSS level (bundled into `dist/style.css`) instead of a JS-side `import '@jbpark/ui-kit/style.css'` that survived unresolved into `dist/index.js`. Consumers following the documented `import '@jbpark/live-editor/style.css'` see no change; consumers whose toolchain couldn't handle a raw CSS import out of `node_modules` (plain Node, non-CSS-aware bundlers) can now import the JS entry without that failing.

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,21 @@
 @import 'tailwindcss/theme.css' layer(theme);
 @import 'tailwindcss/utilities.css' layer(utilities);
 
+/*
+ * Pull @jbpark/ui-kit's compiled stylesheet in here (at the CSS level,
+ * resolved at build time into dist/style.css) instead of importing it as a
+ * bare `import '@jbpark/ui-kit/style.css'` from src/index.tsx. That JS-side
+ * import survived into dist/index.js as a literal, unresolved
+ * `import "@jbpark/ui-kit/style.css"` statement — which requires every
+ * consumer's toolchain to resolve and handle a CSS import straight out of
+ * node_modules, breaking plain Node resolution and any non-CSS-aware
+ * bundler (see #190). The single documented `@jbpark/live-editor/style.css`
+ * import now carries both this library's own [data-editor-mode] styles and
+ * ui-kit's, so nothing else needs to change for consumers already following
+ * the docs.
+ */
+@import '@jbpark/ui-kit/style.css';
+
 @layer utilities {
   /* 편집 모드 기본 설정 */
   [data-editor-mode] {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,3 @@
-import '@jbpark/ui-kit/style.css';
-
 import './index.css';
 
 import Context from './components/context';


### PR DESCRIPTION
## Summary
`src/index.tsx` did `import '@jbpark/ui-kit/style.css'`, which survived into `dist/index.js` as a literal, unresolved `import "@jbpark/ui-kit/style.css"` statement. That requires every consumer's toolchain to resolve and handle a CSS import straight out of `node_modules` — breaking plain Node resolution and any non-CSS-aware bundler — for a package whose docs already instruct an explicit `import '@jbpark/live-editor/style.css'`. Two mechanisms for the same thing, and only one of them was documented.

`src/index.css` already builds into `dist/style.css` (confirmed: its `[data-editor-mode]` rules were already there, no ui-kit-specific tokens like `--btn-bg` were). Moved the dependency there instead — `@import '@jbpark/ui-kit/style.css';` at the CSS level, resolved at build time and inlined into `dist/style.css` — rather than importing it from JS at the entry.

Also removes the last inconsistency #194 left behind: the `./dnd`, `./editor`, `./preview` subpaths never had this JS-side CSS import either, so a root import silently behaved differently from every subpath. Every entry point now requires the same explicit `@jbpark/live-editor/style.css` import — nothing implicit anywhere.

## Verified with real builds, not a code read
- `dist/style.css` grew from 567 to 4575 lines and now contains ui-kit tokens (`--btn-bg`, `--sidebar`, 45 occurrences) alongside this library's own `[data-editor-mode]` rules (unchanged, still 8)
- `dist/index.js` no longer contains any `"ui-kit/style.css"` reference
- Packed the tarball and bundled `import Live from '@jbpark/live-editor'` with esbuild using **zero CSS-loader configuration** — previously impossible (esbuild errors on unhandled `.css` by default), now succeeds, which is the concrete case #190 described
- `pnpm run build:demo` (the root app's own Vite build, a second, independent bundler pipeline) still resolves the full chain correctly — its output CSS contains ui-kit tokens too

Consumers following the documented `import '@jbpark/live-editor/style.css'` see no change — they get the exact same combined stylesheet, just assembled at build time instead of via a second runtime import.

Resolves the last open item from #190 (CSS imported from JS) — the #190 umbrella issue can be closed now that all four split-out issues (#192-#195) and this have landed.

## Test plan
- [x] `pnpm lint` / `tsc -b` / `pnpm run test` (220 tests) / `pnpm run build` / `pnpm run build:demos` / `pnpm run build:demo` / `pnpm --dir website typecheck` / `pnpm --dir website build` — all pass
- [x] Real-bundle verification described above (esbuild + packed tarball fixture)