### PR TITLE
🐛 fix: pass render/min/max/pattern/required through to renderPanel

### DIFF
--- a/.changeset/fix-panel-binding-passthrough.md
+++ b/.changeset/fix-panel-binding-passthrough.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fixed `renderPanel`'s `PanelBinding` silently dropping `render`, `min`, `max`, `pattern`, and `required` from each binding — a custom panel had no way to type a nested `object`/`array` key or validate a constraint, even though `validateBindingValue` was already exported for exactly that purpose. Also fixed `validateBindingValue` skipping `min`/`max` for a numeric string, which is the only form `PanelBinding.value` ever takes — the built-in panel worked around this itself with an ad-hoc `Number(next)` coercion before calling it, now removed since the exported helper handles it directly.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -27,6 +27,7 @@ import { DRAGGABLE_ITEMS } from '~/constants';
 import type { Section } from '~/types';
 import {
   type BindingOption,
+  type BindingRenderMap,
   type BindingType,
   type DataAttrNode,
   extract,
@@ -106,6 +107,17 @@ export interface PanelBinding {
   type?: BindingType;
   // Present when the binding defines a fixed option set (render a <select>).
   options?: BindingOption[];
+  // Present for `object`/`array` bindings whose nested keys/items declare
+  // their own types — the same map the built-in panel uses to type each
+  // nested field instead of falling back to a plain string input.
+  render?: BindingRenderMap;
+  // Constraints declared on the binding. `min`/`max` apply even though
+  // `value` below is a string (see `validateBindingValue`, which coerces
+  // numeric strings before comparing).
+  min?: number;
+  max?: number;
+  pattern?: string;
+  required?: boolean;
   // Current serialized value — the same string the built-in field receives.
   value: string;
   // Commit a new value through the same AST-update pipeline the built-in
@@ -456,6 +468,11 @@ const Dnd = ({
         property: binding.property,
         type: binding.type,
         options: binding.options,
+        render: binding.render,
+        min: binding.min,
+        max: binding.max,
+        pattern: binding.pattern,
+        required: binding.required,
         value: getCurrentValue(node, binding.property),
         onChange: (value: string) =>
           onFieldChange({ id: dataId, label: binding.label, value }),

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -507,10 +507,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
           placeholder="Enter a numeric value"
           onBlur={e => {
             const next = e.target.value.trim();
-            const result = validateBindingValue(
-              binding,
-              next ? Number(next) : '',
-            );
+            const result = validateBindingValue(binding, next);
 
             if (!result.valid) {
               setValidationError(result.message ?? 'Invalid value.');

--- a/src/utils/ast/validate.test.ts
+++ b/src/utils/ast/validate.test.ts
@@ -92,6 +92,36 @@ describe('validateBindingValue', () => {
     ).toEqual({ valid: true });
   });
 
+  // PanelBinding.value (what a custom renderPanel receives) is always a
+  // string, even for type: 'number' bindings — see #225. These pin that
+  // min/max apply to the numeric-string form the same way they already do
+  // for an actual number.
+  it('fails when a numeric string is below min', () => {
+    const result = validateBindingValue(makeBinding({ min: 10 }), '5');
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('10');
+  });
+
+  it('fails when a numeric string is above max', () => {
+    const result = validateBindingValue(makeBinding({ max: 100 }), '150');
+
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('100');
+  });
+
+  it('passes when a numeric string is within min/max bounds', () => {
+    expect(validateBindingValue(makeBinding({ min: 0, max: 10 }), '5')).toEqual(
+      { valid: true },
+    );
+  });
+
+  it('does not apply min/max to a whitespace-only string', () => {
+    expect(
+      validateBindingValue(makeBinding({ min: 10, max: 20 }), '   '),
+    ).toEqual({ valid: true });
+  });
+
   it('does not apply pattern to non-string values', () => {
     expect(
       validateBindingValue(makeBinding({ pattern: '^[0-9]+$' }), 42),

--- a/src/utils/ast/validate.ts
+++ b/src/utils/ast/validate.ts
@@ -20,11 +20,27 @@ export const validateBindingValue = (
     return VALID;
   }
 
-  if (typeof value === 'number') {
-    if (binding.min !== undefined && value < binding.min) {
+  // `PanelBinding.value` (the value a custom renderPanel gets) is always a
+  // string, even for `type: 'number'` bindings — coerce a numeric string
+  // the same way the built-in field does today (see field.tsx's ad-hoc
+  // `Number(next)`), so min/max apply to both callers instead of silently
+  // no-op'ing on the string form. A non-numeric string (`NaN`) or
+  // whitespace-only string is left alone; `isEmpty` above already handles
+  // the plain empty-string case.
+  const numericValue =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' &&
+          value.trim() !== '' &&
+          !Number.isNaN(Number(value))
+        ? Number(value)
+        : undefined;
+
+  if (numericValue !== undefined) {
+    if (binding.min !== undefined && numericValue < binding.min) {
       return { valid: false, message: `Must be at least ${binding.min}.` };
     }
-    if (binding.max !== undefined && value > binding.max) {
+    if (binding.max !== undefined && numericValue > binding.max) {
       return { valid: false, message: `Must be at most ${binding.max}.` };
     }
   }

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -140,17 +140,35 @@ the built-in panel uses. Switch on `binding.type` to render your own control:
 | `property` | `string` | The bound prop/attribute name. |
 | `type` | `BindingType?` | The declared data-binding type — switch on this to pick a control. `undefined` means a plain string binding. See the full list below. |
 | `options` | `BindingOption[]?` | Present when the binding defines a fixed option set (render a `<select>`). |
+| `render` | `BindingRenderMap?` | Present on `object`/`array` bindings whose nested keys/items declare their own types — walk it to type each nested field instead of treating the value as an opaque string. |
+| `min` | `number?` | Minimum value for a `number` binding. Applies to `value` below even though it's a string — pass it straight to `validateBindingValue`, which coerces numeric strings. |
+| `max` | `number?` | Maximum value for a `number` binding, same coercion as `min`. |
+| `pattern` | `string?` | A regex source the value must match. |
+| `required` | `boolean?` | Whether an empty value should fail validation. |
 | `value` | `string` | Current serialized value. |
 | `onChange` | `(value: string) => void` | Commit an edit through the same AST-update pipeline (including the error toast on a bad edit). |
 
-`BindingType` is a closed union of 12 values, since a `renderPanel` is
-expected to switch on it exhaustively: `array`, `object`, `string`, `number`,
-`boolean`, `color`, `jsx`, `richtext`, `date`, `url`, `icon-picker`,
-`asset-picker`.
+`BindingType` is a closed union of 12 values: `array`, `object`, `string`,
+`number`, `boolean`, `color`, `jsx`, `richtext`, `date`, `url`,
+`icon-picker`, `asset-picker`. Switching on it alone is enough for the
+scalar types, but `object`/`array` values are only opaque strings unless
+the binding also declares `render` — check for it before assuming you can
+treat those two types as plain text.
 
-`BindingType` and `BindingOption` aren't exported from the package root —
-import them from the `utils/ast` subpath instead:
+Constraints declared on a binding (`min`/`max`/`pattern`/`required`) aren't
+enforced automatically — call the exported `validateBindingValue(binding,
+value)` yourself before committing an edit, the same way the built-in panel
+does.
+
+`BindingType`, `BindingOption`, `BindingRenderMap`, and `validateBindingValue`
+aren't exported from the package root — import them from the `utils/ast`
+subpath instead:
 
 ```ts
-import type { BindingOption, BindingType } from '@jbpark/live-editor/utils/ast';
+import {
+  type BindingOption,
+  type BindingRenderMap,
+  type BindingType,
+  validateBindingValue,
+} from '@jbpark/live-editor/utils/ast';
 ```


### PR DESCRIPTION
## Summary
`PanelBinding` dropped 5 of `BindingItem`'s 9 fields (`render`, `min`, `max`, `pattern`, `required`), even though `parseBinding` already recovers them correctly — the loss was strictly in `Dnd`'s flattening. Without `render`, a custom panel can't type a nested `object`/`array` key; without `min`/`max`/`pattern`/`required`, it can't call the already-exported `validateBindingValue` meaningfully.

Fixed together with a second bug that would have made `min`/`max` silently no-op even after passthrough: `PanelBinding.value` is always a string, but `validateBindingValue` only checked `min`/`max` for `typeof value === 'number'`. Coerces a numeric string the same way `field.tsx`'s own ad-hoc `Number(next)` did — now removed since the exported helper handles it.

- `dnd.tsx`: `PanelBinding` gains `render`/`min`/`max`/`pattern`/`required`; the bindings flattening passes them through instead of discarding them
- `validate.ts`: `validateBindingValue` coerces a non-empty numeric string before comparing against `min`/`max`
- `field.tsx`: drops the now-redundant `Number(next)` coercion
- `validate.test.ts`: pins the numeric-string min/max behavior
- `custom-palette-panel.mdx`: documents the new `PanelBinding` fields, `validateBindingValue` as the way to enforce them, and corrects the claim that `BindingType` alone is enough for exhaustive switching (`object`/`array` are opaque strings without `render`)

Fixes #225

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm test` — 229 tests pass (225 previous + 4 new)
- [x] Verified against the issue's own reproduction script: the string `'9'` against `{min:1, max:6}` now returns `{"valid":false,"message":"Must be at most 6."}`, matching the number form (previously `{"valid":true}`)