### PR TITLE
🐛 fix: cap flattenEditableValue entries in custom-palette-panel demo

### DIFF
--- a/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
+++ b/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
@@ -15,6 +15,12 @@ import {
   validateBindingValue,
 } from '~/utils/ast';
 
+// Above this many leaves, `flattenEditableValue`'s result is more likely a
+// serialized document tree (tag names, ids, individual attributes...) than
+// a form a person would want to fill in field-by-field — see the "Feature
+// Cards" binding below.
+const MAX_EDITABLE_ENTRIES = 20;
+
 const ParsedValueField = ({
   label,
   value,
@@ -212,9 +218,25 @@ const CustomPalettePanelDemo = () => {
                     bindings.map((binding, index) => {
                       const isMultiline =
                         binding.type === 'jsx' || binding.type === 'richtext';
-                      const entries = isMultiline
+                      // Some `children` bindings hold a serialized document
+                      // tree rather than a few simple fields — Features'
+                      // "Feature Cards" flattens to 240 leaves (tag names,
+                      // ids, individual attributes...), which is technically
+                      // correct but useless as a form. Capping the entry
+                      // count treats those as opaque instead of rendering a
+                      // wall of tiny inputs; a value long enough to likely be
+                      // one of these (or just a long plain string) falls
+                      // back to a textarea rather than the single-line
+                      // ValidatedField either way.
+                      const flattened = isMultiline
                         ? null
                         : flattenEditableValue(binding.value);
+                      const entries =
+                        flattened && flattened.length <= MAX_EDITABLE_ENTRIES
+                          ? flattened
+                          : null;
+                      const useTextarea =
+                        isMultiline || (!entries && binding.value.length > 120);
 
                       return (
                         <label
@@ -242,7 +264,7 @@ const CustomPalettePanelDemo = () => {
                                 </option>
                               ))}
                             </select>
-                          ) : isMultiline ? (
+                          ) : useTextarea ? (
                             <textarea
                               className="w-full rounded border border-gray-300
                                 px-2 py-1 text-sm"


### PR DESCRIPTION
## Summary
Reported after checking the deployed demo: the Features section's "Feature Cards" binding (a serialized document tree, not a small object/array) flattened into 240 leaf entries — tag names, ids, individual attributes — technically correct per `flattenEditableValue`'s contract, but useless as a form.

- Caps `flattenEditableValue`'s result at `MAX_EDITABLE_ENTRIES` (20); past that, treat the binding as opaque instead of rendering a wall of tiny inputs
- The opaque/fallback path (whether from the cap or from a value that never structurally parsed at all) now also checks `value.length`: past 120 chars it renders as a `textarea` instead of the single-line `ValidatedField`, which every binding without a declared `type` was hitting before (Stats/FAQ/Features/CTA/Getting Started all omit `type` entirely, so this affected more than just the one binding that surfaced it)

Verified against real shipped content: Stats' "Stats Items" (2 leaves) still renders the per-field editor; Features' "Feature Cards" (240 leaves) now falls back to a textarea instead of either 240 inputs or a single-line one.

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` + `pnpm build:demos` pass
- [x] `pnpm test` — 243 tests pass
- [x] `website` typecheck + build pass
- [x] Verified against real shipped content via the actual extract/parseBinding/getCurrentValue pipeline: Stats renders 2-field editor, Features renders textarea