### PR TITLE
🐛 fix: key update()/bulkUpdate() bindings by property, not label

### DIFF
--- a/.changeset/fix-update-identity-by-property.md
+++ b/.changeset/fix-update-identity-by-property.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fixed `update()`/`bulkUpdate()` (`@jbpark/live-editor/utils/ast`) resolving the target binding by its human-readable `label` instead of its `property` — the real identifier. Two bindings sharing a label on the same element (or a label that's been reworded/translated) used to silently collide: `.find()` picked whichever came first, the other binding's edit was dropped, and the caller still got `success: true`. `update` now accepts an optional 5th `property` argument (and `bulkUpdate`'s entries an optional `property` field) and matches on it when provided, falling back to `label` only when it isn't — and either way, more than one match on an element is now a failure (`success: false`) instead of a silent pick of the first. `Live.Dnd`'s own field-editing pipeline (the built-in panel and `PanelBinding.onChange`, used by both the built-in panel and a custom `renderPanel`) always supplies `property` now, so this collision can no longer happen through the library's own UI — only a direct `update()`/`bulkUpdate()` call that omits `property` still uses the (now safer) label fallback.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -421,13 +421,15 @@ const Dnd = ({
   const onFieldChange = ({
     id,
     label,
+    property,
     value: fieldValue,
   }: {
     id: string;
     label: string;
+    property: string;
     value: string;
   }) => {
-    const result = update(updatedCode, id, label, fieldValue);
+    const result = update(updatedCode, id, label, fieldValue, property);
 
     if (!result.success) {
       Toast.error('Failed to update this field', {
@@ -475,7 +477,12 @@ const Dnd = ({
         required: binding.required,
         value: getCurrentValue(node, binding.property),
         onChange: (value: string) =>
-          onFieldChange({ id: dataId, label: binding.label, value }),
+          onFieldChange({
+            id: dataId,
+            label: binding.label,
+            property: binding.property,
+            value,
+          }),
       }));
     });
     // onFieldChange is intentionally omitted — it's recreated every render

--- a/src/components/dnd/panel/children.tsx
+++ b/src/components/dnd/panel/children.tsx
@@ -14,7 +14,12 @@ import { moveSelectedIndices, removeIndices } from './selection';
 interface Props {
   value: DataAttrNode[];
   onChange?: (value: string) => void;
-  onNodeChange?: (params: { id: string; label: string; value: string }) => void;
+  onNodeChange?: (params: {
+    id: string;
+    label: string;
+    property: string;
+    value: string;
+  }) => void;
 }
 
 const Children = ({ value, onChange, onNodeChange }: Props) => {

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -28,14 +28,12 @@ interface Props {
   binding: BindingItem;
   id: string;
   value: string;
-  onChange?: (params: { id: string; label: string; value: string }) => void;
-}
-
-interface Props {
-  binding: BindingItem;
-  id: string;
-  value: string;
-  onChange?: (params: { id: string; label: string; value: string }) => void;
+  onChange?: (params: {
+    id: string;
+    label: string;
+    property: string;
+    value: string;
+  }) => void;
 }
 
 const isColorProperty = (propertyName: string): boolean => {
@@ -87,13 +85,20 @@ const COLOR_COMMIT_DELAY = 75;
 interface ColorPickerFieldProps {
   id: string;
   label: string;
+  property: string;
   value: string;
-  onChange?: (params: { id: string; label: string; value: string }) => void;
+  onChange?: (params: {
+    id: string;
+    label: string;
+    property: string;
+    value: string;
+  }) => void;
 }
 
 const ColorPickerField = ({
   id,
   label,
+  property,
   value,
   onChange,
 }: ColorPickerFieldProps) => {
@@ -127,7 +132,7 @@ const ColorPickerField = ({
       return;
     }
     lastCommittedRef.current = next;
-    onChange?.({ id, label, value: next });
+    onChange?.({ id, label, property, value: next });
   };
 
   const debouncedCommit = useDebounce(() => commit(liveValue), {
@@ -186,6 +191,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
           onChange?.({
             id,
             label: binding.label,
+            property: binding.property,
             value: next,
           });
         }}
@@ -203,6 +209,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             onChange?.({
               id,
               label: binding.label,
+              property: binding.property,
               value: next,
             });
           }
@@ -225,6 +232,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             onChange?.({
               id,
               label: binding.label,
+              property: binding.property,
               value: next,
             });
           }
@@ -241,6 +249,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
           onChange?.({
             id,
             label: binding.label,
+            property: binding.property,
             value: next,
           });
         }}
@@ -293,6 +302,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
                 onChange?.({
                   id,
                   label: binding.label,
+                  property: binding.property,
                   value: JSON.stringify(updated),
                 });
               }}
@@ -311,6 +321,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
           onChange?.({
             id,
             label: binding.label,
+            property: binding.property,
             value: checked.toString(),
           });
         }}
@@ -330,6 +341,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             onChange?.({
               id,
               label: binding.label,
+              property: binding.property,
               value: next,
             });
           }
