### PR TITLE
✨ feat: add flattenEditableValue/setEditableValue for structured bindings

### DIFF
--- a/.changeset/feat-flatten-editable-value.md
+++ b/.changeset/feat-flatten-editable-value.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Added `flattenEditableValue`/`setEditableValue` (`@jbpark/live-editor/utils/ast`) — a follow-up to #225's `render`/`min`/`max`/`pattern`/`required` passthrough. `flattenEditableValue` recovers editable structure directly from a binding's current value, with no `render` map declaration required: it parses the value and, if it's an object or array, recursively walks it into one `{ path, value }` entry per primitive leaf, treating a JSX-bearing string (e.g. a further, separately data-bound nested element) as an opaque leaf rather than decomposing it further. `setEditableValue(value, path, next)` is the companion setter — it replaces just that one leaf and re-serializes the whole structure back into a string for `PanelBinding.onChange`. Together they let a custom `renderPanel` build a field-by-field editor for structured bindings (including an array of objects, like the shipped Stats/FAQ sections' `items`) without reimplementing the built-in panel's recursive decomposition, and without requiring the binding to declare a `render` map ahead of time.

--- a/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
+++ b/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
@@ -7,61 +7,13 @@ import Context from '~/components/context';
 import Dnd, { type PanelBinding } from '~/components/dnd';
 import { DEFAULT_TEMPLATE } from '~/constants';
 import { cn } from '~/utils';
