### PR TITLE
🐛 fix: measure DemoFrame's breakout with JS instead of pure CSS

### DIFF
--- a/website/src/components/DemoFrame.tsx
+++ b/website/src/components/DemoFrame.tsx
@@ -1,4 +1,10 @@
-import type { CSSProperties, ReactNode } from 'react';
+import {
+  type CSSProperties,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
@@ -19,20 +25,33 @@ interface Props {
   // every realistic desktop width shows the mobile drawer layout instead of
   // the desktop palette the page's copy describes. `breakout` escapes the
   // iframe past the article column's max-width, right up to the page edges,
-  // which clears `md` from ~1150px up. `box-sizing: border-box` matters
-  // here: without it, the 1px border pushes the content box (and so the
-  // breakpoint check) 2px narrower than the frame's own reported width,
-  // occasionally missing `md` by exactly that margin.
+  // which clears `md` from ~1150px up.
   //
-  // Uses `--scrollbar-width` (custom.css) rather than bare `100vw`/`-50vw`:
-  // on a non-overlay scrollbar (Windows/Linux desktop), `100vw` includes the
-  // scrollbar's own width, so the naive full-bleed technique overflowed past
-  // the page's actual visible right edge and forced a page-wide horizontal
-  // scrollbar — not caught by the original CDP-based verification, since
-  // headless Chrome's overlay scrollbars don't reserve any width, so `100vw`
-  // and the visible width already agreed there.
+  // Measured with JS (getBoundingClientRect on the iframe's own, untouched
+  // parent) rather than a pure-CSS `100vw`/`-50vw` full-bleed trick — #224
+  // found two independent ways that trick breaks on this site's actual doc
+  // layout: (1) a `--scrollbar-width: calc(100vw - 100%)` custom property
+  // doesn't resolve once at :root the way a real constant would — CSS
+  // substitutes it as a token stream at each *use* site, re-resolving
+  // `100%` there, which made #221's version a complete no-op (its width
+  // and margin cancelled back to exactly the container's own box); (2)
+  // even the original `100vw`/`-50vw` form (#215) assumes the container is
+  // horizontally centered in the viewport, which doesn't hold on this
+  // layout (a left sidebar), so it overflowed the visible viewport on the
+  // right by however far off-center the column actually sits. Measuring
+  // the real DOM position sidesteps both: no constant-folding assumption,
+  // no centering assumption.
   breakout?: boolean;
 }
+
+const baseStyle: CSSProperties = {
+  display: 'block',
+  width: '100%',
+  boxSizing: 'border-box',
+  border: '1px solid var(--ifm-color-emphasis-300)',
+  borderRadius: 'var(--ifm-global-radius)',
+  background: 'var(--ifm-background-surface-color)',
+};
 
 export default function DemoFrame({
   src,
@@ -41,23 +60,56 @@ export default function DemoFrame({
   breakout = false,
 }: Props): ReactNode {
   const url = useBaseUrl(src);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  // Empty until the first post-mount measurement, so server-rendered and
+  // first-paint markup is the safe non-breakout (100%-width) layout rather
+  // than a guess — avoids ever rendering an overflowing box, at the cost
+  // of a one-time widen once JS measures the real position.
+  const [breakoutStyle, setBreakoutStyle] = useState<CSSProperties>({});
 
-  const style: CSSProperties = {
-    display: 'block',
-    width: '100%',
-    height,
-    boxSizing: 'border-box',
-    border: '1px solid var(--ifm-color-emphasis-300)',
-    borderRadius: 'var(--ifm-global-radius)',
-    background: 'var(--ifm-background-surface-color)',
-    ...(breakout && {
-      position: 'relative',
-      width: 'calc(100vw - var(--scrollbar-width, 0px))',
-      maxWidth: 'calc(100vw - var(--scrollbar-width, 0px))',
-      left: '50%',
-      marginLeft: 'calc(-50vw + (var(--scrollbar-width, 0px) / 2))',
-    }),
-  };
+  useEffect(() => {
+    if (!breakout) {
+      return;
+    }
+
+    const update = () => {
+      // Measures the iframe's own parent, not the iframe itself: the
+      // parent is never given breakout styles, so its rect stays an
+      // accurate, stable reference on every recomputation. Measuring the
+      // iframe directly here would read back whatever offset a *previous*
+      // update already applied, compounding instead of correcting.
+      const parent = iframeRef.current?.parentElement;
+
+      if (!parent) {
+        return;
+      }
+
+      const rect = parent.getBoundingClientRect();
+      const viewportWidth = document.documentElement.clientWidth;
+
+      setBreakoutStyle({
+        position: 'relative',
+        width: `${viewportWidth}px`,
+        maxWidth: `${viewportWidth}px`,
+        marginLeft: `${-rect.left}px`,
+      });
+    };
+
+    update();
+
+    const parent = iframeRef.current?.parentElement;
+    const resizeObserver = parent ? new ResizeObserver(update) : undefined;
+    resizeObserver?.observe(parent!);
+    // Belt-and-suspenders alongside the ResizeObserver: a scrollbar
+    // appearing/disappearing (changing document.documentElement.clientWidth)
+    // doesn't necessarily resize the column element the observer watches.
+    window.addEventListener('resize', update);
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, [breakout]);
 
   // The demos are served from `static/demos/*` on the same origin as the docs
   // site and run arbitrary reader-authored code (the Editor demo compiles and
@@ -69,10 +121,11 @@ export default function DemoFrame({
   // `allow-scripts` it would hand the frame its origin back and defeat this.
   return (
     <iframe
+      ref={iframeRef}
       src={url}
       title={title}
       loading="lazy"
-      style={style}
+      style={{ ...baseStyle, height, ...breakoutStyle }}
       sandbox="allow-scripts"
     />
   );

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -12,19 +12,6 @@
    investigation for the byte-identical computed-style verification. */
 @import '@jbpark/live-editor/style.css';
 
-/* `100%` on the root element resolves against the viewport minus the
-   vertical scrollbar's own width (browsers carve the scrollbar out of the
-   root's layout box), while `100vw` includes it — so the difference is
-   exactly the scrollbar's width. DemoFrame's `breakout` full-bleed layout
-   subtracts this to avoid overflowing past the page's actual visible
-   right edge on non-overlay scrollbars (Windows/Linux desktop Chrome/
-   Firefox), which otherwise adds a page-wide horizontal scrollbar. Evaluates
-   to 0px on platforms with overlay scrollbars (macOS, mobile), where
-   `100vw` and `100%` already agree. */
-:root {
-  --scrollbar-width: calc(100vw - 100%);
-}
-
 /* Live Editor's black-and-white palette replaces Docusaurus' default green
    theme — matches ui-kit docs' monochrome tone (and the favicon). A neutral
    scale sidesteps the pastel-on-dark-page problem a hue-based accent runs


### PR DESCRIPTION
## Summary
`#221`'s `--scrollbar-width: calc(100vw - 100%)` custom property doesn't resolve once at `:root` the way a real constant would — CSS substitutes it as a token stream at each *use* site, re-resolving `100%` there against whatever element uses the variable. Substituted and simplified, `calc(100vw - var(--scrollbar-width))` collapses back to exactly the container's own width, and the matching `margin-left` math cancels `left: 50%` exactly — the whole breakout was a complete no-op, silently reverting #215's original fix.

Even before that, #215's own `100vw`/`-50vw` full-bleed form assumed the container is horizontally centered in the viewport, which doesn't hold on this site's actual layout (a left sidebar) — it overflowed the visible viewport on the right by however far off-center the column sits.

Pure CSS got this wrong twice for two independent reasons, so this switches to measuring the real DOM position with JS: `getBoundingClientRect` on the iframe's own (untouched) parent, re-measured via a `ResizeObserver` plus a window resize listener. No constant-folding assumption, no centering assumption — exact by construction regardless of sidebar width or scrollbar presence. Server-rendered/first-paint markup stays the safe non-breakout 100%-width layout until the first client measurement, so this never renders an overflowing box.

Fixes #224

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes — verified compiled static HTML: initial markup is the safe `width:100%` fallback, no leftover `--scrollbar-width` references
- [x] `pnpm test` — 225 tests pass