### PR TITLE
🐛 fix: bump @jbpark/ui-kit to 5.4.4

### DIFF
--- a/.changeset/fix-bump-ui-kit-5-4-4.md
+++ b/.changeset/fix-bump-ui-kit-5-4-4.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Bumped `@jbpark/ui-kit` from `^5.4.1` to `^5.4.4`, which fixes dark mode not applying on hosts that toggle `[data-theme='dark']` instead of the `.dark` class (5.4.3), and a `[data-slot]`-scoped preflight normalization for consumers without Tailwind preflight, so bare buttons no longer pick up the browser's default `outset` border/native `appearance`/UA font (5.4.4). Verified with a real build: `dist/style.css` includes the new `[data-slot]` normalization and `data-theme` dark-mode rules, with no bare-tag selectors leaking in.

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@jbpark/ui-kit": "^5.4.1",
+    "@jbpark/ui-kit": "^5.4.4",
     "@jbpark/use-hooks": "^4.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@tiptap/core": "^3.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.8)
       '@jbpark/ui-kit':
-        specifier: ^5.4.1
-        version: 5.4.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^5.4.4
+        version: 5.4.4(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@jbpark/use-hooks':
         specifier: ^4.0.1
         version: 4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -621,8 +621,8 @@ packages:
     resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
-  '@jbpark/ui-kit@5.4.1':
-    resolution: {integrity: sha512-mQVz6tifo+FE8sI6n9+QB8HRcj+PZQX9UQajvPGQD16SbdLG5lnw7Ao7reP7RnDd3vxbf+H8eHymX7m/MM6KLg==}
+  '@jbpark/ui-kit@5.4.4':
+    resolution: {integrity: sha512-WpgXVl8SDilcXyAG1IR50N/B2+oHdJ0B6APvWS0rluRIe6mo5cYb6kX7opW99mpE12O677I3kTupinh3oLgDiA==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -4424,7 +4424,7 @@ snapshots:
       '@isaacs/balanced-match': 4.0.1
     optional: true
 
-  '@jbpark/ui-kit@5.4.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@jbpark/ui-kit@5.4.4(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@gsap/react': 2.1.2(gsap@3.15.0)(react@19.2.8)
       '@jbpark/use-hooks': 4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)


### PR DESCRIPTION
## Summary
- Bump `@jbpark/ui-kit` dependency from `^5.4.1` to `^5.4.4`
- Picks up the dark-mode `[data-theme]` fix (5.4.3) and the `[data-slot]` preflight normalization fix (5.4.4)

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 225 tests pass
- [x] `dist/style.css` verified to include new `[data-slot]`/`data-theme` rules with no bare-tag leakage