### PR TITLE
🐛 fix(dnd): give sections a real identity instead of a position

### DIFF
--- a/.changeset/fix-section-identity.md
+++ b/.changeset/fix-section-identity.md
@@ -1,0 +1,36 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Give sections a real identity so the DnD canvas stops losing track of them (#245).
+
+`Section.id` was modelled two incompatible ways at once. `getSections`
+re-derived it from the section's _position_ on every parse, while `Dnd` minted
+`uuidv4()` ids for sections it added or copied. A uuid was never written into
+the document, so it ceased to exist at the next parse: right after copying a
+section, `selectedId` resolved to nothing and the property panel dropped back
+to "Please select a section." Positional ids have the same flaw more generally
+— any insert, delete, copy or move silently re-points every id at or after the
+edit, which is why `moveSection` carried a hand-rolled `setSelectedId(String(targetIndex))`
+correction.
+
+- Sections now identify themselves with `data-id`, the same attribute editable
+  elements already use. `getSections` reads it and falls back to the positional
+  id for documents authored before this, so existing code keeps working
+  unchanged until an edit fills the ids in.
+- New `fillSectionIds()` splices `data-id` into any top-level `<section>`
+  missing one, editing the original source rather than regenerating it so the
+  author's formatting is untouched everywhere else.
+- Copying a section now selects the copy, because `replaceIds` refreshes the
+  section's own `data-id` too and the new id is read back from the committed
+  document instead of invented.
+- Selection now survives adding, moving and reordering sections, and deleting
+  a section no longer clears the selection unless it was the one deleted.
+- The `moveSection` index-arithmetic workaround is gone.
+
+Internally, the `replaceSections -> onChange -> setCode` commit sequence — which
+was written out seven separate times in `dnd.tsx` — is now a single
+`useSectionDocument` hook, taking `dnd.tsx` from 704 to 558 lines and making the
+section logic testable without rendering dnd-kit.
+
+No public API change.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -15,13 +15,11 @@ import {
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import {
   SortableContext,
-  arrayMove,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { Button, Drawer, Space, Toast, Typography } from '@jbpark/ui-kit';
 import { useResponsiveSize } from '@jbpark/use-hooks';
 import { LayoutGrid } from 'lucide-react';
-import { v4 as uuidv4 } from 'uuid';
 
 import { DRAGGABLE_ITEMS } from '~/constants';
 import type { Section } from '~/types';
@@ -34,19 +32,11 @@ import {
   fillIds,
   getCurrentValue,
   parseBinding,
-  replaceIds,
   update,
 } from '~/utils/ast';
 
 import { DEFAULT_TEMPLATE } from '../../constants';
-import {
-  cn,
-  createSectionPreviewCache,
-  extractSections,
-  preloadScripts,
-  replaceSections,
-} from '../../utils';
-import { usePreview } from '../context/states';
+import { cn, preloadScripts } from '../../utils';
 import { type FrameProps } from '../frame';
 import DraggableItem, { DefaultDraggableItem } from './draggable';
 import Droppable from './droppable';
@@ -54,6 +44,7 @@ import Overlay from './overlay';
 import Panel from './panel';
 import Renderer from './renderer';
 import Sortable from './sortable';
+import { useSectionDocument } from './use-section-document';
 
 export interface PaletteRenderData {
   items: Section[];
@@ -170,13 +161,10 @@ const Dnd = ({
   renderPanel,
   ...restProps
 }: Props) => {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [mobilePaletteOpen, setMobilePaletteOpen] = useState(false);
 
   const { breakpoint } = useResponsiveSize();
   const isMobile = breakpoint.current === 'xs' || breakpoint.current === 'sm';
-
-  const { setCode } = usePreview();
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -187,24 +175,22 @@ const Dnd = ({
   );
 
   const value = _value || DEFAULT_TEMPLATE;
-  const sections = useMemo(() => extractSections(value), [value]);
-  const selectedItem = useMemo(
-    () => sections.find(s => s.id === selectedId),
-    [sections, selectedId],
-  );
 
-  // One cache per Dnd instance (lazy `useState` initializer, never
-  // replaced) — see createSectionPreviewCache (#131). It's stateful by
-  // design (remembers the previous render's previews to reuse the ones
-  // that didn't change), which a `useMemo`/`useRef` can't do without
-  // touching a ref during render; a cache object stored via `useState`
-  // and only ever mutated through its own method isn't subject to that
-  // restriction the way `ref.current` is.
-  const [previewCache] = useState(() => createSectionPreviewCache());
-  const previews = useMemo(
-    () => previewCache.compute(value, sections),
-    [previewCache, sections, value],
-  );
+  const {
+    sections,
+    previews,
+    selectedId,
+    selectedItem,
+    selectedIndex,
+    select,
+    clearSelection,
+    add: addItem,
+    remove: onDelete,
+    copy: onCopy,
+    move: moveSection,
+    reorder,
+    patch,
+  } = useSectionDocument(value, _onChange);
 
   const onDragStart = (_: DragStartEvent) => {};
 
@@ -218,161 +204,30 @@ const Dnd = ({
     }
 
     if (active.data.current?.type === 'new-item') {
-      const newItem = active.data.current.item;
-      const newSection = {
-        id: uuidv4(),
-        name: newItem.name,
-        code: newItem.code,
-      };
+      const item = active.data.current.item as Section;
+      const atBottom =
+        over.id === 'sortable-area' || over.id === 'sortable-area-bottom';
 
-      let nextSections: typeof sections;
-
-      if (over.id === 'sortable-area' || over.id === 'sortable-area-bottom') {
-        nextSections = [...sections, newSection];
-      } else {
-        const overIndex = sections.findIndex(s => s.id === over.id);
-        if (overIndex >= 0) {
-          nextSections = [
-            ...sections.slice(0, overIndex),
-            newSection,
-            ...sections.slice(overIndex),
-          ];
-        } else {
-          nextSections = [...sections, newSection];
-        }
-      }
-
-      const nextCode = replaceSections(
-        value,
-        nextSections.map(s => s.code),
+      addItem(
+        item,
+        atBottom ? undefined : sections.findIndex(s => s.id === over.id),
       );
-
-      _onChange?.(nextCode);
-      setCode(nextCode);
       return;
     }
 
     if (active.id !== over.id && sections.some(s => s.id === active.id)) {
-      const prevIndex = sections.findIndex(s => s.id === active.id);
-      const nextIndex = sections.findIndex(s => s.id === over.id);
-
-      if (prevIndex >= 0 && nextIndex >= 0) {
-        const nextSections = arrayMove(sections, prevIndex, nextIndex);
-
-        const nextCode = replaceSections(
-          value,
-          nextSections.map(s => s.code),
-        );
-
-        _onChange?.(nextCode);
-        setCode(nextCode);
-      }
+      reorder(String(active.id), String(over.id));
     }
   };
 
-  const addItem = (item: (typeof DRAGGABLE_ITEMS)[0]) => {
-    const newSection = {
-      id: uuidv4(),
-      name: item.name,
-      code: item.code,
-    };
+  const onSelect = (id: string) => select(id);
 
-    const nextSections = [...sections, newSection];
-
-    const nextCode = replaceSections(
-      value,
-      nextSections.map(s => s.code),
-    );
-
-    _onChange?.(nextCode);
-    setCode(nextCode);
-  };
-
-  const onDelete = (id: string) => {
-    const nextSections = sections.filter(s => s.id !== id);
-
-    setSelectedId(null);
-
-    const nextCode = replaceSections(
-      value,
-      nextSections.map(s => s.code),
-    );
-
-    _onChange?.(nextCode);
-    setCode(nextCode);
-  };
-
-  const moveSection = (id: string | null, direction: 'up' | 'down') => {
-    const index = sections.findIndex(s => s.id === id);
-    const targetIndex = direction === 'up' ? index - 1 : index + 1;
-
-    if (index < 0 || targetIndex < 0 || targetIndex >= sections.length) {
+  const onChange = (next: Partial<Section>) => {
+    if (!next.id) {
       return;
     }
 
-    const nextSections = arrayMove(sections, index, targetIndex);
-
-    const nextCode = replaceSections(
-      value,
-      nextSections.map(s => s.code),
-    );
-
-    _onChange?.(nextCode);
-    setCode(nextCode);
-    // Section ids are just the section's positional index, re-derived from
-    // scratch on every parse (getSections) rather than a stable identity —
-    // so once `sections` recomputes after this reorder, `selectedId`
-    // (unchanged) would silently point at whatever content now sits at its
-    // old position instead of following the section that actually moved.
-    setSelectedId(String(targetIndex));
-  };
-
-  const onCopy = (id: string) => {
-    const sectionIndex = sections.findIndex(s => s.id === id);
-    const sectionToCopy = sections[sectionIndex];
-
-    if (sectionToCopy) {
-      const nextId = uuidv4();
-      const nextSection = {
-        id: nextId,
-        code: replaceIds(sectionToCopy.code),
-        name: sectionToCopy.name,
-      };
-
-      const nextSections = [
-        ...sections.slice(0, sectionIndex + 1),
-        nextSection,
-        ...sections.slice(sectionIndex + 1),
-      ];
-
-      setSelectedId(nextId);
-
-      const nextCode = replaceSections(
-        value,
-        nextSections.map(s => s.code),
-      );
-
-      _onChange?.(nextCode);
-      setCode(nextCode);
-    }
-  };
-
-  const onSelect = (id: string) => {
-    setSelectedId(prev => (prev === id ? null : id));
-  };
-
-  const onChange = (next: Partial<Section>) => {
-    const nextSections = sections.map(s =>
-      s.id === next.id ? { ...s, ...next } : s,
-    );
-
-    const nextCode = replaceSections(
-      value,
-      nextSections.map(s => s.code),
-    );
-
-    _onChange?.(nextCode);
-    setCode(nextCode);
+    patch(next as Partial<Section> & { id: string });
   };
 
   // Reads only the extracted `code` local, not `selectedItem`, so the
@@ -527,7 +382,6 @@ const Dnd = ({
   };
 
   const renderPanelContent = () => {
-    const selectedIndex = sections.findIndex(s => s.id === selectedId);
     const canMoveUp = selectedIndex > 0;
     const canMoveDown =
       selectedIndex >= 0 && selectedIndex < sections.length - 1;
@@ -676,7 +530,7 @@ const Dnd = ({
           </Drawer>
           <Drawer
             open={isMobile && Boolean(selectedId)}
-            onClose={() => setSelectedId(null)}
+            onClose={clearSelection}
             direction="bottom"
             size="large"
             title="Properties"

--- a/src/components/dnd/use-section-document.ts
+++ b/src/components/dnd/use-section-document.ts
@@ -1,0 +1,221 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { arrayMove } from '@dnd-kit/sortable';
+
+import type { Section } from '~/types';
+import {
+  createSectionPreviewCache,
+  extractSections,
+  replaceSections,
+} from '~/utils';
+import { fillSectionIds, replaceIds } from '~/utils/ast';
+
+import { usePreview } from '../context/states';
+
+export interface SectionDocument {
+  sections: Section[];
+  previews: string[];
+  selectedId: string | null;
+  selectedItem?: Section;
+  selectedIndex: number;
+  select: (id: string) => void;
+  clearSelection: () => void;
+  add: (item: Pick<Section, 'name' | 'code'>, atIndex?: number) => void;
+  remove: (id: string) => void;
+  copy: (id: string) => void;
+  move: (id: string | null, direction: 'up' | 'down') => void;
+  reorder: (activeId: string, overId: string) => void;
+  patch: (next: Partial<Section> & { id: string }) => void;
+}
+
+// Owns the document side of the DnD canvas: deriving sections from the code
+// string, tracking which one is selected, and committing every mutation.
+//
+// Extracted from Dnd (#245), where the commit sequence
+// `replaceSections -> onChange -> setCode` was spelled out seven separate
+// times. Naming it once means no mutation can perform half of it, and it
+// puts the section logic somewhere reachable without rendering dnd-kit.
+export const useSectionDocument = (
+  value: string,
+  onChange?: (value: string) => void,
+): SectionDocument => {
+  const { setCode } = usePreview();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // Sections identify themselves by `data-id`; `getSections` falls back to a
+  // positional id for documents predating that (see #245). Filling the gap
+  // here makes the ids below real identities rather than positions, so a
+  // held `selectedId` survives an insert, copy, move or delete.
+  //
+  // Deliberately not committed on its own — like dnd.tsx's existing use of
+  // fillIds for field ids, the filled document only reaches
+  // `onChange`/`setCode` when a real mutation commits, so merely opening a
+  // document never rewrites the author's code.
+  const document = useMemo(() => fillSectionIds(value), [value]);
+  const sections = useMemo(() => extractSections(document), [document]);
+
+  // One cache per hook instance (lazy `useState` initializer, never
+  // replaced) — see createSectionPreviewCache (#131). It's stateful by
+  // design (remembers the previous render's previews to reuse the ones that
+  // didn't change), which a `useMemo`/`useRef` can't do without touching a
+  // ref during render; a cache object stored via `useState` and only ever
+  // mutated through its own method isn't subject to that restriction the way
+  // `ref.current` is.
+  const [previewCache] = useState(() => createSectionPreviewCache());
+  const previews = useMemo(
+    () => previewCache.compute(document, sections),
+    [previewCache, sections, document],
+  );
+
+  const selectedIndex = sections.findIndex(s => s.id === selectedId);
+  const selectedItem = selectedIndex >= 0 ? sections[selectedIndex] : undefined;
+
+  // The single place a set of sections becomes a new document. Takes only
+  // `code` because that is genuinely all a commit reads — ids and names are
+  // re-derived from the result, never carried across.
+  //
+  // Runs `fillSectionIds` on the way out so a section that arrived without
+  // one still lands with an id: a palette template is a bare `<section>`
+  // snippet with no `#app-container`, so it cannot be filled until after
+  // it's spliced in. Returns the resulting sections so a caller that needs
+  // to select what it just created can read the real id back rather than
+  // inventing one.
+  const commit = useCallback(
+    (nextSections: { code: string }[]): Section[] => {
+      const nextCode = fillSectionIds(
+        replaceSections(
+          document,
+          nextSections.map(s => s.code),
+        ),
+      );
+
+      onChange?.(nextCode);
+      setCode(nextCode);
+
+      return extractSections(nextCode);
+    },
+    [document, onChange, setCode],
+  );
+
+  const select = useCallback((id: string) => {
+    setSelectedId(prev => (prev === id ? null : id));
+  }, []);
+
+  const clearSelection = useCallback(() => setSelectedId(null), []);
+
+  const add = useCallback(
+    (item: Pick<Section, 'name' | 'code'>, atIndex?: number) => {
+      const next = { code: item.code };
+
+      commit(
+        atIndex === undefined || atIndex < 0
+          ? [...sections, next]
+          : [...sections.slice(0, atIndex), next, ...sections.slice(atIndex)],
+      );
+    },
+    [commit, sections],
+  );
+
+  const remove = useCallback(
+    (id: string) => {
+      // Removes by position, not by predicate: `fillSectionIds` keeps ids
+      // unique, but a filter would delete every match if that invariant ever
+      // slipped — and this is the one destructive operation here, so it
+      // shouldn't be the one relying on it.
+      const index = sections.findIndex(s => s.id === id);
+
+      if (index < 0) {
+        return;
+      }
+
+      // Only the deleted section loses the selection. The previous
+      // implementation cleared it unconditionally, so deleting any section
+      // closed the panel for whichever one was open.
+      if (id === selectedId) {
+        setSelectedId(null);
+      }
+
+      commit(sections.filter((_, i) => i !== index));
+    },
+    [commit, sections, selectedId],
+  );
+
+  const copy = useCallback(
+    (id: string) => {
+      const index = sections.findIndex(s => s.id === id);
+      const source = sections[index];
+
+      if (!source) {
+        return;
+      }
+
+      // replaceIds refreshes every data-id in the snippet, the section's own
+      // included, so the copy carries a distinct identity into the document.
+      const committed = commit([
+        ...sections.slice(0, index + 1),
+        { code: replaceIds(source.code) },
+        ...sections.slice(index + 1),
+      ]);
+
+      // Read the new id back from the committed document. This used to
+      // select a `uuidv4()` that was never written into the code and so
+      // didn't exist after the next parse, leaving the panel empty right
+      // after a copy (#245).
+      setSelectedId(committed[index + 1]?.id ?? null);
+    },
+    [commit, sections],
+  );
+
+  const move = useCallback(
+    (id: string | null, direction: 'up' | 'down') => {
+      const index = sections.findIndex(s => s.id === id);
+      const targetIndex = direction === 'up' ? index - 1 : index + 1;
+
+      if (index < 0 || targetIndex < 0 || targetIndex >= sections.length) {
+        return;
+      }
+
+      // No `setSelectedId` compensation needed any more: the id travels with
+      // the section's own markup, so the selection follows it across a move.
+      commit(arrayMove(sections, index, targetIndex));
+    },
+    [commit, sections],
+  );
+
+  const reorder = useCallback(
+    (activeId: string, overId: string) => {
+      const prevIndex = sections.findIndex(s => s.id === activeId);
+      const nextIndex = sections.findIndex(s => s.id === overId);
+
+      if (prevIndex < 0 || nextIndex < 0 || prevIndex === nextIndex) {
+        return;
+      }
+
+      commit(arrayMove(sections, prevIndex, nextIndex));
+    },
+    [commit, sections],
+  );
+
+  const patch = useCallback(
+    (next: Partial<Section> & { id: string }) => {
+      commit(sections.map(s => (s.id === next.id ? { ...s, ...next } : s)));
+    },
+    [commit, sections],
+  );
+
+  return {
+    sections,
+    previews,
+    selectedId,
+    selectedItem,
+    selectedIndex,
+    select,
+    clearSelection,
+    add,
+    remove,
+    copy,
+    move,
+    reorder,
+    patch,
+  };
+};

--- a/src/utils/ast/document.test.ts
+++ b/src/utils/ast/document.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CONFIG } from '../../constants';
 import {
   clearDocumentParseCache,
   createSectionPreviewCache,
+  fillSectionIds,
   generateDocumentCode,
   generateSectionPreview,
   generateSectionPreviews,
@@ -634,5 +635,197 @@ describe('parseDocument caching', () => {
     const second = parseDocument(FULL_CODE)!;
 
     expect(second.ast).not.toBe(first.ast);
+  });
+});
+
+describe('fillSectionIds', () => {
+  const LEGACY = `
+const App = () => {
+  return (
+    <main id="app-container">
+      <section data-name="Hero"><h1>Hero</h1></section>
+      <section data-name="Features"><p>Features</p></section>
+    </main>
+  )
+}
+`;
+
+  let counter = 0;
+  const ids = () => `id${++counter}`;
+
+  beforeEach(() => {
+    counter = 0;
+    clearDocumentParseCache();
+  });
+
+  it('adds data-id to every top-level section that lacks one', () => {
+    const filled = fillSectionIds(LEGACY, ids);
+
+    expect(filled).toContain('<section data-id="id1" data-name="Hero">');
+    expect(filled).toContain('<section data-id="id2" data-name="Features">');
+  });
+
+  it('leaves the rest of the source byte-identical', () => {
+    const filled = fillSectionIds(LEGACY, ids);
+
+    expect(
+      filled.replace(' data-id="id1"', '').replace(' data-id="id2"', ''),
+    ).toBe(LEGACY);
+  });
+
+  it('is a no-op when every section already has an id', () => {
+    const filled = fillSectionIds(LEGACY, ids);
+
+    expect(fillSectionIds(filled, ids)).toBe(filled);
+  });
+
+  it('only fills the sections that are missing an id', () => {
+    const partial = `
+const App = () => {
+  return (
+    <main id="app-container">
+      <section data-id="kept" data-name="Hero"><h1>Hero</h1></section>
+      <section data-name="Features"><p>Features</p></section>
+    </main>
+  )
+}
+`;
+
+    const filled = fillSectionIds(partial, ids);
+
+    expect(filled).toContain('data-id="kept"');
+    expect(filled).toContain('<section data-id="id1" data-name="Features">');
+  });
+
+  it('returns the input unchanged when the document cannot be parsed', () => {
+    expect(fillSectionIds('<main id="app-container">', ids)).toBe(
+      '<main id="app-container">',
+    );
+  });
+});
+
+describe('getSections identity (#245)', () => {
+  beforeEach(() => clearDocumentParseCache());
+
+  const sectionsOf = (code: string) => {
+    const doc = parseDocument(code);
+    return doc ? getSections(doc) : [];
+  };
+
+  const WITH_IDS = `
+const App = () => {
+  return (
+    <main id="app-container">
+      <section data-id="hero" data-name="Hero"><h1>Hero</h1></section>
+      <section data-id="feat" data-name="Features"><p>Features</p></section>
+    </main>
+  )
+}
+`;
+
+  it('uses the section data-id as the id when present', () => {
+    expect(sectionsOf(WITH_IDS).map(s => s.id)).toEqual(['hero', 'feat']);
+  });
+
+  it('keeps an id pointing at the same section after a reorder', () => {
+    const before = sectionsOf(WITH_IDS);
+    const reordered = replaceDocumentSections(
+      WITH_IDS,
+      [before[1]!, before[0]!].map(s => s.code),
+    );
+
+    const heroBefore = before.find(s => s.id === 'hero')!;
+    const heroAfter = sectionsOf(reordered).find(s => s.id === 'hero')!;
+
+    expect(heroAfter.name).toBe(heroBefore.name);
+    expect(heroAfter.code).toBe(heroBefore.code);
+  });
+
+  it('falls back to the positional id for documents without section ids', () => {
+    const legacy = `
+const App = () => {
+  return (
+    <main id="app-container">
+      <section data-name="Hero"><h1>Hero</h1></section>
+      <section data-name="Features"><p>Features</p></section>
+    </main>
+  )
+}
+`;
+
+    expect(sectionsOf(legacy).map(s => s.id)).toEqual(['0', '1']);
+  });
+});
+
+describe('fillSectionIds uniqueness', () => {
+  let counter = 0;
+  const ids = () => `gen${++counter}`;
+
+  beforeEach(() => {
+    counter = 0;
+    clearDocumentParseCache();
+  });
+
+  const sectionsOf = (code: string) => {
+    const doc = parseDocument(code);
+    return doc ? getSections(doc) : [];
+  };
+
+  // Reachable by copy-pasting a section in Editor mode: both modes share one
+  // document, so a duplicated `data-id` is ordinary authored text.
+  it('re-mints a duplicate id, keeping the first occurrence', () => {
+    const dup = `
+const App = () => {
+  return (
+    <main id="app-container">
+      <section data-id="same" data-name="A"><h1>A</h1></section>
+      <section data-id="same" data-name="B"><h1>B</h1></section>
+    </main>
+  )
+}
+`;
+
+    const filled = fillSectionIds(dup, ids);
+
+    expect(filled).toContain('<section data-id="same" data-name="A">');
+    expect(filled).toContain('<section data-id="gen1" data-name="B">');
+    expect(sectionsOf(filled).map(s => s.id)).toEqual(['same', 'gen1']);
+  });
+
+  it('leaves every section with a distinct id', () => {
+    const dup = `
+const App = () => {
+  return (
+    <main id="app-container">
+      <section data-id="x" data-name="A"><h1>A</h1></section>
+      <section data-id="x" data-name="B"><h1>B</h1></section>
+      <section data-name="C"><h1>C</h1></section>
+    </main>
+  )
+}
+`;
+
+    const idList = sectionsOf(fillSectionIds(dup, ids)).map(s => s.id);
+
+    expect(new Set(idList).size).toBe(idList.length);
+  });
+
+  // A non-string `data-id` yields no readable value, so a naive "is it
+  // missing?" check would splice a second data-id in beside it.
+  it('replaces a non-string data-id instead of adding a second one', () => {
+    const expr = `
+const App = () => {
+  return (
+    <main id="app-container">
+      <section data-id={dynamic} data-name="A"><h1>A</h1></section>
+    </main>
+  )
+}
+`;
+
+    const filled = fillSectionIds(expr, ids);
+
+    expect(filled).toContain('<section data-id="gen1" data-name="A">');
+    expect(filled.match(/data-id/g)).toHaveLength(1);
   });
 });

--- a/src/utils/ast/document.ts
+++ b/src/utils/ast/document.ts
@@ -1,8 +1,9 @@
 import { parse } from '@babel/parser';
 import _traverse from '@babel/traverse';
 import * as t from '@babel/types';
+import { nanoid } from 'nanoid';
 
-import { CONFIG } from '../../constants';
+import { CONFIG, DATA_ATTR } from '../../constants';
 import type { Section } from '../../types';
 import { createBoundedCache } from '../cache';
 
@@ -38,16 +39,22 @@ const getTagName = (element: t.JSXElement): string => {
   return t.isJSXIdentifier(name) ? name.name : '';
 };
 
-const getAttrValue = (
+const getAttr = (
   element: t.JSXElement,
   attrName: string,
-): string | undefined => {
-  const attr = element.openingElement.attributes.find(
+): t.JSXAttribute | undefined =>
+  element.openingElement.attributes.find(
     (a): a is t.JSXAttribute =>
       t.isJSXAttribute(a) &&
       t.isJSXIdentifier(a.name) &&
       a.name.name === attrName,
   );
+
+const getAttrValue = (
+  element: t.JSXElement,
+  attrName: string,
+): string | undefined => {
+  const attr = getAttr(element, attrName);
 
   return attr && t.isStringLiteral(attr.value) ? attr.value.value : undefined;
 };
@@ -151,12 +158,102 @@ export const clearDocumentParseCache = () => {
   documentCache.clear();
 };
 
+// `id` prefers the section's own `data-id`, falling back to its position.
+//
+// A positional id is not an identity: it is re-derived from scratch on every
+// parse, so any insert, delete, copy or move silently re-points every id at
+// or after the edit. A caller holding one across a mutation — which the DnD
+// canvas does, via `selectedId` — ends up pointing at whatever content moved
+// into that slot. See #245.
+//
+// The fallback stays for documents authored before sections carried
+// `data-id` (localStorage, existing user code, hand-written JSX). Those keep
+// exactly the old behaviour until `fillSectionIds` gives them real ids, so
+// this is additive rather than a breaking change to the document format.
 export const getSections = (doc: DocumentTree): Section[] =>
   findOutermostSections(doc.container.children).map((node, index) => ({
-    id: `${index}`,
+    id: getAttrValue(node, DATA_ATTR.ID) || `${index}`,
     name: getAttrValue(node, DATA_NAME_ATTR) || `${index + 1}번째 컴포넌트`,
     code: doc.code.slice(node.start!, node.end!),
   }));
+
+// Gives every top-level <section> a `data-id` that is present *and* unique
+// within the document, so `getSections` can return a real identity instead of
+// a position (#245). Sections ship with `data-name` only, which is a display
+// string — two "Hero" sections collide, exactly the way duplicate binding
+// labels did in #240.
+//
+// Uniqueness is enforced, not just presence. A positional id was unique by
+// construction; `data-id` is authored text, and the Editor/DnD modes share one
+// document, so copy-pasting a `<section data-id="abc">` block in the code
+// editor is an ordinary way to end up with two. Callers key destructive
+// operations off this id, so a duplicate would let one delete take both
+// sections with it. A repeat is therefore re-minted, keeping the first
+// occurrence.
+//
+// Splices into the original source rather than regenerating the tree, matching
+// how the rest of this module edits (see parseDocument's note): the author's
+// formatting everywhere else is left byte-identical.
+//
+// Callers should treat the result the way dnd.tsx treats fillIds' output —
+// derive from it, but only let it reach the document when a real edit
+// commits, so merely opening a file doesn't rewrite it.
+export const fillSectionIds = (
+  code: string,
+  generateId: () => string = () => nanoid(6),
+): string => {
+  const doc = parseDocument(code);
+
+  if (!doc) {
+    return code;
+  }
+
+  const seen = new Set<string>();
+  const edits: { start: number; end: number; text: string }[] = [];
+
+  findOutermostSections(doc.container.children).forEach(node => {
+    const attr = getAttr(node, DATA_ATTR.ID);
+    const id =
+      attr && t.isStringLiteral(attr.value) ? attr.value.value : undefined;
+
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      return;
+    }
+
+    const nextId = generateId();
+    seen.add(nextId);
+
+    // Replace the whole attribute when one is already there — including a
+    // non-string form like `data-id={x}`, which would otherwise get a second
+    // `data-id` spliced in beside it.
+    edits.push(
+      attr
+        ? {
+            start: attr.start!,
+            end: attr.end!,
+            text: `${DATA_ATTR.ID}="${nextId}"`,
+          }
+        : {
+            start: node.openingElement.name.end!,
+            end: node.openingElement.name.end!,
+            text: ` ${DATA_ATTR.ID}="${nextId}"`,
+          },
+    );
+  });
+
+  if (!edits.length) {
+    return code;
+  }
+
+  // Ids are drawn in document order, but applied right-to-left so each edit
+  // leaves the offsets of the ones before it untouched.
+  return edits.reduceRight(
+    (acc, edit) =>
+      `${acc.slice(0, edit.start)}${edit.text}${acc.slice(edit.end)}`,
+    code,
+  );
+};
 
 export const generateDocumentCode = (doc: DocumentTree): string => doc.code;
 

--- a/src/utils/ast/index.ts
+++ b/src/utils/ast/index.ts
@@ -32,6 +32,7 @@ export type { DocumentTree, SectionPreviewCache } from './document';
 export {
   clearDocumentParseCache,
   createSectionPreviewCache,
+  fillSectionIds,
   generateDocumentCode,
   generateSectionPreview,
   generateSectionPreviews,


### PR DESCRIPTION
## Summary

Fixes #245. `Section.id` was modelled two incompatible ways at once: `getSections` re-derived it from the section's **position** on every parse, while `Dnd` minted `uuidv4()` ids for sections it added or copied. A uuid was never written into the document, so it ceased to exist at the next parse — right after copying a section, `selectedId` resolved to nothing and the property panel dropped back to "Please select a section."

Sections now identify themselves with `data-id`, the same attribute editable elements already use.

## Changes

- **`getSections` prefers the section's own `data-id`**, falling back to the positional id so documents authored before this keep working unchanged until an edit fills ids in. Additive, not a breaking document-format change.
- **New `fillSectionIds()`** splices `data-id` into the original source rather than regenerating the tree, so the author's formatting elsewhere stays byte-identical (matching how the rest of `document.ts` edits).
- **Uniqueness is enforced, not just presence.** A positional id was unique *by construction*; `data-id` is authored text, and Editor/DnD modes share one document — copy-pasting a `<section data-id="abc">` block in the code editor is an ordinary way to end up with two. Since `remove`/`select`/`patch` all key off this id, a duplicate would let one delete take **both** sections. A repeat is re-minted, keeping the first occurrence. An existing attribute is replaced wholesale, so a non-string form (`data-id={x}`) doesn't get a second `data-id` spliced in beside it. *(This case was caught in review — thanks.)*
- **Copying selects the copy.** `replaceIds` refreshes the section's own `data-id` too, and the new id is read back from the committed document instead of invented.
- **Selection survives add, move and reorder**, and deleting a section no longer clears the selection unless it was the deleted one. `moveSection`'s hand-rolled `setSelectedId(String(targetIndex))` correction is gone.
- **`remove()` deletes by position, not by predicate** — it's the one destructive operation here, so it shouldn't be the one relying on the uniqueness invariant holding.
- **New `useSectionDocument` hook.** The commit sequence `replaceSections → onChange → setCode` was written out **seven** separate times in `dnd.tsx`. It is now one function, which also fills section ids on the way out (a palette template is a bare `<section>` snippet with no `#app-container`, so it can't be filled until it's spliced in) and returns the resulting sections. `dnd.tsx`: **704 → 558 lines**, and the `uuid` dependency drops out of this path.

No public API change.

## Type of Change

- [x] 🐛 fix — bug fix
- [x] ♻️ refactor — code structure improvement

## Scope

- [x] DnD / Canvas
- [x] AST transform (`src/utils/ast`)
- [x] Context / State

## Validation

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`
- [x] Manual verification completed

`pnpm test` (**259 tests**, up from 248) and `pnpm build:demos` also pass. 11 new tests cover `fillSectionIds` (fill, no-op, partial, unparsable, formatting preservation), the identity/fallback behaviour, and the duplicate-id and non-string-`data-id` cases.

### Manual verification

| step | result |
| --- | --- |
| Copy a section | count 2 → 3; **selected index 1** (the copy, not the original); panel populated with `Hero` |
| Move selected down | selected index 1 → **2**; panel still `Hero` — selection followed the section |
| Add another section while one is selected | count 3 → 4; selection **unchanged** at index 2 |
| Inspect the document | `<section data-id="abm1Fg" data-name="Hero">` — the id really is in the source |
| Legacy document (sections with no `data-id`) | renders, selects and shows the panel (`Beta` → `Title(innerText)`) |

Before this change, the copy step left the panel at "Please select a section."

Verified in the browser rather than as automated component tests — the repo has no DOM test environment (`vitest.config.ts` uses `environment: 'node'` with `include: ['src/**/*.test.ts']`). The AST-level behaviour that underpins all of it *is* covered by the new unit tests.

## Checklist

- [x] Commit messages follow gitmoji + conventional-commit style
- [x] Updated docs when behavior/API changed — no public API change
- [x] Added or updated tests when needed — 11 added
- [x] No unrelated changes included
