### PR TITLE
✨ feat(dnd): split binding type into type + widget axes

### DIFF
--- a/.changeset/split-binding-type-widget.md
+++ b/.changeset/split-binding-type-widget.md
@@ -1,0 +1,27 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Split the binding `type` axis into `type` (data kind) + `widget` (presentation) so a custom `renderPanel` can declare its own controls (#234, #236).
+
+`BindingItem`/`PanelBinding` gained a `widget?: string` field, separate from
+`type`. `type` stays a closed enum describing what a value _is_ — the
+library's own validation/coercion has to be able to switch on it
+exhaustively. `widget` is deliberately just a `string`, not an enum: it
+describes how to _render_ the value, and the library can't enumerate
+controls it doesn't implement. A consumer's `renderPanel` now owns
+presentation outright by declaring and switching on any `widget` value it
+wants (e.g. `widget: 'slider'`), instead of losing that metadata to
+`parseBinding`'s zod schema the way a custom `type` string used to (#234).
+
+`icon-picker`/`asset-picker` — previously the only two `BindingType` values
+that actually described a control rather than a data kind — are kept as
+deprecated aliases for backward compatibility. Existing content authored as
+`data-binding={[{ type: 'icon-picker', ... }]}` keeps parsing unchanged;
+`parseBinding` now normalizes it into `{ type: 'string', widget: 'icon-picker' }`
+rather than passing `icon-picker` through as `type` directly. The built-in
+panel's icon set is now exported as `ICON_MAP` so a custom `renderPanel` can
+reuse it instead of reimplementing an icon library.
+
+No breaking change: `widget` is additive, and every previously-valid
+`data-binding` literal still produces the same effective behavior.

--- a/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
+++ b/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
@@ -98,6 +98,26 @@ const ParsedValueEditor = ({
   </div>
 );
 
+// `binding.widget` is an open string (#236) — a custom renderPanel switches
+// on it to render whatever control it wants; the built-in panel only knows
+// `icon-picker`/`asset-picker`, so anything else (like `'slider'` here) is
+// exclusively this demo's own choice, not a value the library defines.
+const SliderField = ({ binding }: { binding: PanelBinding }) => (
+  <div className="flex items-center gap-2">
+    <input
+      type="range"
+      min={binding.min ?? 0}
+      max={binding.max ?? 100}
+      defaultValue={Number(binding.value) || 0}
+      className="w-full"
+      onChange={e => binding.onChange(e.target.value)}
+    />
+    <span className="w-8 text-right text-xs text-gray-500">
+      {binding.value}
+    </span>
+  </div>
+);
+
 // The plain-input fallback field, running `binding.min`/`max`/`pattern`/
 // `required` through the exported `validateBindingValue` before
 // committing — those constraints reach here as of #225, but nothing
@@ -251,6 +271,8 @@ const CustomPalettePanelDemo = () => {
                               binding={binding}
                               entries={entries}
                             />
+                          ) : binding.widget === 'slider' ? (
+                            <SliderField binding={binding} />
                           ) : binding.options ? (
                             <select
                               className="w-full rounded border border-gray-300

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -97,6 +97,12 @@ export interface PanelBinding {
   // (`string`/`url` -> <input>, `jsx`/`richtext` -> <textarea>, `boolean`
   // -> checkbox, ...). `undefined` means a plain string binding.
   type?: BindingType;
+  // Presentation, as opposed to `type`'s data kind — an open string, not a
+  // closed enum, since a custom renderPanel can declare any widget it
+  // wants (e.g. `'slider'`) and switch on it itself. The built-in panel
+  // only recognizes `'icon-picker'`/`'asset-picker'`; anything else falls
+  // back to the `type`-appropriate default control. See #236.
+  widget?: string;
   // Present when the binding defines a fixed option set (render a <select>).
   options?: BindingOption[];
   // Present for `object`/`array` bindings whose nested keys/items declare
@@ -340,6 +346,7 @@ const Dnd = ({
         label: binding.label,
         property: binding.property,
         type: binding.type,
+        widget: binding.widget,
         options: binding.options,
         render: binding.render,
         min: binding.min,

--- a/src/components/dnd/index.ts
+++ b/src/components/dnd/index.ts
@@ -8,6 +8,7 @@ import DraggableItem, {
   type DraggableItemDragState,
   type DraggableItemProps,
 } from './draggable';
+import { ICON_MAP } from './panel/icon-map';
 
 type DndComponent = typeof DndImpl & {
   DraggableItem: typeof DraggableItem;
@@ -18,6 +19,10 @@ const Dnd = DndImpl as DndComponent;
 Dnd.DraggableItem = DraggableItem;
 
 export { DraggableItem };
+// The built-in panel's own `widget: 'icon-picker'` icon set — exported so a
+// custom renderPanel can opt into it (name -> lucide-react component)
+// instead of reimplementing an icon library, per #236.
+export { ICON_MAP };
 export type {
   Props,
   PaletteRenderData,

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -430,7 +430,12 @@ const Field = ({ binding, id, value, onChange }: Props) => {
     );
   }
 
-  if (binding.type === 'icon-picker') {
+  // Checks `type` too, not just `widget`: a `type: 'icon-picker'` binding
+  // parsed by `parseBinding` is already normalized to `widget: 'icon-picker'`
+  // (see #236), but a hand-constructed BindingItem — e.g. the nested
+  // render-leaf case just above, which doesn't carry `widget` — can still
+  // arrive with the alias directly in `type`.
+  if (binding.widget === 'icon-picker' || binding.type === 'icon-picker') {
     const SelectedIcon = ICON_MAP[stringValue];
 
     return (
@@ -454,7 +459,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
     );
   }
 
-  if (binding.type === 'asset-picker') {
+  if (binding.widget === 'asset-picker' || binding.type === 'asset-picker') {
     const defaultUploadValue: UploadFile[] = stringValue
       ? [
           {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -84,12 +84,20 @@ export const DRAGGABLE_ITEMS: Section[] = [
               label: 'Background Style',
               property: 'style',
             },
+            {
+              label: 'Content Spacing',
+              property: 'size',
+              type: 'number',
+              widget: 'slider',
+              min: 0,
+              max: 40,
+            },
           ]}
           style={{
             backgroundColor: '#6366f1',
           }}
           orientation="vertical"
-          size="large"
+          size={16}
           align="center"
           className={cn(
             'px-5 py-15',

--- a/src/utils/ast/binding.test.ts
+++ b/src/utils/ast/binding.test.ts
@@ -53,17 +53,46 @@ describe('parseBinding', () => {
     expect(result[0]).not.toHaveProperty('type');
   });
 
-  it.each(['date', 'url', 'icon-picker', 'asset-picker'])(
-    'accepts %s as a valid type value',
+  it.each(['date', 'url'])('accepts %s as a valid type value', typeValue => {
+    const result = parseBinding(
+      `[{label: 'X', property: 'y', type: '${typeValue}'}]`,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveProperty('type', typeValue);
+  });
+
+  it.each(['icon-picker', 'asset-picker'])(
+    'normalizes %s from a legacy type value into type: string + widget',
     typeValue => {
       const result = parseBinding(
         `[{label: 'X', property: 'y', type: '${typeValue}'}]`,
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toHaveProperty('type', typeValue);
+      expect(result[0]).toHaveProperty('type', 'string');
+      expect(result[0]).toHaveProperty('widget', typeValue);
     },
   );
+
+  it('passes through an arbitrary widget string alongside a real type', () => {
+    const result = parseBinding(
+      "[{label: 'X', property: 'y', type: 'number', widget: 'slider'}]",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveProperty('type', 'number');
+    expect(result[0]).toHaveProperty('widget', 'slider');
+  });
+
+  it('keeps an unrecognized widget value instead of dropping the item', () => {
+    const result = parseBinding(
+      "[{label: 'X', property: 'y', type: 'string', widget: 'not-a-real-widget'}]",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveProperty('widget', 'not-a-real-widget');
+  });
 
   it('extracts both type and property on nested render leaves', () => {
     const result = parseBinding(`

--- a/src/utils/ast/binding.ts
+++ b/src/utils/ast/binding.ts
@@ -24,16 +24,26 @@ const bindingRenderLeafSchema = z.object({
   property: z.string().optional(),
 });
 
+// `widget` is deliberately just `z.string()`, not an enum — see #236. An
+// unrecognized widget is expected (a renderPanel consumer's own value, not
+// this library's), so unlike `type` there is no "drop it" failure mode to
+// design for.
 const rawBindingItemSchema = z.object({
   label: z.string(),
   property: z.string().optional(),
   type: bindingTypeSchema.optional(),
+  widget: z.string().optional(),
   options: z.array(bindingOptionSchema).optional(),
   min: z.number().optional(),
   max: z.number().optional(),
   pattern: z.string().optional(),
   required: z.boolean().optional(),
 });
+
+// The two BINDING_TYPES entries that describe a control, not a data kind —
+// see the type/widget split in #236. Normalized below into `widget` instead
+// of being passed through as `type` directly.
+const WIDGET_TYPE_ALIASES = new Set(['icon-picker', 'asset-picker']);
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -103,6 +113,19 @@ export const parseBinding = (bindingValue: string | null): BindingItem[] => {
     // untyped field rather than disappearing entirely.
     const sanitizedType = bindingTypeSchema.safeParse(rawItem.type);
 
+    // `icon-picker`/`asset-picker` describe a widget, not a data kind
+    // (#236) — normalize them into `widget` instead of passing them
+    // through as `type`. An explicitly authored `widget` (checked below,
+    // once the schema has validated it) wins if both are somehow present.
+    const isWidgetAlias =
+      sanitizedType.success && WIDGET_TYPE_ALIASES.has(sanitizedType.data);
+    const normalizedType = isWidgetAlias
+      ? 'string'
+      : sanitizedType.success
+        ? sanitizedType.data
+        : undefined;
+    const derivedWidget = isWidgetAlias ? sanitizedType.data : undefined;
+
     // Drop individually malformed options instead of rejecting the whole
     // item — a select field with 3 valid options and 1 malformed one should
     // still work with the 3 valid ones.
@@ -117,7 +140,7 @@ export const parseBinding = (bindingValue: string | null): BindingItem[] => {
 
     const parsed = rawBindingItemSchema.safeParse({
       ...rawItem,
-      type: sanitizedType.success ? sanitizedType.data : undefined,
+      type: normalizedType,
       options: sanitizedOptions?.length ? sanitizedOptions : undefined,
     });
 
@@ -125,8 +148,18 @@ export const parseBinding = (bindingValue: string | null): BindingItem[] => {
       continue;
     }
 
-    const { label, property, type, options, min, max, pattern, required } =
-      parsed.data;
+    const {
+      label,
+      property,
+      type,
+      widget: explicitWidget,
+      options,
+      min,
+      max,
+      pattern,
+      required,
+    } = parsed.data;
+    const widget = explicitWidget ?? derivedWidget;
 
     if (property === undefined && type !== 'richtext') {
       continue;
@@ -138,6 +171,7 @@ export const parseBinding = (bindingValue: string | null): BindingItem[] => {
       label,
       property: property ?? BINDING_PROP.INNER_HTML,
       ...(type !== undefined && { type }),
+      ...(widget !== undefined && { widget }),
       ...(options?.length && { options }),
       ...(render && { render }),
       ...(min !== undefined && { min }),

--- a/src/utils/ast/types.ts
+++ b/src/utils/ast/types.ts
@@ -25,6 +25,14 @@ export interface BindingOption {
   value: string;
 }
 
+// `icon-picker`/`asset-picker` are kept here as deprecated aliases, not
+// removed — see #236. They describe a *control*, not a data kind, and
+// conflating that with the rest of this list (which does describe what a
+// value actually is) left a consumer with nowhere to express their own
+// widget choice. `parseBinding` normalizes an authored `type: 'icon-picker'`
+// into `{ type: 'string', widget: 'icon-picker' }` rather than passing it
+// through as-is, so existing authored content keeps working unchanged while
+// `BindingItem.widget` becomes the real, open-ended home for this axis.
 export const BINDING_TYPES = [
   'array',
   'object',
@@ -55,7 +63,17 @@ export interface BindingRenderMap {
 export interface BindingItem {
   label: string;
   property: string;
+  // Data kind — what the value *is*. Closed, since the library's own
+  // validation/coercion (validateBindingValue, parseValue) has to be able
+  // to switch on it exhaustively.
   type?: BindingType;
+  // Presentation — how to *render* it. Deliberately an open string, not a
+  // closed enum: the library cannot enumerate controls it doesn't
+  // implement, and a renderPanel consumer owns presentation once they use
+  // it (see #234/#236). `'icon-picker'`/`'asset-picker'` are the built-in
+  // panel's own two widgets; anything else (e.g. `'slider'`) is free for a
+  // custom renderPanel to switch on.
+  widget?: string;
   options?: BindingOption[];
   render?: BindingRenderMap;
   min?: number;
@@ -65,13 +83,7 @@ export interface BindingItem {
 }
 
 export type NodeValueType =
-  | 'boolean'
-  | 'number'
-  | 'string'
-  | 'null'
-  | 'array'
-  | 'object'
-  | 'unknown';
+  'boolean' | 'number' | 'string' | 'null' | 'array' | 'object' | 'unknown';
 
 export type EditableNodeValueType = 'boolean' | 'number' | 'string' | 'null';
 

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -147,7 +147,8 @@ the built-in panel uses. Switch on `binding.type` to render your own control:
 | `id` | `string` | `data-id` of the owning element (stable across edits). |
 | `label` | `string` | Human-readable label from the binding definition. |
 | `property` | `string` | The bound prop/attribute name. |
-| `type` | `BindingType?` | The declared data-binding type — switch on this to pick a control. `undefined` means a plain string binding. See the full list below. |
+| `type` | `BindingType?` | The declared data kind — what the value *is* (`string`, `number`, `boolean`, ...). `undefined` means a plain string binding. See the full list below. |
+| `widget` | `string?` | The declared presentation — how to *render* it. An open string, not `BindingType`: the library can't enumerate controls it doesn't implement, so a custom `renderPanel` is free to declare and switch on any value it wants (e.g. `'slider'`). The built-in panel only recognizes `'icon-picker'`/`'asset-picker'`. |
 | `options` | `BindingOption[]?` | Present when the binding defines a fixed option set (render a `<select>`). |
 | `render` | `BindingRenderMap?` | Present on `object`/`array` bindings whose nested keys/items declare their own types — walk it to type each nested field instead of treating the value as an opaque string. |
 | `min` | `number?` | Minimum value for a `number` binding. Applies to `value` below even though it's a string — pass it straight to `validateBindingValue`, which coerces numeric strings. |
@@ -162,6 +163,43 @@ the built-in panel uses. Switch on `binding.type` to render your own control:
 `icon-picker`, `asset-picker`. Switching on it alone is enough for the
 scalar types; for `object`/`array` values, see `flattenEditableValue`
 below rather than treating them as plain text.
+
+`icon-picker` and `asset-picker` are kept in `BindingType` only so
+existing authored content (`data-binding={[{ type: 'icon-picker', ... }]}`)
+keeps parsing — they describe a control, not a data kind, so `parseBinding`
+normalizes them into `{ type: 'string', widget: 'icon-picker' }` /
+`{ type: 'string', widget: 'asset-picker' }` rather than passing them
+through as-is. A custom `renderPanel` should switch on `binding.widget`
+for these, not `binding.type`. The built-in panel's icon set is exported
+as `ICON_MAP` (`name -> lucide-react component`) if you want to reuse it
+instead of building your own:
+
+```ts
+import { ICON_MAP } from '@jbpark/live-editor';
+```
+
+Author a brand-new field with any other widget the same way — `type`
+still describes the data kind (so validation/coercion keeps working),
+`widget` is free text your own `renderPanel` switches on:
+
+```tsx
+// data-binding={[{ label: 'Spacing', property: 'size', type: 'number', widget: 'slider', min: 0, max: 40 }]}
+
+bindings.map(binding =>
+  binding.widget === 'slider' ? (
+    <input
+      type="range"
+      min={binding.min}
+      max={binding.max}
+      defaultValue={binding.value}
+      onChange={e => binding.onChange(e.target.value)}
+    />
+  ) : (
+    // ...fall back to type-based defaults
+    <input defaultValue={binding.value} onBlur={e => binding.onChange(e.target.value)} />
+  ),
+);
+```
 
 Constraints declared on a binding (`min`/`max`/`pattern`/`required`) aren't
 enforced automatically — call the exported `validateBindingValue(binding,


### PR DESCRIPTION
## Summary

`data-binding` metadata only had one axis (`type`), so a custom `renderPanel` couldn't declare its own presentation without either colliding with the library's closed `BindingType` enum or losing the value entirely — `parseBinding`'s zod schema silently strips any key it doesn't know about (#234). `icon-picker`/`asset-picker` made this concrete: they were the only two `BindingType` values that actually described a *control*, not a data kind, leaving no room for a consumer's own widget choice.

This is roadmap step 2 of #235's recommended sequence.

## Changes

- **`BindingItem.widget` / `PanelBinding.widget`**: an open `string`, not an enum, since the library can't enumerate controls it doesn't implement. `type` stays closed (validation/coercion still switches on it exhaustively); `widget` is free text a custom `renderPanel` switches on itself.
- **`binding.ts`**: `parseBinding` normalizes an authored `type: 'icon-picker'` into `{ type: 'string', widget: 'icon-picker' }` instead of passing it through as-is (`asset-picker` likewise). An explicit `widget` wins if both are somehow present. `widget` itself is `z.string().optional()` — no schema-level "unknown value" failure mode, unlike `type`.
- **`dnd.tsx` / `field.tsx`**: `PanelBinding` threads `widget` through; the built-in panel's `icon-picker`/`asset-picker` branches check `widget` first, falling back to `type` for hand-constructed `BindingItem`s that don't carry `widget` (the nested render-leaf case).
- **`index.ts`**: exports `ICON_MAP` so a custom `renderPanel` can reuse the built-in icon set instead of reimplementing one.
- **Demo + docs**: `CustomPalettePanelDemo` gains a `widget: 'slider'` example field (Hero's "Content Spacing", wired to a real numeric `size` prop so it's a working example, not just illustrative markup); docs updated with the `type` vs `widget` explanation and an `ICON_MAP` pointer.

## Scope note

This resolves the `type`/`widget` conflation part of #234 (icon-picker/asset-picker no longer eat a slot in the closed data-kind enum), but **not** #234 in full — the `meta`/`.passthrough()` fix for arbitrary custom keys (`step`, `unit`, `placeholder`, ...) is still open and tracked separately on #234, per #235's own child-issue notes ("#236 is the recommended structural resolution; #234's `meta` passthrough is complementary"). Not closing #234 with this PR.

Fixes #236

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm test` — 261 passed (2 pre-existing tests updated to reflect the new normalization behavior; 4 new tests added)
- [x] `pnpm build`
- [x] `pnpm build:demos`
- [x] `website`: `pnpm typecheck` passes (`docusaurus build` currently fails on an unrelated pre-existing `radix-ui` resolution error, reproduced identically on `main`)