-import { parseValue, validateBindingValue } from '~/utils/ast';
-
-type Primitive = string | number | boolean;
-
-const isPrimitive = (value: unknown): value is Primitive =>
-  typeof value === 'string' ||
-  typeof value === 'number' ||
-  typeof value === 'boolean';
-
-// A binding's declared `type`/`render` (see #225) is one way to know a
-// value is structured, but most existing content — e.g. the shipped
-// Hero item's "Background Style" binding on `style` — declares neither;
-// it's just an object-shaped string because that's what `style` actually
-// is. `parseValue` (also exported from utils/ast) recovers the real JS
-// value from that string regardless, so inferring structure from the
-// *parsed value's own shape* works on binding declared today, not just
-// ones authored with a `render` map in mind. Kept intentionally shallow:
-// an object/array is only treated as editable here if every one of its
-// own values is a primitive — a nested object/array falls back to the
-// plain text field below rather than recursing.
-interface EditableShape {
-  isArray: boolean;
-  entries: { key: string; value: Primitive }[];
-}
-
-const parseEditableShape = (value: string): EditableShape | null => {
-  const parsed = parseValue(value);
-
-  if (Array.isArray(parsed)) {
-    return parsed.every(isPrimitive)
-      ? {
-          isArray: true,
-          entries: parsed.map((item, index) => ({
-            key: String(index),
-            value: item,
-          })),
-        }
-      : null;
-  }
-
-  if (typeof parsed === 'object' && parsed !== null) {
-    const entries = Object.entries(parsed);
-    return entries.every(([, v]) => isPrimitive(v))
-      ? {
-          isArray: false,
-          entries: entries.map(([key, value]) => ({
-            key,
-            value: value as Primitive,
-          })),
-        }
-      : null;
-  }
-
-  return null;
-};
+import {
+  type EditablePrimitive,
+  type EditableValueEntry,
+  flattenEditableValue,
+  setEditableValue,
+  validateBindingValue,
+} from '~/utils/ast';
 
 const ParsedValueField = ({
   label,
@@ -69,8 +21,8 @@ const ParsedValueField = ({
   onChange,
 }: {
   label: string;
-  value: Primitive;
-  onChange: (next: Primitive) => void;
+  value: EditablePrimitive;
+  onChange: (next: EditablePrimitive) => void;
 }) => {
   if (typeof value === 'boolean') {
     return (
@@ -111,41 +63,34 @@ const ParsedValueField = ({
   );
 };
 
-// Renders one labeled input per key/index of an object- or array-shaped
-// binding value, reconstructing and re-serializing the whole structure on
-// each field's change. `shape` is recomputed by the caller from the raw
-// string each render, so this always reflects the latest committed value.
+// Renders one labeled input per leaf `flattenEditableValue` (utils/ast)
+// found in the binding's current value — including a leaf nested inside
+// an array of objects, e.g. the shipped Stats/FAQ sections' `items` array
+// of `{ key, children }`, where `children` is itself a further, separately
+// data-bound element and is treated as an opaque text leaf here rather
+// than decomposed. Each field commits through `setEditableValue`, which
+// replaces just that one leaf and re-serializes the whole structure back
+// into the string `binding.onChange` expects.
 const ParsedValueEditor = ({
   binding,
-  shape,
+  entries,
 }: {
   binding: PanelBinding;
-  shape: EditableShape;
-}) => {
-  const onFieldChange = (key: string, next: Primitive) => {
-    const nextEntries = shape.entries.map(entry =>
-      entry.key === key ? { ...entry, value: next } : entry,
-    );
-    const nextValue = shape.isArray
-      ? nextEntries.map(entry => entry.value)
-      : Object.fromEntries(nextEntries.map(entry => [entry.key, entry.value]));
-
-    binding.onChange(JSON.stringify(nextValue));
-  };
-
-  return (
-    <div className="space-y-2 rounded border border-gray-200 p-2">
-      {shape.entries.map(({ key, value }) => (
-        <ParsedValueField
-          key={key}
-          label={shape.isArray ? `[${key}]` : key}
-          value={value}
-          onChange={next => onFieldChange(key, next)}
-        />
-      ))}
-    </div>
-  );
-};
+  entries: EditableValueEntry[];
+}) => (
+  <div className="space-y-2 rounded border border-gray-200 p-2">
+    {entries.map(({ path, value }) => (
+      <ParsedValueField
+        key={path.join('.')}
+        label={path.join('.')}
+        value={value}
+        onChange={next =>
+          binding.onChange(setEditableValue(binding.value, path, next))
+        }
+      />
+    ))}
+  </div>
+);
 
 // The plain-input fallback field, running `binding.min`/`max`/`pattern`/
 // `required` through the exported `validateBindingValue` before
@@ -267,9 +212,9 @@ const CustomPalettePanelDemo = () => {
                     bindings.map((binding, index) => {
                       const isMultiline =
                         binding.type === 'jsx' || binding.type === 'richtext';
-                      const shape = isMultiline
+                      const entries = isMultiline
                         ? null
-                        : parseEditableShape(binding.value);
+                        : flattenEditableValue(binding.value);
 
                       return (
                         <label
@@ -279,10 +224,10 @@ const CustomPalettePanelDemo = () => {
                           <span className="text-xs font-semibold text-gray-700">
                             {binding.label}
                           </span>
-                          {shape ? (
+                          {entries ? (
                             <ParsedValueEditor
                               binding={binding}
-                              shape={shape}
+                              entries={entries}
                             />
                           ) : binding.options ? (
                             <select

--- a/src/utils/ast/index.ts
+++ b/src/utils/ast/index.ts
@@ -11,13 +11,20 @@ export type {
 } from './types';
 
 export { findEditableChildren, getCurrentValue, parseBinding } from './binding';
+export type {
+  EditablePathSegment,
+  EditablePrimitive,
+  EditableValueEntry,
+} from './value';
 export {
   arrayExpressionToCode,
   createNodeFromValue,
   extractNodeValue,
   extractObjectProperties,
+  flattenEditableValue,
   parseArrayExpression,
   parseValue,
+  setEditableValue,
 } from './value';
 export { generateCode } from './helpers';
 export { clearExtractCache, extract } from './extract';

--- a/src/utils/ast/value.test.ts
+++ b/src/utils/ast/value.test.ts
@@ -8,8 +8,10 @@ import {
   createNodeFromValue,
   extractNodeValue,
   extractObjectProperties,
+  flattenEditableValue,
   parseArrayExpression,
   parseValue,
+  setEditableValue,
 } from './value';
 
 describe('parseValue', () => {
@@ -252,5 +254,96 @@ describe('arrayExpressionToCode', () => {
     expect(code).toBe(generateCode(t.arrayExpression(elements)));
     expect(code).toContain('a: 1');
     expect(code).toContain('b: 2');
+  });
+});
+
+describe('flattenEditableValue', () => {
+  it('flattens a simple object into one entry per key', () => {
+    expect(flattenEditableValue("{ backgroundColor: '#6366f1' }")).toEqual([
+      { path: ['backgroundColor'], value: '#6366f1' },
+    ]);
+  });
+
+  it('flattens an array of primitives into one entry per index', () => {
+    expect(flattenEditableValue('[1, 2, 3]')).toEqual([
+      { path: [0], value: 1 },
+      { path: [1], value: 2 },
+      { path: [2], value: 3 },
+    ]);
+  });
+
+  it('recurses into an array of objects, treating a JSX-bearing string as a leaf', () => {
+    const value = `[{ key: 'stats-row', children: <div data-id="x">Some JSX</div> }]`;
+
+    expect(flattenEditableValue(value)).toEqual([
+      { path: [0, 'key'], value: 'stats-row' },
+      { path: [0, 'children'], value: '<div data-id="x">Some JSX</div>' },
+    ]);
+  });
+
+  it('recurses into a plain nested object', () => {
+    expect(flattenEditableValue('{a: {b: {c: 1}}}')).toEqual([
+      { path: ['a', 'b', 'c'], value: 1 },
+    ]);
+  });
+
+  it('returns null for a value that is not object/array-shaped', () => {
+    expect(flattenEditableValue('42')).toBeNull();
+    expect(flattenEditableValue('hello')).toBeNull();
+  });
+
+  it('returns null for an empty object or array', () => {
+    expect(flattenEditableValue('{}')).toBeNull();
+    expect(flattenEditableValue('[]')).toBeNull();
+  });
+
+  it('omits null/undefined values rather than representing them as a leaf', () => {
+    expect(flattenEditableValue('{a: 1, b: null, c: undefined}')).toEqual([
+      { path: ['a'], value: 1 },
+    ]);
+  });
+});
+
+describe('setEditableValue', () => {
+  it('replaces a top-level key and re-serializes', () => {
+    const result = setEditableValue("{a: 1, b: 'x'}", ['a'], 2);
+
+    expect(JSON.parse(result)).toEqual({ a: 2, b: 'x' });
+  });
+
+  it('replaces a leaf nested inside an array of objects', () => {
+    const value = `[{ key: 'stats-row', children: <div data-id="x">Some JSX</div> }]`;
+    const result = setEditableValue(value, [0, 'key'], 'new-key');
+
+    expect(JSON.parse(result)).toEqual([
+      { key: 'new-key', children: '<div data-id="x">Some JSX</div>' },
+    ]);
+  });
+
+  it('fails safe (returns the original value) for a missing key', () => {
+    expect(setEditableValue('{a: 1}', ['nonexistent'], 5)).toBe('{a: 1}');
+  });
+
+  it('fails safe (returns the original value) for a path through a non-object', () => {
+    expect(setEditableValue('{a: 1}', ['a', 'b'], 5)).toBe('{a: 1}');
+  });
+
+  it('fails safe (returns the original value) when the value is not object/array-shaped', () => {
+    expect(setEditableValue('42', ['a'], 5)).toBe('42');
+  });
+
+  it('fails safe (returns the original value) for an empty path', () => {
+    expect(setEditableValue('{a: 1}', [], 5)).toBe('{a: 1}');
+  });
+
+  it('round-trips with flattenEditableValue', () => {
+    const value = '[1, 2, 3]';
+    const updated = setEditableValue(value, [1], 99);
+
+    expect(flattenEditableValue(updated)).toEqual([
+      { path: [0], value: 1 },
+      { path: [1], value: 99 },
+      { path: [2], value: 3 },
+    ]);
   });
 });

--- a/src/utils/ast/value.ts
+++ b/src/utils/ast/value.ts
@@ -154,6 +154,134 @@ export const parseValue = (value: unknown): unknown => {
   return value;
 };
 
+export type EditablePathSegment = string | number;
+export type EditablePrimitive = string | number | boolean;
+
+export interface EditableValueEntry {
+  path: EditablePathSegment[];
+  value: EditablePrimitive;
+}
+
+const MAX_FLATTEN_DEPTH = 20;
+
+const isEditablePrimitive = (value: unknown): value is EditablePrimitive =>
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean';
+
+// A binding's data-binding declaration is one way to know a value is
+// structured (`type: 'object'` + a `render` map — see #225), but most
+// existing content declares neither; it's just an object/array-shaped
+// string because that's what the bound prop actually is (e.g. `style`).
+// This recovers editable leaves from the *parsed value's own shape*
+// instead, so it works on content authored without a renderPanel in mind
+// — including an array of objects whose own members embed further JSX
+// (Live Editor's shipped Stats/FAQ sections both look like this: an
+// `items` array of `{ key, children }`, where `children` is itself a
+// nested, separately data-bound element). A JSX-bearing string is never
+// parsed further here — `parseValue` already reduced it to plain text
+// (see `evaluateLiteral`'s JSXElement case), and this function only ever
+// recurses into genuine object/array structure, treating every string,
+// number, and boolean as a leaf regardless of what the string contains.
+// Depth is capped defensively (pathological/deeply-recursive input
+// shouldn't be able to blow the stack); anything past that depth is
+// treated as a leaf-less dead end and simply omitted, not thrown.
+export const flattenEditableValue = (
+  value: string,
+): EditableValueEntry[] | null => {
+  const parsed = parseValue(value);
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    Object.keys(parsed).length === 0
+  ) {
+    return null;
+  }
+
+  const entries: EditableValueEntry[] = [];
+
+  const walk = (node: unknown, path: EditablePathSegment[], depth: number) => {
+    if (depth > MAX_FLATTEN_DEPTH) {
+      return;
+    }
+
+    if (isEditablePrimitive(node)) {
+      entries.push({ path, value: node });
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      node.forEach((item, index) => walk(item, [...path, index], depth + 1));
+      return;
+    }
+
+    if (typeof node === 'object' && node !== null) {
+      Object.entries(node).forEach(([key, item]) =>
+        walk(item, [...path, key], depth + 1),
+      );
+    }
+
+    // null/undefined/function/symbol values have no editable leaf form —
+    // silently omitted rather than represented as, say, an empty string,
+    // which would misrepresent what's actually stored there.
+  };
+
+  walk(parsed, [], 0);
+
+  return entries.length ? entries : null;
+};
+
+// Companion to `flattenEditableValue`: replaces the single leaf at `path`
+// and re-serializes the whole structure — the result is a plain string
+// suitable for `PanelBinding.onChange`/`Dnd`'s AST-update pipeline, same
+// as any other committed value. Fails safe: an out-of-range index, a
+// missing key, or a `value` that didn't parse to an object/array in the
+// first place returns `value` unchanged rather than throwing or silently
+// writing to the wrong place.
+export const setEditableValue = (
+  value: string,
+  path: EditablePathSegment[],
+  next: EditablePrimitive,
+): string => {
+  if (!path.length) {
+    return value;
+  }
+
+  const parsed = parseValue(value);
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return value;
+  }
+
+  const root: unknown = Array.isArray(parsed) ? [...parsed] : { ...parsed };
+  let cursor: Record<EditablePathSegment, unknown> | unknown[] = root as
+    Record<EditablePathSegment, unknown> | unknown[];
+
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i]!;
+    const child = (cursor as Record<EditablePathSegment, unknown>)[key];
+
+    if (typeof child !== 'object' || child === null) {
+      return value;
+    }
+
+    const clonedChild = Array.isArray(child) ? [...child] : { ...child };
+    (cursor as Record<EditablePathSegment, unknown>)[key] = clonedChild;
+    cursor = clonedChild as Record<EditablePathSegment, unknown> | unknown[];
+  }
+
+  const lastKey = path[path.length - 1]!;
+
+  if (!(lastKey in (cursor as object))) {
+    return value;
+  }
+
+  (cursor as Record<EditablePathSegment, unknown>)[lastKey] = next;
+
+  return JSON.stringify(root);
+};
+
 export const extractNodeValue = (node: t.Node): ExtractedNodeValue => {
   if (t.isBooleanLiteral(node)) {
     return { type: 'boolean', value: node.value };

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -22,7 +22,11 @@ drag-and-drop and field editing keep working exactly as before.
 Drag in the demo's **Hero** item and select it to see its "Background
 Style" field — an object-shaped binding with no declared `type` at all —
 rendered as one input per key instead of an opaque string, by inferring
-structure from the parsed value rather than requiring it upfront.
+structure from the parsed value rather than requiring it upfront. Try
+**Stats** or **FAQ** too: their `items` bindings are arrays of objects
+whose own `children`/`label` fields are further, separately data-bound
+JSX elements — each array entry gets its own group of fields instead of
+one opaque blob for the whole array.
 
 ## Custom palette
 
@@ -156,24 +160,64 @@ the built-in panel uses. Switch on `binding.type` to render your own control:
 `BindingType` is a closed union of 12 values: `array`, `object`, `string`,
 `number`, `boolean`, `color`, `jsx`, `richtext`, `date`, `url`,
 `icon-picker`, `asset-picker`. Switching on it alone is enough for the
-scalar types, but `object`/`array` values are only opaque strings unless
-the binding also declares `render` — check for it before assuming you can
-treat those two types as plain text.
+scalar types; for `object`/`array` values, see `flattenEditableValue`
+below rather than treating them as plain text.
 
 Constraints declared on a binding (`min`/`max`/`pattern`/`required`) aren't
 enforced automatically — call the exported `validateBindingValue(binding,
 value)` yourself before committing an edit, the same way the built-in panel
 does.
 
-`BindingType`, `BindingOption`, `BindingRenderMap`, and `validateBindingValue`
-aren't exported from the package root — import them from the `utils/ast`
-subpath instead:
+### Editing `object`/`array` values
+
+`binding.value` is always a string — for an `object`/`array` binding, that
+string is a serialized structure, not a scalar. A binding's own declared
+`render` map (above) is one way to know how to decompose it, but most
+content doesn't declare one; e.g. the shipped Hero item's "Background
+Style" binding on `style` has no `type` or `render` at all, since `style`
+is just naturally object-shaped.
+
+`flattenEditableValue(value)` recovers editable structure straight from
+the value itself, with no declaration required: it parses the string
+(the same way `parseValue` does) and, if the result is an object or array,
+recursively walks it, returning one `{ path, value }` entry per primitive
+leaf found. `path` is a list of keys/indices you can hand to
+`setEditableValue` to commit an edit to just that leaf, re-serializing the
+whole structure back into a string for `binding.onChange`. A nested
+object/array is walked into further; a string, number, or boolean is
+always a leaf — including one that happens to contain JSX. This is what
+lets it handle the shipped Stats/FAQ sections' `items` arrays of
+`{ key, children }`, where `children` is itself a separately data-bound
+JSX element: `children` comes back as one opaque text leaf rather than
+being decomposed further, exactly like `parseValue` already treats JSX
+elsewhere.
+
+```tsx
+const entries = flattenEditableValue(binding.value);
+// null if the value isn't an object/array, or is empty
+
+entries?.map(({ path, value }) => (
+  <input
+    key={path.join('.')}
+    defaultValue={String(value)}
+    onBlur={e =>
+      binding.onChange(setEditableValue(binding.value, path, e.target.value))
+    }
+  />
+));
+```
+
+`BindingType`, `BindingOption`, `BindingRenderMap`, `validateBindingValue`,
+`flattenEditableValue`, and `setEditableValue` aren't exported from the
+package root — import them from the `utils/ast` subpath instead:
 
 ```ts
 import {
   type BindingOption,
   type BindingRenderMap,
   type BindingType,
+  flattenEditableValue,
+  setEditableValue,
   validateBindingValue,
 } from '@jbpark/live-editor/utils/ast';
 ```


### PR DESCRIPTION
## Summary
Follow-up to #225 and the custom-palette-panel demo work: a custom `renderPanel` can now decompose an object/array binding into per-leaf fields without a declared `render` map, and without reimplementing the built-in panel's recursive Items/Field decomposition itself.

- `value.ts`: `flattenEditableValue(value)` parses a binding's current value and, if the result is an object or array, recursively walks it into one `{path, value}` entry per primitive leaf. A JSX-bearing string (e.g. the shipped Stats/FAQ sections' `items` array of `{key, children}`, where `children` is itself a further, separately data-bound element) is a leaf, not decomposed further — matches how `parseValue` already treats JSX elsewhere. Depth-capped defensively. `setEditableValue(value, path, next)` is the companion setter: replaces one leaf and re-serializes the whole structure back into a string for `PanelBinding.onChange`. Fails safe (returns the input unchanged) for an out-of-range index, missing key, non-object/array value, or empty path, rather than throwing.
- `index.ts`: exports both functions plus their types (`EditablePathSegment`, `EditablePrimitive`, `EditableValueEntry`)
- `value.test.ts`: 15 new cases — simple object/array, nested object-in-array with a JSX leaf, empty/scalar → null, null/undefined members omitted, and `setEditableValue`'s fail-safe paths
- `CustomPalettePanelDemo.tsx`: replaces the demo's local `parseEditableShape`/`ParsedValueEditor` reimplementation with the exported functions, which also fixes a real gap the local version had — an array of objects (Stats/FAQ's `items`) now decomposes instead of falling back to one opaque textarea for the whole array
- `custom-palette-panel.mdx`: documents both functions, and points readers at the Stats/FAQ `items` example in addition to Hero's Background Style

Verified against real shipped content, not just synthetic examples: ran `flattenEditableValue` on the actual Stats section's "Stats Items" binding value (extracted via the same extract/parseBinding/getCurrentValue pipeline `Dnd` itself uses) and confirmed it correctly produces `0.key` and `0.children` leaf entries.

Also corrects something said earlier while investigating this: a section's top-level `bindings` list does *not* already include separately-`data-id`'d elements nested inside a prop value (e.g. `items={[{children: <div data-id="..." />}]}`) — `extract()` only walks the JSX element tree, not JSX embedded in prop expressions, and canvas clicks only ever select a whole top-level section. `flattenEditableValue` is therefore the only way to reach that nested content through the bindings/renderPanel API today, not just a convenience over an already-reachable path.

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` + `pnpm build:demos` pass
- [x] `pnpm test` — 243 tests pass (228 previous + 15 new)
- [x] `website` typecheck + build pass
- [x] Verified against real shipped Stats section content via the actual extract/parseBinding/getCurrentValue pipeline, not just synthetic examples