### PR TITLE
🐛 fix: prevent DemoFrame breakout from overflowing past the scrollbar

### DIFF
--- a/website/src/components/DemoFrame.tsx
+++ b/website/src/components/DemoFrame.tsx
@@ -23,6 +23,14 @@ interface Props {
   // here: without it, the 1px border pushes the content box (and so the
   // breakpoint check) 2px narrower than the frame's own reported width,
   // occasionally missing `md` by exactly that margin.
+  //
+  // Uses `--scrollbar-width` (custom.css) rather than bare `100vw`/`-50vw`:
+  // on a non-overlay scrollbar (Windows/Linux desktop), `100vw` includes the
+  // scrollbar's own width, so the naive full-bleed technique overflowed past
+  // the page's actual visible right edge and forced a page-wide horizontal
+  // scrollbar — not caught by the original CDP-based verification, since
+  // headless Chrome's overlay scrollbars don't reserve any width, so `100vw`
+  // and the visible width already agreed there.
   breakout?: boolean;
 }
 
@@ -44,10 +52,10 @@ export default function DemoFrame({
     background: 'var(--ifm-background-surface-color)',
     ...(breakout && {
       position: 'relative',
-      width: '100vw',
-      maxWidth: '100vw',
+      width: 'calc(100vw - var(--scrollbar-width, 0px))',
+      maxWidth: 'calc(100vw - var(--scrollbar-width, 0px))',
       left: '50%',
-      marginLeft: '-50vw',
+      marginLeft: 'calc(-50vw + (var(--scrollbar-width, 0px) / 2))',
     }),
   };
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -12,6 +12,19 @@
    investigation for the byte-identical computed-style verification. */
 @import '@jbpark/live-editor/style.css';
 
+/* `100%` on the root element resolves against the viewport minus the
+   vertical scrollbar's own width (browsers carve the scrollbar out of the
+   root's layout box), while `100vw` includes it — so the difference is
+   exactly the scrollbar's width. DemoFrame's `breakout` full-bleed layout
+   subtracts this to avoid overflowing past the page's actual visible
+   right edge on non-overlay scrollbars (Windows/Linux desktop Chrome/
+   Firefox), which otherwise adds a page-wide horizontal scrollbar. Evaluates
+   to 0px on platforms with overlay scrollbars (macOS, mobile), where
+   `100vw` and `100%` already agree. */
+:root {
+  --scrollbar-width: calc(100vw - 100%);
+}
+
 /* Live Editor's indigo palette replaces Docusaurus' default green theme. */
 :root {
   --ifm-color-primary: #5b5bd6;


### PR DESCRIPTION
## Summary
- `DemoFrame`'s `breakout` full-bleed layout (added in #218 to clear the `md` breakpoint for the desktop palette) used bare `100vw`/`-50vw`, which includes the vertical scrollbar's own width
- On any non-overlay scrollbar (Windows/Linux desktop Chrome/Firefox), the frame rendered wider than the page's actual visible area and overflowed past the right edge, forcing a page-wide horizontal scrollbar — not caught by #218's original CDP-based verification since headless Chrome uses overlay scrollbars, where `100vw` and the visible width already agree
- Added `--scrollbar-width: calc(100vw - 100%)` in `custom.css` (standard CSS-only technique for isolating the scrollbar's width) and subtracted it from the breakout width/margin so the frame lands flush with the actual visible viewport

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes, verified built HTML/CSS contains the corrected `calc()` values
- [ ] Visual check on the deployed preview (no working browser sandbox in this environment — verified via CSS geometry instead)