### PR TITLE
🐛 fix: support syncStyle under shadow mode

### DIFF
--- a/.changeset/fix-shadow-syncstyle.md
+++ b/.changeset/fix-shadow-syncstyle.md
@@ -1,0 +1,9 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Added `syncStyle` support to `frame.mode: 'shadow'` (previously `iframe`-only), cloning the host document's `<link>`/`<style>` tags directly into the shadow root instead of the iframe document.
+
+This complements `dynamicTailwind` rather than replacing it: `dynamicTailwind` recompiles whatever classes it finds in the rendered DOM at runtime, but only knows Tailwind's own default theme — a utility backed by a consuming app's custom theme token (e.g. ui-kit's `Button` rendering `bg-primary`, backed by its own `--primary` token) silently compiles to nothing, since that token doesn't exist in Tailwind's stock theme. `syncStyle` clones the host's _already-compiled_ CSS instead, which includes anything the host's own build knew about — covering custom theme tokens, at the cost of not covering a class that only appears in code typed at runtime (which `dynamicTailwind` still handles). Use both together for full coverage.
+
+Verified with a real build, not just code review: the docs site's `dnd`/`editor-mode`/`custom-editor` demos (embedded via `frame.mode: 'shadow'`, see #206) now render ui-kit's `Button` with its real theme color (`oklch(0.205 0 0)`, matching ui-kit's actual `--primary` token) instead of the browser's default grey — see #210.

--- a/demos/custom-editor/CustomEditorDemo.tsx
+++ b/demos/custom-editor/CustomEditorDemo.tsx
@@ -35,7 +35,11 @@ const CustomEditorDemo = () => {
             'md:border-r md:border-b-0',
           )}
         >
-          <Preview showError frame={{ mode: 'shadow' }} dynamicTailwind />
+          <Preview
+            showError
+            frame={{ mode: 'shadow', syncStyle: true }}
+            dynamicTailwind
+          />
         </div>
         <div className="overflow-auto p-2">
           <Editor

--- a/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
+++ b/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
@@ -22,7 +22,7 @@ const CustomPalettePanelDemo = () => {
         <Dnd
           value={value}
           onChange={setValue}
-          frame={{ mode: 'shadow' }}
+          frame={{ mode: 'shadow', syncStyle: true }}
           dynamicTailwind
           renderPalette={({ items, onAdd, DraggableItem, isMobile }) => (
             <div className="space-y-2 p-2">

--- a/demos/dnd/DndDemo.tsx
+++ b/demos/dnd/DndDemo.tsx
@@ -24,7 +24,7 @@ const DndDemo = () => {
         <Dnd
           value={value}
           onChange={setValue}
-          frame={{ mode: 'shadow' }}
+          frame={{ mode: 'shadow', syncStyle: true }}
           dynamicTailwind
         />
       </div>

--- a/demos/editor-mode/EditorModeDemo.tsx
+++ b/demos/editor-mode/EditorModeDemo.tsx
@@ -37,7 +37,11 @@ const EditorModeDemo = () => {
             'md:border-r md:border-b-0',
           )}
         >
-          <Preview showError frame={{ mode: 'shadow' }} dynamicTailwind />
+          <Preview
+            showError
+            frame={{ mode: 'shadow', syncStyle: true }}
+            dynamicTailwind
+          />
         </div>
         <div className="overflow-auto">
           <Editor value={value} onChange={setValue} />

--- a/src/components/frame/frame.tsx
+++ b/src/components/frame/frame.tsx
@@ -17,7 +17,11 @@ const Frame = ({ mode, children, ...restProps }: Props) => {
   }
 
   if (mode === 'shadow') {
-    return <Shadow>{container => children(container || document.body)}</Shadow>;
+    return (
+      <Shadow syncStyle={restProps.syncStyle}>
+        {container => children(container || document.body)}
+      </Shadow>
+    );
   }
 
   return <IFrame {...restProps}>{children}</IFrame>;

--- a/src/components/frame/shadow.tsx
+++ b/src/components/frame/shadow.tsx
@@ -1,17 +1,113 @@
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useMutationObserver } from '@jbpark/use-hooks';
+
 interface Props {
+  // Clones the host document's <link rel="stylesheet">/<style> tags into the
+  // shadow root, mirroring `iframe.tsx`'s option of the same name. Unlike
+  // `dynamicTailwind` (which recompiles only the classes it can find in the
+  // rendered DOM, and only knows Tailwind's own default theme), this gets
+  // the host's *actual* compiled CSS — including a consuming app's own
+  // custom utilities/theme tokens — at the cost of only covering classes
+  // that were already known at the host's own build time. The two are
+  // complementary: this handles anything already in the host's stylesheets,
+  // dynamicTailwind covers whatever's left (e.g. a class typed at runtime
+  // that no build ever saw).
+  syncStyle?: boolean;
   children: (hostContainer: HTMLElement | null) => ReactNode;
 }
 
-const Shadow = ({ children }: Props) => {
+const Shadow = ({ syncStyle = false, children }: Props) => {
   const hostRef = useRef<HTMLDivElement>(null);
   const shadowRootRef = useRef<ShadowRoot | null>(null);
   const renderTargetRef = useRef<HTMLDivElement | null>(null);
   const [renderTarget, setRenderTarget] = useState<HTMLDivElement | null>(null);
   const [hostContainer, setHostContainer] = useState<HTMLElement | null>(null);
+
+  // Appended as siblings of the portal target (below), not inside it — that
+  // subtree is React-owned via createPortal, and anything appended there
+  // directly would get wiped on the next reconcile.
+  const styleManagerRef = useRef<{
+    copiedLinks: Set<string>;
+    copiedStyles: Set<string>;
+  }>({
+    copiedLinks: new Set(),
+    copiedStyles: new Set(),
+  });
+
+  const applyStyle = useCallback(() => {
+    const shadowRoot = shadowRootRef.current;
+
+    if (!shadowRoot || !syncStyle) {
+      return;
+    }
+
+    const manager = styleManagerRef.current;
+
+    const links = document.querySelectorAll<HTMLLinkElement>(
+      'link[rel="stylesheet"]',
+    );
+    const newLinks = Array.from(links)
+      .map(link => link.href)
+      .filter(href => !manager.copiedLinks.has(href));
+
+    if (newLinks.length) {
+      const fragment = document.createDocumentFragment();
+      newLinks.forEach(href => {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = href;
+        fragment.appendChild(link);
+        manager.copiedLinks.add(href);
+      });
+      shadowRoot.appendChild(fragment);
+    }
+
+    const styleTags = document.querySelectorAll<HTMLStyleElement>('style');
+    const newStyles = Array.from(styleTags)
+      .map(style => style.textContent || '')
+      .filter(content => {
+        if (!content) {
+          return false;
+        }
+        const hash = content.length + content.slice(0, 50);
+        if (manager.copiedStyles.has(hash)) {
+          return false;
+        }
+        manager.copiedStyles.add(hash);
+        return true;
+      });
+
+    if (newStyles.length) {
+      const fragment = document.createDocumentFragment();
+      newStyles.forEach(content => {
+        const style = document.createElement('style');
+        style.textContent = content;
+        fragment.appendChild(style);
+      });
+      shadowRoot.appendChild(fragment);
+    }
+  }, [syncStyle]);
+
+  const applyStyleTimeoutRef = useRef<number>(undefined);
+
+  // Debounced so a burst of head mutations (a stylesheet swap can fire
+  // several in quick succession) only re-runs applyStyle once — same
+  // rationale as iframe.tsx's identical setup.
+  const debouncedApplyStyle = useCallback(() => {
+    clearTimeout(applyStyleTimeoutRef.current);
+    applyStyleTimeoutRef.current = window.setTimeout(applyStyle, 50);
+  }, [applyStyle]);
+
+  useMutationObserver(document.head, debouncedApplyStyle, {
+    enabled: syncStyle,
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['href'],
+  });
 
   useLayoutEffect(() => {
     if (!hostRef.current) {
@@ -41,6 +137,8 @@ const Shadow = ({ children }: Props) => {
       renderTargetRef.current = target;
       setRenderTarget(target);
     }
+
+    applyStyle();
     // click/pointerdown/pointerup are `composed: true` by spec, so they
     // already retarget across the shadow boundary and reach listeners
     // outside it (document, this host's ancestors, React's own root
@@ -49,7 +147,7 @@ const Shadow = ({ children }: Props) => {
     // needing the real element inside the shadow tree (not the retargeted
     // host) can still read it via event.composedPath()[0], unaffected by
     // this removal. See #92.
-  }, []);
+  }, [applyStyle]);
 
   useLayoutEffect(() => {
     if (renderTargetRef.current && !renderTarget) {

--- a/website/docs/custom-editor.mdx
+++ b/website/docs/custom-editor.mdx
@@ -23,7 +23,11 @@ export default function CustomEditor() {
 
   return (
     <Live>
-      <Live.Preview showError frame={{ mode: 'shadow' }} dynamicTailwind />
+      <Live.Preview
+        showError
+        dynamicTailwind
+        frame={{ mode: 'shadow', syncStyle: true }}
+      />
       <Live.Editor
         value={value}
         onChange={setValue}

--- a/website/docs/drag-and-drop.mdx
+++ b/website/docs/drag-and-drop.mdx
@@ -23,7 +23,12 @@ export default function DragAndDrop() {
 
   return (
     <Live>
-      <Live.Dnd value={value} onChange={setValue} frame={{ mode: 'shadow' }} />
+      <Live.Dnd
+        value={value}
+        onChange={setValue}
+        dynamicTailwind
+        frame={{ mode: 'shadow', syncStyle: true }}
+      />
     </Live>
   );
 }

--- a/website/docs/editor-mode.mdx
+++ b/website/docs/editor-mode.mdx
@@ -37,7 +37,11 @@ export default function EditorMode() {
 
   return (
     <Live>
-      <Live.Preview showError frame={{ mode: 'shadow' }} dynamicTailwind />
+      <Live.Preview
+        showError
+        dynamicTailwind
+        frame={{ mode: 'shadow', syncStyle: true }}
+      />
       <Live.Editor value={value} onChange={setValue} />
     </Live>
   );

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -91,26 +91,41 @@ Every sample on this site uses Tailwind utility classes
 (`className="p-6 space-y-2"`), and none of them work for free — the code a
 reader types is compiled and rendered at runtime, so there's no build step
 that could have generated CSS for classes that don't exist yet when the app
-first loads. There are two ways to make them actually apply:
+first loads. There are three ways to make them actually apply, and the first
+two are complementary — use both together to cover each other's gaps.
 
-**`dynamicTailwind` (simplest, and the only option under `shadow` mode)** —
-pass it to `Live.Preview` and it scans the _rendered DOM_ after mount,
-compiles whatever classes actually ended up on the page with the real
-`tailwindcss` engine, and injects the result as a `<style>` tag next to the
-rendered output. Scanning the DOM rather than the source text means it also
-picks up classes contributed by an imported component (e.g. `ui.Button`
-rendering its own `bg-primary`), not just literal `className`/`cn(...)`
-usage in the code the reader typed. Works with or without `frame`, and under
-either `frame.mode`:
+**`syncStyle`** — clones the host document's already-compiled
+`<link>`/`<style>` tags in (into the iframe document, or directly into the
+shadow root — works under both `frame.mode`s):
+
+```tsx
+<Live.Preview frame={{ mode: 'shadow', syncStyle: true }} />
+```
+
+Since it's copying real, already-built CSS, it includes anything a
+consuming app's own build knew about — including custom theme tokens (e.g.
+ui-kit's `Button` rendering `bg-primary`, backed by a project-specific
+`--primary` token that Tailwind's own default theme has no idea exists). Its
+limitation is the mirror image: it can't include a utility class that only
+appears in code typed at runtime, since by definition no build ever saw it
+to compile CSS for it.
+
+**`dynamicTailwind`** — pass it to `Live.Preview` and it scans the
+_rendered DOM_ after mount, compiles whatever classes actually ended up on
+the page with the real `tailwindcss` engine, and injects the result as a
+`<style>` tag next to the rendered output. Scanning the DOM rather than the
+source text means it also picks up classes contributed by an imported
+component, not just literal `className`/`cn(...)` usage in the code the
+reader typed. Works with or without `frame`, and under either `frame.mode`:
 
 ```tsx
 <Live.Preview dynamicTailwind frame={{ mode: 'shadow' }} />
 ```
 
-One limitation: it only knows Tailwind's own default theme (colors, spacing,
-font sizes, ...), not a consuming app's custom theme extensions — a
-`bg-primary` utility backed by a project-specific `--color-primary` token
-won't resolve, since that token doesn't exist in Tailwind's stock theme.
+Its limitation is the mirror image of `syncStyle`'s: it only knows
+Tailwind's own default theme (colors, spacing, font sizes, ...), not a
+consuming app's custom theme extensions, since it recompiles from scratch
+rather than reusing anything the host already built.
 
 **`frame.scripts` + a Tailwind runtime (`iframe` mode only)** — load a
 standalone Tailwind runtime script into the iframe via `frame.scripts` so the
@@ -126,9 +141,6 @@ iframe's own document processes its own classes live:
 />
 ```
 
-`frame.syncStyle` alone does **not** do this — it only copies the host page's
-_already-compiled_ stylesheet into the iframe, which by definition can't
-contain utilities that only appear in code the reader types at runtime.
 `scripts` doesn't apply under `frame.mode: 'shadow'` at all (there's no
 separate document to load it into) — see [Preview Modes](./preview-modes.mdx)
 for what does and doesn't apply there.

--- a/website/docs/preview-modes.mdx
+++ b/website/docs/preview-modes.mdx
@@ -18,14 +18,19 @@ options passed.
   attribute, which is DOM/CSS isolation, not a security boundary either).
   Supports every option in the table below.
 - **`shadow`** — isolates styles via a shadow DOM host in the same document,
-  without an iframe boundary. Only `mode` itself applies here — `syncStyle`,
-  `scripts`, `styles`, `stylesheets`, and `autoHeight` are all silently
-  ignored, since there's no separate document to inject them into. The shadow
-  host only gets whatever CSS naturally inherits across the shadow boundary
-  (font, color, and similar inherited properties) — not utility classes on
-  their own. Pass `dynamicTailwind` on `Live.Preview`/`Live.Dnd` to get those
-  working too — see
+  without an iframe boundary. `scripts`, `styles`, `stylesheets`, and
+  `autoHeight` are all silently ignored, since there's no separate document
+  to inject them into. The shadow host only gets whatever CSS naturally
+  inherits across the shadow boundary (font, color, and similar inherited
+  properties) on its own — not utility classes. Two ways to get those
+  working too: `syncStyle` clones the host document's `<link>`/`<style>`
+  tags directly into the shadow root (covers anything already in the host's
+  compiled CSS, including a consuming app's own custom theme tokens), and
+  `dynamicTailwind` recompiles whatever classes it finds in the rendered DOM
+  at runtime (covers anything the host's build never saw, e.g. a class typed
+  at runtime) — see
   [How Tailwind reaches the preview](./intro.md#how-tailwind-reaches-the-preview).
+  The two are complementary and can be used together.
 
 <PreviewModesEmbed />
 
@@ -50,12 +55,20 @@ export default function PreviewModes() {
     <>
       {/* iframe isolation */}
       <Live>
-        <Live.Preview code={SAMPLE} dynamicTailwind frame={{ mode: 'iframe' }} />
+        <Live.Preview
+          code={SAMPLE}
+          dynamicTailwind
+          frame={{ mode: 'iframe', syncStyle: true }}
+        />
       </Live>
 
       {/* shadow DOM isolation */}
       <Live>
-        <Live.Preview code={SAMPLE} dynamicTailwind frame={{ mode: 'shadow' }} />
+        <Live.Preview
+          code={SAMPLE}
+          dynamicTailwind
+          frame={{ mode: 'shadow', syncStyle: true }}
+        />
       </Live>
     </>
   );
@@ -75,7 +88,7 @@ to isolate (the sample is a fixed string, not wired to an editor).
 | `mode` | `'iframe' \| 'shadow'` | both | Isolation strategy. Omit it and nothing else in this table has any effect. |
 | `title` | `string` | iframe | The iframe's `title` attribute (accessibility). |
 | `sandbox` | `string` | iframe | Forwarded to the iframe's `sandbox` attribute, for DOM/CSS isolation only — **not** a security boundary (see the note above). |
-| `syncStyle` | `boolean` | iframe | Copy the host document's *already-compiled* stylesheets into the iframe. Can't include utility classes that only appear in code typed at runtime — see [How Tailwind reaches the preview](./intro.md#how-tailwind-reaches-the-preview). |
+| `syncStyle` | `boolean` | both | Copy the host document's *already-compiled* `<link>`/`<style>` tags in (into the iframe document, or directly into the shadow root). Can't include utility classes that only appear in code typed at runtime — see [How Tailwind reaches the preview](./intro.md#how-tailwind-reaches-the-preview). |
 | `scripts` | `string[]` | iframe | External script URLs to load into the iframe document (e.g. a Tailwind runtime). |
 | `styles` | `string[]` | iframe | Raw CSS strings to inject as `<style>` tags into the iframe. |
 | `stylesheets` | `string[]` | iframe | External stylesheet URLs to `<link>` into the iframe. |


### PR DESCRIPTION
## Summary

`syncStyle` was `iframe`-only — shadow mode had no way to pull in the host's already-compiled CSS at all, only `dynamicTailwind`'s from-scratch runtime recompile. That gap matters specifically for a consuming app's own custom theme tokens: ui-kit's `Button` renders `bg-primary`, backed by ui-kit's own `--primary` token (not part of Tailwind's stock color palette), so `dynamicTailwind`'s compile context has no way to know it exists and silently drops it, leaving `type="primary"` buttons stuck on the browser's default grey — see #210.

- Added the same `syncStyle` mechanism `iframe.tsx` already has (clone `<link rel="stylesheet">`/`<style>` tags in, `MutationObserver`-driven so later head changes get picked up too) to `shadow.tsx`, appending the clones as siblings of the portal target rather than inside it, since that subtree is React-owned via `createPortal` and anything appended there directly would get wiped on the next reconcile
- `Frame` threads `syncStyle` through to `Shadow` the same way it already does for `IFrame`
- `syncStyle` and `dynamicTailwind` are complementary now, not alternatives: `syncStyle` covers whatever the host's own build already compiled (including custom theme tokens), `dynamicTailwind` covers whatever that build never saw (a class only typed at runtime)
- Wired both into the docs site's `dnd`/`custom-palette-panel`/`editor-mode`/`custom-editor` demos, and updated the docs (`intro.md`, `preview-modes.mdx`, and the per-demo pages) to describe the pairing

## Test plan

- [x] `pnpm run lint` / `pnpm exec tsc -b` / `pnpm run test` (225 tests) all pass
- [x] `pnpm run build` (library) and `pnpm run build:demos` succeed
- [x] `pnpm --dir website run typecheck` succeeds
- [x] Verified with a real build, not just code review: served the rebuilt demos, drove drag-and-drop and page loads via CDP, and measured a shadow-mode `Button`'s computed `background-color` as `oklch(0.205 0 0)` — ui-kit's actual `--primary` token value, confirmed by reading its published stylesheet directly — versus the browser-default grey before this fix
- [x] `dnd`'s own drag-and-drop interaction still works correctly afterward (dragged a new section in, verified it renders styled and in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)