### PR TITLE
🐛 fix: give docs Dnd demos room for their desktop layout, fix copy mismatch

### DIFF
--- a/.changeset/fix-empty-state-tap-vs-drag.md
+++ b/.changeset/fix-empty-state-tap-vs-drag.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fixed `Live.Dnd`'s empty-canvas placeholder always saying "Drag a component from the left to add it", even below the mobile breakpoint where the palette lives in a `Drawer` over the canvas and dragging isn't the available gesture there — only tapping is (see `draggable.tsx`'s existing `tapToAdd` handling). The message now follows the same `isMobile` condition that already drives `tapToAdd`, showing "Tap a component to add it" instead when the palette is in the drawer.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -594,7 +594,9 @@ const Dnd = ({
                       No sections available
                     </Typography.Paragraph>
                     <Typography.Text>
-                      Drag a component from the left to add it
+                      {isMobile
+                        ? 'Tap a component to add it'
+                        : 'Drag a component from the left to add it'}
                     </Typography.Text>
                   </Space>
                 </div>

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 5
 title: Custom Palette & Panel
+hide_table_of_contents: true
 ---
 
 import DemoFrame from '@site/src/components/DemoFrame';
@@ -11,7 +12,12 @@ import DemoFrame from '@site/src/components/DemoFrame';
 built-in left palette and right property panel with your own markup, while
 drag-and-drop and field editing keep working exactly as before.
 
-<DemoFrame src="demos/custom-palette-panel/" title="Live Editor — Custom Palette &amp; Panel demo" height={680} />
+<DemoFrame
+  src="demos/custom-palette-panel/"
+  title="Live Editor — Custom Palette &amp; Panel demo"
+  height={680}
+  breakout
+/>
 
 ## Custom palette
 

--- a/website/docs/drag-and-drop.mdx
+++ b/website/docs/drag-and-drop.mdx
@@ -1,17 +1,26 @@
 ---
 sidebar_position: 4
 title: Drag & Drop
+hide_table_of_contents: true
 ---
 
 import DemoFrame from '@site/src/components/DemoFrame';
 
 # Drag & Drop
 
-`Live.Dnd` lets you build UIs visually: drag a component from the left palette
-onto the canvas, then edit its properties from the panel on the right. Powered
+`Live.Dnd` lets you build UIs visually. At wider sizes, drag a component from
+the left palette onto the canvas, then edit its properties from the panel on
+the right; below `Live.Dnd`'s own responsive breakpoint, the palette and
+panel move into a drawer instead, and a tap adds the section (there's nothing
+visible to drag onto once the canvas is stacked behind the drawer). Powered
 by [`@dnd-kit`](https://dndkit.com/).
 
-<DemoFrame src="demos/dnd/" title="Live Editor — Drag & Drop demo" height={620} />
+<DemoFrame
+  src="demos/dnd/"
+  title="Live Editor — Drag & Drop demo"
+  height={620}
+  breakout
+/>
 
 ```tsx
 import { useState } from 'react';

--- a/website/src/components/DemoFrame.tsx
+++ b/website/src/components/DemoFrame.tsx
@@ -12,12 +12,25 @@ interface Props {
   src: string;
   title: string;
   height?: number | string;
+  // `Live.Dnd` switches its own internal layout at Tailwind's `md` (768px)
+  // breakpoint, evaluated against *this iframe's* width — not the reader's
+  // browser window. Sized to the article column (the default), that
+  // breakpoint only clears above a ~2560px browser viewport (see #215), so
+  // every realistic desktop width shows the mobile drawer layout instead of
+  // the desktop palette the page's copy describes. `breakout` escapes the
+  // iframe past the article column's max-width, right up to the page edges,
+  // which clears `md` from ~1150px up. `box-sizing: border-box` matters
+  // here: without it, the 1px border pushes the content box (and so the
+  // breakpoint check) 2px narrower than the frame's own reported width,
+  // occasionally missing `md` by exactly that margin.
+  breakout?: boolean;
 }
 
 export default function DemoFrame({
   src,
   title,
   height = 560,
+  breakout = false,
 }: Props): ReactNode {
   const url = useBaseUrl(src);
 
@@ -25,9 +38,17 @@ export default function DemoFrame({
     display: 'block',
     width: '100%',
     height,
+    boxSizing: 'border-box',
     border: '1px solid var(--ifm-color-emphasis-300)',
     borderRadius: 'var(--ifm-global-radius)',
     background: 'var(--ifm-background-surface-color)',
+    ...(breakout && {
+      position: 'relative',
+      width: '100vw',
+      maxWidth: '100vw',
+      left: '50%',
+      marginLeft: '-50vw',
+    }),
   };
 
   // The demos are served from `static/demos/*` on the same origin as the docs


### PR DESCRIPTION
## Summary

Fixes #215. `Live.Dnd` switches between its desktop 3-column layout and mobile FAB+drawer layout at Tailwind's `md` (768px) breakpoint, evaluated against the iframe's own width. `DemoFrame` sizes the iframe to the article column, which measured at 606-734px across every realistic desktop browser width (only clearing 768px above a ~2560px browser viewport) — so `/docs/drag-and-drop` and `/docs/custom-palette-panel` showed the mobile drawer layout everywhere a reader would actually look, while the page told them to "drag a component from the left palette", which isn't there at that width.

Not a regression and not a broken interaction — tap-to-add in the drawer works correctly today, this is a "the demo doesn't showcase what the page says it does" problem.

- `DemoFrame` gained an opt-in `breakout` prop: escapes the iframe past the article column's max-width using the standard full-bleed technique (`position: relative; width/max-width: 100vw; left: 50%; margin-left: -50vw`), clearing `md` from ~1150px up. `box-sizing: border-box` now applies unconditionally, so the 1px border doesn't shave 2px off the reported width and miss the breakpoint by exactly that margin.
- Wired `breakout` + `hide_table_of_contents: true` (reclaims the ~200px the right-hand TOC takes at wide viewports) into `drag-and-drop.mdx` and `custom-palette-panel.mdx`, the two pages that embed `Live.Dnd`.
- `drag-and-drop.mdx`'s intro now describes both gestures (drag above the breakpoint, tap in the drawer below it) instead of asserting a left palette unconditionally, since readers below ~1150px still get the drawer.
- `Live.Dnd`'s empty-canvas placeholder always said "Drag a component from the left to add it", even in the mobile/drawer layout where tapping is the only available gesture (`draggable.tsx`'s `tapToAdd` already handles this correctly). Now follows the same `isMobile` condition `tapToAdd` uses.

## Test plan

- [x] `pnpm run lint` / `pnpm exec tsc -b` / `pnpm run test` (225 tests) all pass
- [x] `pnpm --dir website run typecheck` / `pnpm --dir website run build` succeed
- [x] Verified with a real build, not just code review: measured the iframe's actual CSS width via CDP at 1200/1440/1920px emulated browser viewports — matches the full viewport width at every size (previously constrained to the article column), confirming the breakout clears `md`
- [ ] Full interactive verification (palette visible, drag-and-drop still works) needs a real CORS-enabled origin — `vercel.json` already sends `Access-Control-Allow-Origin: *` for `/demos/*`, which the sandboxed iframe's opaque origin needs for its module script to load at all; a plain local `docusaurus serve` doesn't send that header (confirmed: `curl -I` shows no CORS header locally, and the demo's own module script never loads in that case — same on the *unmodified* `editor-mode` page too, so this is a local-testing-only gap, not something this PR introduces). Will verify on the Vercel preview/production deployment after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)