@@ -343,6 +355,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
       <ColorPickerField
         id={id}
         label={binding.label}
+        property={binding.property}
         value={normalizeToHex(stringValue)}
         onChange={onChange}
       />
@@ -369,6 +382,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
               onChange?.({
                 id,
                 label: binding.label,
+                property: binding.property,
                 value: next,
               });
             }
@@ -403,6 +417,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
               onChange?.({
                 id,
                 label: binding.label,
+                property: binding.property,
                 value: next,
               });
             }
@@ -428,6 +443,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
               onChange?.({
                 id,
                 label: binding.label,
+                property: binding.property,
                 value: next,
               });
             }
@@ -469,6 +485,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
               onChange?.({
                 id,
                 label: binding.label,
+                property: binding.property,
                 value: next,
               });
             }
@@ -486,6 +503,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
               onChange?.({
                 id,
                 label: binding.label,
+                property: binding.property,
                 value: next,
               });
             }
@@ -520,6 +538,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
               onChange?.({
                 id,
                 label: binding.label,
+                property: binding.property,
                 value: next,
               });
             }
@@ -552,6 +571,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             onChange?.({
               id,
               label: binding.label,
+              property: binding.property,
               value: next,
             });
           }

--- a/src/components/dnd/panel/items.tsx
+++ b/src/components/dnd/panel/items.tsx
@@ -57,6 +57,7 @@ interface Props {
   onChildChange?: (params: {
     id: string;
     label: string;
+    property: string;
     value: string;
   }) => void;
 }

