### PR TITLE
🔧 chore: bump @jbpark/live-editor to 1.15.1 and use syncStyle in Preview Modes

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
     "@docusaurus/core": "3.10.2",
     "@docusaurus/faster": "3.10.2",
     "@docusaurus/preset-classic": "3.10.2",
-    "@jbpark/live-editor": "^1.15.0",
+    "@jbpark/live-editor": "^1.15.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 3.10.2
         version: 3.10.2(@algolia/client-search@5.56.0)(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.0)(@types/react@19.2.18)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)(typescript@6.0.3)
       '@jbpark/live-editor':
-        specifier: ^1.15.0
-        version: 1.15.0(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.9)(@floating-ui/dom@1.8.0)(@tiptap/extensions@3.30.2(@tiptap/core@3.30.2(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0))
+        specifier: ^1.15.1
+        version: 1.15.1(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.9)(@floating-ui/dom@1.8.0)(@tiptap/extensions@3.30.2(@tiptap/core@3.30.2(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0))
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
@@ -1340,8 +1340,8 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
-  '@jbpark/live-editor@1.15.0':
-    resolution: {integrity: sha512-6hG9IPIjMeCU4aT19Y+6WdVrjbJGfjFTb4btHlavddtS+HtwYFp5zcDWKr4qL/Pl5jal58T/WswsKH3I5tzzUg==}
+  '@jbpark/live-editor@1.15.1':
+    resolution: {integrity: sha512-F0TMYm8DWu0rHi12GyQbLMaJfOKqJpMUfP5haYSVcf+MCXHogoBf4gcrJfrGlkituqaTywXuJcRC6V1ghSKskA==}
     engines: {node: '>=20', pnpm: '>=10'}
     peerDependencies:
       react: '>=19.0.0'
@@ -9498,7 +9498,7 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@jbpark/live-editor@1.15.0(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.9)(@floating-ui/dom@1.8.0)(@tiptap/extensions@3.30.2(@tiptap/core@3.30.2(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0))':
+  '@jbpark/live-editor@1.15.1(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.9)(@floating-ui/dom@1.8.0)(@tiptap/extensions@3.30.2(@tiptap/core@3.30.2(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2))(@tiptap/pm@3.30.2)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0))':
     dependencies:
       '@babel/standalone': 7.29.8
       '@codemirror/lang-javascript': 6.2.5

--- a/website/src/components/PreviewModesDemo.tsx
+++ b/website/src/components/PreviewModesDemo.tsx
@@ -33,7 +33,7 @@ const PreviewModesDemo = () => {
             <Preview
               code={SAMPLE_CODE}
               dynamicTailwind
-              frame={{ mode: 'iframe' }}
+              frame={{ mode: 'iframe', syncStyle: true }}
             />
           </Context>
         </div>
@@ -45,7 +45,7 @@ const PreviewModesDemo = () => {
             <Preview
               code={SAMPLE_CODE}
               dynamicTailwind
-              frame={{ mode: 'shadow' }}
+              frame={{ mode: 'shadow', syncStyle: true }}
             />
           </Context>
         </div>


### PR DESCRIPTION
## Summary

Picks up #212's shadow-mode `syncStyle` support. `PreviewModesDemo` now passes `syncStyle` alongside `dynamicTailwind` on both the `iframe` and `shadow` panels, so `ui.Button`'s `type="primary"` renders with ui-kit's actual `--primary` token (near-black) instead of the browser's default grey in both.

Closes #210.

## Test plan

- [x] `pnpm run lint` / `pnpm exec tsc -b` / `pnpm run test` (225 tests) all pass
- [x] `pnpm --dir website run typecheck` / `pnpm --dir website run build` succeed
- [x] Verified with a real build, not just code review: served the site, loaded `/docs/preview-modes` over CDP — both panels now report `background-color: rgb(23, 23, 23)` / `color: rgb(250, 250, 250)` (matches ui-kit's real `--primary`/`--primary-foreground` tokens), where the shadow panel previously fell back to the browser's default grey button

🤖 Generated with [Claude Code](https://claude.com/claude-code)