### PR TITLE
✨ feat: infer nested object/array fields in custom-palette-panel demo

### DIFF
--- a/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
+++ b/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
@@ -4,9 +4,182 @@ import { Button } from '@jbpark/ui-kit';
 import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 
 import Context from '~/components/context';
-import Dnd from '~/components/dnd';
+import Dnd, { type PanelBinding } from '~/components/dnd';
 import { DEFAULT_TEMPLATE } from '~/constants';
 import { cn } from '~/utils';
+import { parseValue, validateBindingValue } from '~/utils/ast';
+
+type Primitive = string | number | boolean;
+
+const isPrimitive = (value: unknown): value is Primitive =>
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean';
+
+// A binding's declared `type`/`render` (see #225) is one way to know a
+// value is structured, but most existing content — e.g. the shipped
+// Hero item's "Background Style" binding on `style` — declares neither;
+// it's just an object-shaped string because that's what `style` actually
+// is. `parseValue` (also exported from utils/ast) recovers the real JS
+// value from that string regardless, so inferring structure from the
+// *parsed value's own shape* works on binding declared today, not just
+// ones authored with a `render` map in mind. Kept intentionally shallow:
+// an object/array is only treated as editable here if every one of its
+// own values is a primitive — a nested object/array falls back to the
+// plain text field below rather than recursing.
+interface EditableShape {
+  isArray: boolean;
+  entries: { key: string; value: Primitive }[];
+}
+
+const parseEditableShape = (value: string): EditableShape | null => {
+  const parsed = parseValue(value);
+
+  if (Array.isArray(parsed)) {
+    return parsed.every(isPrimitive)
+      ? {
+          isArray: true,
+          entries: parsed.map((item, index) => ({
+            key: String(index),
+            value: item,
+          })),
+        }
+      : null;
+  }
+
+  if (typeof parsed === 'object' && parsed !== null) {
+    const entries = Object.entries(parsed);
+    return entries.every(([, v]) => isPrimitive(v))
+      ? {
+          isArray: false,
+          entries: entries.map(([key, value]) => ({
+            key,
+            value: value as Primitive,
+          })),
+        }
+      : null;
+  }
+
+  return null;
+};
+
+const ParsedValueField = ({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: Primitive;
+  onChange: (next: Primitive) => void;
+}) => {
+  if (typeof value === 'boolean') {
+    return (
+      <label className="flex items-center justify-between gap-2">
+        <span className="text-xs text-gray-600">{label}</span>
+        <input
+          type="checkbox"
+          checked={value}
+          onChange={e => onChange(e.target.checked)}
+        />
+      </label>
+    );
+  }
+
+  if (typeof value === 'number') {
+    return (
+      <label className="flex items-center justify-between gap-2">
+        <span className="text-xs text-gray-600">{label}</span>
+        <input
+          type="number"
+          className="w-20 rounded border border-gray-300 px-2 py-1 text-sm"
+          defaultValue={value}
+          onBlur={e => onChange(Number(e.target.value))}
+        />
+      </label>
+    );
+  }
+
+  return (
+    <label className="flex items-center justify-between gap-2">
+      <span className="text-xs text-gray-600">{label}</span>
+      <input
+        className="w-32 rounded border border-gray-300 px-2 py-1 text-sm"
+        defaultValue={value}
+        onBlur={e => onChange(e.target.value)}
+      />
+    </label>
+  );
+};
+
+// Renders one labeled input per key/index of an object- or array-shaped
+// binding value, reconstructing and re-serializing the whole structure on
+// each field's change. `shape` is recomputed by the caller from the raw
+// string each render, so this always reflects the latest committed value.
+const ParsedValueEditor = ({
+  binding,
+  shape,
+}: {
+  binding: PanelBinding;
+  shape: EditableShape;
+}) => {
+  const onFieldChange = (key: string, next: Primitive) => {
+    const nextEntries = shape.entries.map(entry =>
+      entry.key === key ? { ...entry, value: next } : entry,
+    );
+    const nextValue = shape.isArray
+      ? nextEntries.map(entry => entry.value)
+      : Object.fromEntries(nextEntries.map(entry => [entry.key, entry.value]));
+
+    binding.onChange(JSON.stringify(nextValue));
+  };
+
+  return (
+    <div className="space-y-2 rounded border border-gray-200 p-2">
+      {shape.entries.map(({ key, value }) => (
+        <ParsedValueField
+          key={key}
+          label={shape.isArray ? `[${key}]` : key}
+          value={value}
+          onChange={next => onFieldChange(key, next)}
+        />
+      ))}
+    </div>
+  );
+};
+
+// The plain-input fallback field, running `binding.min`/`max`/`pattern`/
+// `required` through the exported `validateBindingValue` before
+// committing — those constraints reach here as of #225, but nothing
+// calls them automatically; a custom panel still has to invoke the
+// helper itself.
+const ValidatedField = ({ binding }: { binding: PanelBinding }) => {
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <div>
+      <input
+        className={cn(
+          'w-full rounded border px-2 py-1 text-sm',
+          error ? 'border-red-400' : 'border-gray-300',
+        )}
+        defaultValue={binding.value}
+        onBlur={e => {
+          const next = e.target.value;
+          const result = validateBindingValue(binding, next);
+
+          if (!result.valid) {
+            setError(result.message ?? 'Invalid value.');
+            return;
+          }
+
+          setError(null);
+          binding.onChange(next);
+        }}
+      />
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  );
+};
 
 // Custom Palette & Panel demo. Mirrors the app's `pages/docs/dnd-custom-render`:
 // `Dnd`'s `renderPalette`/`renderPanel` fully replace the built-in layouts.