--- a/src/components/dnd/panel/node.tsx
+++ b/src/components/dnd/panel/node.tsx
@@ -4,7 +4,12 @@ import Field from './field';
 
 export interface FieldEditorProps {
   data: DataAttrNode;
-  onChange?: (params: { id: string; label: string; value: string }) => void;
+  onChange?: (params: {
+    id: string;
+    label: string;
+    property: string;
+    value: string;
+  }) => void;
 }
 
 const Node = ({ data, onChange }: FieldEditorProps) => {

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -22,7 +22,12 @@ interface Props {
   // update + error-toast handling behind onFieldChange) lives in Dnd, so
   // it's shared with a custom renderPanel instead of computed here too.
   fields: DataAttrNode[];
-  onFieldChange: (params: { id: string; label: string; value: string }) => void;
+  onFieldChange: (params: {
+    id: string;
+    label: string;
+    property: string;
+    value: string;
+  }) => void;
 }
 
 const Panel = ({

--- a/src/utils/ast/update.test.ts
+++ b/src/utils/ast/update.test.ts
@@ -111,6 +111,65 @@ describe('update', () => {
 
     expect(result).toEqual({ code: CODE, success: false });
   });
+
+  // #240: label is a display string, not an identifier — these pin
+  // `property` as the real identity, with `label` only as a fallback for
+  // callers that don't have `property` on hand.
+  describe('identity: property vs. label (#240)', () => {
+    const DUPLICATE_LABEL_CODE = `
+<div
+  data-id="b"
+  data-binding="[{label:'Same',property:'title'},{label:'Same',property:'alt'}]"
+  title="t"
+  alt="a"
+>x</div>
+`;
+
+    it('matches by property when provided, ignoring which binding the label happens to point at', () => {
+      const result = update(
+        DUPLICATE_LABEL_CODE,
+        'b',
+        'Same',
+        'new alt',
+        'alt',
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('alt="new alt"');
+      expect(result.code).toContain('title="t"');
+    });
+
+    it('resolves a translated label correctly as long as property is unchanged', () => {
+      // Simulates i18n: the panel shows a translated label, but the
+      // authored `property` — the real identity — never changes.
+      const result = update(
+        CODE,
+        'a',
+        '텍스트 (translated)',
+        'new text',
+        'innerText',
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('>new text<');
+    });
+
+    it('fails safe instead of silently writing the first match when property is ambiguous on one element', () => {
+      const ambiguousPropertyCode = `<div data-id="x" data-binding="[{label:'A',property:'dup'},{label:'B',property:'dup'}]" dup="orig">x</div>`;
+
+      const result = update(ambiguousPropertyCode, 'x', 'A', 'next', 'dup');
+
+      expect(result).toEqual({ code: ambiguousPropertyCode, success: false });
+    });
+
+    it('fails safe on the label fallback too when two bindings share a label — the #240 repro', () => {
+      // Previously: `.find()` silently picked the first ("title"),
+      // "alt" was never touched, and the caller still got success: true.
+      const result = update(DUPLICATE_LABEL_CODE, 'b', 'Same', 'zzz');
+
+      expect(result).toEqual({ code: DUPLICATE_LABEL_CODE, success: false });
+    });
+  });
 });
 
 describe('bulkUpdate', () => {
@@ -135,5 +194,17 @@ describe('bulkUpdate', () => {
 
     expect(result.success).toBe(false);
     expect(result.code).toContain('>bulk text<');
+  });
+
+  it("threads an entry's optional property through to update, same as calling it directly (#240)", () => {
+    const duplicateLabelCode = `<div data-id="b" data-binding="[{label:'Same',property:'title'},{label:'Same',property:'alt'}]" title="t" alt="a">x</div>`;
+
+    const result = bulkUpdate(duplicateLabelCode, [
+      { dataId: 'b', label: 'Same', property: 'alt', value: 'bulk alt' },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('alt="bulk alt"');
+    expect(result.code).toContain('title="t"');
   });
 });

--- a/src/utils/ast/update.ts
+++ b/src/utils/ast/update.ts
@@ -155,11 +155,19 @@ export interface UpdateResult {
   success: boolean;
 }
 
+// `label` is a display string — reworded, duplicated, or translated at
+// authors' whim — so it identifies a binding only as a fallback. `property`
+// (an actual key, unique per element) is the real identity; pass it
+// whenever the caller has it (every internal caller does, via
+// PanelBinding.property). See #240: two bindings sharing a label used to
+// resolve to whichever `.find()` hit first, silently dropping the other's
+// edit while still reporting success.
 export const update = (
   code: string,
   dataId: string,
   label: string,
   value: string,
+  property?: string,
 ): UpdateResult => {
   try {
     const wrapped = wrap(code);
@@ -215,13 +223,22 @@ export const update = (
 
         const bindings = parseBinding(bindingValue);
 
-        const propertyBinding = bindings.find(
-          binding => binding.label === label,
+        // Prefer `property` (an actual key) over `label` (a display
+        // string) — see the module-level comment on `update`. Either way,
+        // more than one match on this element is an authoring ambiguity
+        // (duplicate labels, or a genuine property collision), not a case
+        // to silently resolve by picking the first — see #240.
+        const matches = bindings.filter(binding =>
+          property !== undefined
+            ? binding.property === property
+            : binding.label === label,
         );
 
-        if (!propertyBinding) {
+        if (matches.length !== 1) {
           return;
         }
+
+        const propertyBinding = matches[0]!;
 
         switch (propertyBinding.property) {
           case BINDING_PROP.INNER_TEXT: {
@@ -295,13 +312,24 @@ export const update = (
 
 export const bulkUpdate = (
   raw: string,
-  entries: { dataId: string; label: string; value: string }[],
+  entries: {
+    dataId: string;
+    label: string;
+    value: string;
+    property?: string;
+  }[],
 ): UpdateResult => {
   let current = raw;
   let allSucceeded = true;
 
   for (const entry of entries) {
-    const result = update(current, entry.dataId, entry.label, entry.value);
+    const result = update(
+      current,
+      entry.dataId,
+      entry.label,
+      entry.value,
+      entry.property,
+    );
     current = result.code;
     allSucceeded = allSucceeded && result.success;
   }


### PR DESCRIPTION
## Summary
Step 1 of #235's recommended sequence. `label` is a display string — reworded, duplicated, or translated at authors' whim — but `update()` resolved the target binding by matching it (#240). Two bindings sharing a label on one element collided silently: `.find()` picked whichever came first, the other binding's edit was dropped, and the caller still got `success: true`. i18n would have broken this pipeline outright, since translating a label breaks the label→binding mapping.

- `update.ts`: `update()` gains an optional 5th `property` argument; matches on it when provided, falling back to `label` only when it isn't (so an external caller that doesn't have `property` on hand doesn't break at once). Either way, anything other than exactly one match on the element is now a failure (`success: false`) rather than a silent pick of the first — applies to the label fallback too, not just property matching, since the same "silent partial success" problem applies equally there. `bulkUpdate()`'s entries gain the same optional `property` field, threaded through to `update()`.
- `dnd.tsx`: `onFieldChange`'s params and the `bindings` memo's `onChange` closure both gain `property` (already available via `PanelBinding.property`, just not threaded through before) and pass it to `update()`
- `panel.tsx` / `node.tsx` / `children.tsx` / `items.tsx`: thread the widened `onFieldChange`/`onChange` param type through the built-in panel's component chain — pure type threading, no behavior change in these files themselves
- `field.tsx`: the 14 places the built-in panel commits a field edit now include `binding.property` in the `onChange` payload; `ColorPickerField` (the one sub-component that receives flattened `id`/`label`/`value` props instead of the full binding) gains a `property` prop for the same reason. Also removes an accidental duplicate `interface Props` declaration found while editing this file.
- `update.test.ts`: pins the #240 repro (duplicate labels now fail instead of silently succeeding), property-based disambiguation, an i18n scenario (translated label, unchanged property), an ambiguous-property fail-safe case, and `bulkUpdate`'s property passthrough

Verified: `Live.Dnd`'s own field-editing pipeline (built-in panel and `PanelBinding.onChange`, shared by both the built-in panel and a custom `renderPanel`) now always supplies `property`, so this collision can no longer happen through the library's own UI — only a direct `update()`/`bulkUpdate()` call that omits `property` still uses the (now safer) label fallback.

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` + `pnpm build:demos` pass
- [x] `pnpm test` — 248 tests pass (243 previous + 5 new)
- [x] `website` typecheck + build pass