### PR TITLE
🐛 fix: uncontrolled Live.Dnd never reads PreviewContext.code (#244)

### DIFF
--- a/.changeset/fix-dnd-uncontrolled-value.md
+++ b/.changeset/fix-dnd-uncontrolled-value.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fixed `Live.Dnd` used without a `value` prop (uncontrolled usage) silently discarding every edit. `Dnd` wrote edits through `setCode` into `PreviewContext` but only ever read its canvas from the `value` prop, never from the context — so with no `value` supplied, a dragged-in section was added and then vanished on the very next render, forever re-deriving from `DEFAULT_TEMPLATE`. Mirrors the fallback `Client` (`preview/client.tsx`) already has for the same dual-source situation: `value` now resolves as `_value || code || DEFAULT_TEMPLATE`, so `<Live><Live.Dnd /></Live>` works standalone.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -176,7 +176,7 @@ const Dnd = ({
   const { breakpoint } = useResponsiveSize();
   const isMobile = breakpoint.current === 'xs' || breakpoint.current === 'sm';
 
-  const { setCode } = usePreview();
+  const { code, setCode } = usePreview();
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -186,7 +186,15 @@ const Dnd = ({
     }),
   );
 
-  const value = _value || DEFAULT_TEMPLATE;
+  // Uncontrolled usage (`<Live.Dnd />` with no `value`) used to read
+  // nothing but DEFAULT_TEMPLATE forever: every edit below writes through
+  // `setCode` into PreviewContext, but the canvas itself never read
+  // `code` back — so the section a reader just dragged in vanished on the
+  // very next render. `Client` (preview/client.tsx) already resolves the
+  // same dual-source situation with `_code || code`; mirrored here, with
+  // DEFAULT_TEMPLATE kept only as the final fallback for the case neither
+  // is set (fresh, empty context) — see #244.
+  const value = _value || code || DEFAULT_TEMPLATE;
   const sections = useMemo(() => extractSections(value), [value]);
   const selectedItem = useMemo(
     () => sections.find(s => s.id === selectedId),


### PR DESCRIPTION
## Summary
`Dnd` wrote every edit through `setCode` into `PreviewContext` but only ever read its canvas from the `value` prop, never from the context it shares with `Preview` — so `<Live><Live.Dnd /></Live>` with no `value` looked like it worked (dnd-kit adds the dragged section to the DOM) and then silently discarded the edit on the very next render, forever re-deriving sections from `DEFAULT_TEMPLATE`.

Fixed with the same fallback `Client` (`preview/client.tsx`) already has for the identical dual-source situation: `value = _value || code || DEFAULT_TEMPLATE`. This is option 2 from the issue's three suggested fixes (the one-line stopgap), not option 1 (moving `value`/`onChange` ownership up to `LiveProvider` entirely) — existing controlled usage is unaffected.

Fixes #244

**Note:** this PR originally also included a fix for #245, but #251 (`feat/section-identity`) already has a more comprehensive fix for that issue in flight (real `data-id`-based section identity instead of the positional-id scheme), so that commit was dropped here to avoid duplicate/conflicting work.

## Test plan
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` + `pnpm build:demos` pass
- [x] `pnpm test` — 248 tests pass (no regressions; not covered by a new automated test — the repo has no DOM test environment, same constraint noted in the source issue and in #248)