@@ -94,6 +267,9 @@ const CustomPalettePanelDemo = () => {
                     bindings.map((binding, index) => {
                       const isMultiline =
                         binding.type === 'jsx' || binding.type === 'richtext';
+                      const shape = isMultiline
+                        ? null
+                        : parseEditableShape(binding.value);
 
                       return (
                         <label
@@ -103,7 +279,12 @@ const CustomPalettePanelDemo = () => {
                           <span className="text-xs font-semibold text-gray-700">
                             {binding.label}
                           </span>
-                          {binding.options ? (
+                          {shape ? (
+                            <ParsedValueEditor
+                              binding={binding}
+                              shape={shape}
+                            />
+                          ) : binding.options ? (
                             <select
                               className="w-full rounded border border-gray-300
                                 px-2 py-1 text-sm"
@@ -125,12 +306,7 @@ const CustomPalettePanelDemo = () => {
                               onBlur={e => binding.onChange(e.target.value)}
                             />
                           ) : (
-                            <input
-                              className="w-full rounded border border-gray-300
-                                px-2 py-1 text-sm"
-                              defaultValue={binding.value}
-                              onBlur={e => binding.onChange(e.target.value)}
-                            />
+                            <ValidatedField binding={binding} />
                           )}
                         </label>
                       );

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -19,6 +19,11 @@ drag-and-drop and field editing keep working exactly as before.
   breakout
 />
 
+Drag in the demo's **Hero** item and select it to see its "Background
+Style" field — an object-shaped binding with no declared `type` at all —
+rendered as one input per key instead of an opaque string, by inferring
+structure from the parsed value rather than requiring it upfront.
+
 ## Custom palette
 
 `renderPalette` receives a `PaletteRenderData` object:


### PR DESCRIPTION
## Summary
Follow-up to #225 — now that `renderPanel` actually receives `render`/`min`/`max`, a custom panel has enough to build a nested field editor. Rather than adding new demo content authored specifically to have a `render` map, this infers editable structure from the parsed value itself, so it works on content that already ships today: the shared `DRAGGABLE_ITEMS`' Hero item has an object-shaped "Background Style" binding on `style` with no declared type at all, and it's now editable field-by-field without any changes to that binding's declaration.

- `parseEditableShape`: parses a binding's current value (`parseValue`, also exported from `utils/ast`) and, if it's an object or array whose own members are all primitives (string/number/boolean), returns one `{key, value}` entry per member. A nested object/array, or a value that isn't object/array-shaped at all, returns `null` and falls through to the existing plain-field handling untouched.
- `ParsedValueEditor`/`ParsedValueField`: one labeled input per entry, picking checkbox/number/text from the value's own type, reconstructing and re-serializing the whole structure through `binding.onChange` on each field's change.
- `ValidatedField`: the plain-input fallback now runs `binding.min`/`max`/`pattern`/`required` through the exported `validateBindingValue` before committing. Kept as a wiring reference even though nothing in `DRAGGABLE_ITEMS` currently declares those constraints (a separate follow-up, not part of this change).
- `custom-palette-panel.mdx`: points readers at Hero's existing Background Style field instead of asking them to author new content

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` + `pnpm build:demos` pass
- [x] `pnpm test` — 229 tests pass
- [x] `website` typecheck + build pass
- [x] Verified compiled demo bundle contains no leftover references from an earlier iteration of this change