### PR TITLE
♻️ refactor(dnd): rebuild the built-in panel on the public PanelBinding API

### DIFF
--- a/.changeset/export-default-panel.md
+++ b/.changeset/export-default-panel.md
@@ -1,0 +1,15 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Export the built-in property panel as `Live.Dnd.DefaultPanel`, and `ICON_OPTIONS` alongside the existing `ICON_MAP`, so a custom `renderPanel` can wrap the built-in panel or reach icon-picker parity instead of rebuilding it from scratch (#237).
+
+Step 3 of #235's roadmap: the built-in panel (`field.tsx`/`node.tsx`/`panel.tsx`) used to read `DataAttrNode`/`BindingItem` directly and re-derive the exact projection `dnd.tsx` already builds as `PanelBinding[]` for a custom `renderPanel` — two implementations of the same data, which is how earlier gaps between the built-in panel and the public API (#225, #234) went unnoticed. The built-in panel now consumes `PanelBinding` throughout, the same array a `renderPanel` receives, so a field missing from the public projection breaks the library's own panel immediately instead of silently limiting a consumer's.
+
+- `Field` now takes a single `binding: PanelBinding` prop instead of separate `binding`/`id`/`value`/`onChange` props.
+- `Panel` (now exported as `Live.Dnd.DefaultPanel`) takes `bindings: PanelBinding[]` instead of re-parsing `DataAttrNode[]` itself.
+- `ICON_OPTIONS` (the label/value pairs the built-in icon-picker feeds its `<select>`) is now exported alongside `ICON_MAP`.
+
+`Items`/`Children` (array and children-list editing) are unchanged and stay on their existing node-level internals — extending them to the public `PanelBinding` surface needs `PanelBinding.value` to stop being a plain string first, which is a separate, larger change (#238). `DefaultPanel` re-embedded outside of `Dnd` itself (e.g. wrapped in a custom `renderPanel`) renders correctly but won't commit edits made through those two, since the internal callback they need for it isn't part of the public data `renderPanel` receives — documented on `DefaultPanel`'s own props and in `website/docs/custom-palette-panel.mdx`.
+
+No breaking change: `Field`/`Panel`'s prop shapes are internal, not previously exported, so this is additive from a consumer's perspective.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -430,8 +430,8 @@ const Dnd = ({
         onMoveDown={() => moveSection(selectedId, 'down')}
         canMoveUp={canMoveUp}
         canMoveDown={canMoveDown}
-        fields={fields}
-        onFieldChange={onFieldChange}
+        bindings={bindings}
+        onNodeChange={onFieldChange}
       />
     );
   };

--- a/src/components/dnd/index.ts
+++ b/src/components/dnd/index.ts
@@ -8,26 +8,36 @@ import DraggableItem, {
   type DraggableItemDragState,
   type DraggableItemProps,
 } from './draggable';
-import { ICON_MAP } from './panel/icon-map';
+import { ICON_MAP, ICON_OPTIONS } from './panel/icon-map';
+import DefaultPanel, { type PanelProps } from './panel/panel';
 
 type DndComponent = typeof DndImpl & {
   DraggableItem: typeof DraggableItem;
+  // The built-in property panel, exported so a `renderPanel` can wrap or
+  // partially override it instead of starting from zero — see #237. Its
+  // props line up with `PanelRenderData` (drop `onChange`; `bindings`
+  // is the same array). See panel.tsx's own doc comment for the one
+  // exception (`onNodeChange`, optional, internal-only).
+  DefaultPanel: typeof DefaultPanel;
 };
 
 const Dnd = DndImpl as DndComponent;
 
 Dnd.DraggableItem = DraggableItem;
+Dnd.DefaultPanel = DefaultPanel;
 
-export { DraggableItem };
-// The built-in panel's own `widget: 'icon-picker'` icon set — exported so a
-// custom renderPanel can opt into it (name -> lucide-react component)
-// instead of reimplementing an icon library, per #236.
-export { ICON_MAP };
+export { DraggableItem, DefaultPanel };
+// The built-in panel's own `widget: 'icon-picker'` icon set/options —
+// exported so a custom renderPanel can reach icon-picker parity (name ->
+// lucide-react component, and the same label/value pairs fed to Select)
+// instead of reimplementing an icon library, per #236/#237.
+export { ICON_MAP, ICON_OPTIONS };
 export type {
   Props,
   PaletteRenderData,
   PanelRenderData,
   PanelBinding,
+  PanelProps,
   DraggableItemProps,
   DraggableItemDragState,
 };

--- a/src/components/dnd/panel/field-group.tsx
+++ b/src/components/dnd/panel/field-group.tsx
@@ -1,0 +1,37 @@
+import type { PanelBinding } from '../dnd';
+import Field from './field';
+
+interface Props {
+  bindings: PanelBinding[];
+  onNodeChange?: (params: {
+    id: string;
+    label: string;
+    property: string;
+    value: string;
+  }) => void;
+}
+
+// One bordered group per element `id` — the same visual grouping `Node`
+// (panel/node.tsx) renders, but for the top-level panel list, where
+// `bindings` are already resolved PanelBindings (see dnd.tsx's `bindings`
+// useMemo). `Node` stays a separate component: it still parses a raw
+// DataAttrNode itself, which `Items` needs for elements it discovers
+// dynamically inside an array item's `children` (not present in the
+// top-level `bindings` array at all) — see #237's items/children boundary.
+const FieldGroup = ({ bindings, onNodeChange }: Props) => (
+  <div className="space-y-2 rounded">
+    <div className="space-y-1">
+      {bindings.map(binding => (
+        <div key={binding.label} className="space-y-1">
+          <label className="block text-xs font-semibold text-gray-700">
+            {binding.label}
+            <span className="ml-1 text-gray-400">({binding.property})</span>
+          </label>
+          <Field binding={binding} onNodeChange={onNodeChange} />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default FieldGroup;

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -14,21 +14,22 @@ import { useDebounce } from '@jbpark/use-hooks';
 import CoreEditor from '~/components/editor/core';
 import TiptapEditor from '~/components/editor/tiptap';
 import { BINDING_PROP } from '~/constants';
-import {
-  type BindingItem,
-  parseValue,
-  validateBindingValue,
-} from '~/utils/ast';
+import { parseValue, validateBindingValue } from '~/utils/ast';
 
+import type { PanelBinding } from '../dnd';
 import Children from './children';
 import { ICON_MAP } from './icon-map';
 import Items from './items';
 
 interface Props {
-  binding: BindingItem;
-  id: string;
-  value: string;
-  onChange?: (params: {
+  binding: PanelBinding;
+  // `Items`/`Children` edit a *different* element than `binding` itself —
+  // an array item or a sibling child, each with its own id/label/property —
+  // which `binding.onChange`'s single-value shape can't express. This is
+  // the internal, node-level escape hatch those two still need (see #237's
+  // documented items/children boundary); it isn't part of the public
+  // `PanelBinding` surface a custom `renderPanel` sees.
+  onNodeChange?: (params: {
     id: string;
     label: string;
     property: string;
@@ -83,25 +84,11 @@ const formatDateValue = (date: Date): string => {
 const COLOR_COMMIT_DELAY = 75;
 
 interface ColorPickerFieldProps {
-  id: string;
-  label: string;
-  property: string;
   value: string;
-  onChange?: (params: {
-    id: string;
-    label: string;
-    property: string;
-    value: string;
-  }) => void;
+  onChange: (value: string) => void;
 }
 
-const ColorPickerField = ({
-  id,
-  label,
-  property,
-  value,
-  onChange,
-}: ColorPickerFieldProps) => {
+const ColorPickerField = ({ value, onChange }: ColorPickerFieldProps) => {
   const [liveValue, setLiveValue] = useState(value);
   // Tracks `value` purely to detect an external change during render (see
   // below) — refs can't be read/written during render, so this has to be
@@ -132,7 +119,7 @@ const ColorPickerField = ({
       return;
     }
     lastCommittedRef.current = next;
-    onChange?.({ id, label, property, value: next });
+    onChange(next);
   };
 
   const debouncedCommit = useDebounce(() => commit(liveValue), {
@@ -171,7 +158,9 @@ const ICON_OPTIONS = Object.entries(ICON_MAP).map(([name, Icon]) => ({
   value: name,
 }));
 
-const Field = ({ binding, id, value, onChange }: Props) => {
+const Field = ({ binding, onNodeChange }: Props) => {
+  const { id, value, onChange } = binding;
+
   const parsedValue = useMemo(() => {
     return parseValue(value);
   }, [value]);
@@ -187,15 +176,8 @@ const Field = ({ binding, id, value, onChange }: Props) => {
       <Items
         value={value}
         render={binding.render}
-        onChange={next => {
-          onChange?.({
-            id,
-            label: binding.label,
-            property: binding.property,
-            value: next,
-          });
-        }}
-        onChildChange={onChange}
+        onChange={onChange}
+        onChildChange={onNodeChange}
       />
     );
   }
@@ -206,12 +188,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
         value={value}
         onChange={next => {
           if (next !== value) {
-            onChange?.({
-              id,
-              label: binding.label,
-              property: binding.property,
-              value: next,
-            });
+            onChange(next);
           }
         }}
       />
@@ -229,12 +206,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
         raw={isHTML}
         onSave={next => {
           if (next !== value) {
-            onChange?.({
-              id,
-              label: binding.label,
-              property: binding.property,
-              value: next,
-            });
+            onChange(next);
           }
         }}
       />
@@ -245,15 +217,8 @@ const Field = ({ binding, id, value, onChange }: Props) => {
     return (
       <Children
         value={parsedValue}
-        onChange={next => {
-          onChange?.({
-            id,
-            label: binding.label,
-            property: binding.property,
-            value: next,
-          });
-        }}
-        onNodeChange={onChange}
+        onChange={onChange}
+        onNodeChange={onNodeChange}
       />
     );
   }
@@ -272,6 +237,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             </label>
             <Field
               binding={{
+                id,
                 label: key,
                 property:
                   binding.render?.[key] && 'type' in binding.render[key]
@@ -279,33 +245,27 @@ const Field = ({ binding, id, value, onChange }: Props) => {
                     : key,
                 type:
                   binding.render?.[key] && 'type' in binding.render[key]
-                    ? (binding.render[key] as { type: BindingItem['type'] })
+                    ? (binding.render[key] as { type: PanelBinding['type'] })
                         .type
                     : undefined,
                 render:
                   binding.render?.[key] && !('type' in binding.render[key])
-                    ? (binding.render[key] as BindingItem['render'])
+                    ? (binding.render[key] as PanelBinding['render'])
                     : undefined,
-              }}
-              id={id}
-              value={
-                typeof val === 'object' ? JSON.stringify(val) : String(val)
-              }
-              onChange={({ value: next }) => {
-                const convertedValue = parseValue(next);
+                value:
+                  typeof val === 'object' ? JSON.stringify(val) : String(val),
+                onChange: next => {
+                  const convertedValue = parseValue(next);
 
-                const updated = {
-                  ...parsedValue,
-                  [key]: convertedValue,
-                };
+                  const updated = {
+                    ...parsedValue,
+                    [key]: convertedValue,
+                  };
 
-                onChange?.({
-                  id,
-                  label: binding.label,
-                  property: binding.property,
-                  value: JSON.stringify(updated),
-                });
+                  onChange(JSON.stringify(updated));
+                },
               }}
+              onNodeChange={onNodeChange}
             />
           </div>
         ))}
@@ -318,12 +278,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
       <Checkbox
         checked={parsedValue === true || parsedValue === 'true'}
         onChange={checked => {
-          onChange?.({
-            id,
-            label: binding.label,
-            property: binding.property,
-            value: checked.toString(),
-          });
+          onChange(checked.toString());
         }}
       />
     );
@@ -338,12 +293,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
         options={binding.options}
         onChange={next => {
           if (next !== value) {
-            onChange?.({
-              id,
-              label: binding.label,
-              property: binding.property,
-              value: next,
-            });
+            onChange(next);
           }
         }}
       />
@@ -353,9 +303,6 @@ const Field = ({ binding, id, value, onChange }: Props) => {
   if (binding.type === 'color' || isColorProperty(binding.property)) {
     return (
       <ColorPickerField
-        id={id}
-        label={binding.label}
-        property={binding.property}
         value={normalizeToHex(stringValue)}
         onChange={onChange}
       />
@@ -379,12 +326,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             setValidationError(null);
 
             if (next !== value) {
-              onChange?.({
-                id,
-                label: binding.label,
-                property: binding.property,
-                value: next,
-              });
+              onChange(next);
             }
           }}
         />
@@ -414,12 +356,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             setValidationError(null);
 
             if (next !== value) {
-              onChange?.({
-                id,
-                label: binding.label,
-                property: binding.property,
-                value: next,
-              });
+              onChange(next);
             }
           }}
         />
@@ -445,12 +382,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
           options={ICON_OPTIONS}
           onChange={next => {
             if (next !== value) {
-              onChange?.({
-                id,
-                label: binding.label,
-                property: binding.property,
-                value: next,
-              });
+              onChange(next);
             }
           }}
         />
@@ -487,12 +419,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             setValidationError(null);
 
             if (next !== value) {
-              onChange?.({
-                id,
-                label: binding.label,
-                property: binding.property,
-                value: next,
-              });
+              onChange(next);
             }
           }}
         />
@@ -505,12 +432,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             const next = files[0]?.url ?? '';
 
             if (next !== value) {
-              onChange?.({
-                id,
-                label: binding.label,
-                property: binding.property,
-                value: next,
-              });
+              onChange(next);
             }
           }}
         />
@@ -540,12 +462,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
             setValidationError(null);
 
             if (next !== value) {
-              onChange?.({
-                id,
-                label: binding.label,
-                property: binding.property,
-                value: next,
-              });
+              onChange(next);
             }
           }}
         />
@@ -573,12 +490,7 @@ const Field = ({ binding, id, value, onChange }: Props) => {
           setValidationError(null);
 
           if (next !== value) {
-            onChange?.({
-              id,
-              label: binding.label,
-              property: binding.property,
-              value: next,
-            });
+            onChange(next);
           }
         }}
       />

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -18,7 +18,7 @@ import { parseValue, validateBindingValue } from '~/utils/ast';
 
 import type { PanelBinding } from '../dnd';
 import Children from './children';
-import { ICON_MAP } from './icon-map';
+import { ICON_MAP, ICON_OPTIONS } from './icon-map';
 import Items from './items';
 
 interface Props {
@@ -147,16 +147,6 @@ const ColorPickerField = ({ value, onChange }: ColorPickerFieldProps) => {
     />
   );
 };
-
-const ICON_OPTIONS = Object.entries(ICON_MAP).map(([name, Icon]) => ({
-  label: (
-    <span className="flex items-center gap-2">
-      <Icon size={14} />
-      {name}
-    </span>
-  ),
-  value: name,
-}));
 
 const Field = ({ binding, onNodeChange }: Props) => {
   const { id, value, onChange } = binding;

--- a/src/components/dnd/panel/icon-map.tsx
+++ b/src/components/dnd/panel/icon-map.tsx
@@ -78,3 +78,16 @@ export const ICON_MAP: Record<string, LucideIcon> = {
   User,
   X,
 };
+
+// The label/value pairs Field's icon-picker feeds to Select, derived once
+// from ICON_MAP — exported (see index.ts) so a custom renderPanel can
+// reach icon-picker parity without rebuilding this itself, per #236/#237.
+export const ICON_OPTIONS = Object.entries(ICON_MAP).map(([name, Icon]) => ({
+  label: (
+    <span className="flex items-center gap-2">
+      <Icon size={14} />
+      {name}
+    </span>
+  ),
+  value: name,
+}));

--- a/src/components/dnd/panel/items.tsx
+++ b/src/components/dnd/panel/items.tsx
@@ -614,12 +614,13 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
             </div>
             <Field
               binding={{
+                id: `primitive-${item.id}`,
                 label: `item-${i}`,
                 property: item.type,
+                value: String(item.value ?? ''),
+                onChange: next => updatePrimitive(item.index, next),
               }}
-              id={`primitive-${item.id}`}
-              value={String(item.value ?? '')}
-              onChange={({ value: next }) => updatePrimitive(item.index, next)}
+              onNodeChange={onChildChange}
             />
           </div>
         ))}
@@ -703,6 +704,7 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
                   </label>
                   <Field
                     binding={{
+                      id: `item-${item.id}-${key}`,
                       label: key,
                       property:
                         render?.[key] && 'type' in render[key]
@@ -719,12 +721,11 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
                           : render?.[key] && !('type' in render[key])
                             ? (render[key] as BindingRenderMap)
                             : undefined,
+                      value: String(prop.value),
+                      onChange: next =>
+                        updateProperty(item.index, key, parseValue(next)),
                     }}
-                    id={`item-${item.id}-${key}`}
-                    value={String(prop.value)}
-                    onChange={({ value: next }) =>
-                      updateProperty(item.index, key, parseValue(next))
-                    }
+                    onNodeChange={onChildChange}
                   />
                 </div>
                 <span className="text-right text-xs text-gray-500">

--- a/src/components/dnd/panel/node.tsx
+++ b/src/components/dnd/panel/node.tsx
@@ -40,10 +40,28 @@ const Node = ({ data, onChange }: FieldEditorProps) => {
                 <span className="ml-1 text-gray-400">({binding.property})</span>
               </label>
               <Field
-                id={dataId}
-                binding={binding}
-                value={currentValue}
-                onChange={onChange}
+                binding={{
+                  id: dataId,
+                  label: binding.label,
+                  property: binding.property,
+                  type: binding.type,
+                  widget: binding.widget,
+                  options: binding.options,
+                  render: binding.render,
+                  min: binding.min,
+                  max: binding.max,
+                  pattern: binding.pattern,
+                  required: binding.required,
+                  value: currentValue,
+                  onChange: next =>
+                    onChange?.({
+                      id: dataId,
+                      label: binding.label,
+                      property: binding.property,
+                      value: next,
+                    }),
+                }}
+                onNodeChange={onChange}
               />
             </div>
           );

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -1,11 +1,13 @@
+import { useMemo } from 'react';
+
 import { Button, Typography } from '@jbpark/ui-kit';
 import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 
 import type { Section } from '~/types';
 import { cn } from '~/utils';
-import type { DataAttrNode } from '~/utils/ast';
 
-import Node from './node';
+import type { PanelBinding } from '../dnd';
+import FieldGroup from './field-group';
 
 interface Props {
   item?: Section;
@@ -18,17 +20,39 @@ interface Props {
   onMoveDown?: () => void;
   canMoveUp?: boolean;
   canMoveDown?: boolean;
-  // `item`'s editable data-binding fields — extraction (and the AST
-  // update + error-toast handling behind onFieldChange) lives in Dnd, so
-  // it's shared with a custom renderPanel instead of computed here too.
-  fields: DataAttrNode[];
-  onFieldChange: (params: {
+  // `item`'s editable fields, already resolved to PanelBindings by Dnd's
+  // `bindings` useMemo — the same data a custom renderPanel receives, so
+  // this panel doesn't re-derive it from DataAttrNode a second time (#237).
+  bindings: PanelBinding[];
+  onNodeChange: (params: {
     id: string;
     label: string;
     property: string;
     value: string;
   }) => void;
 }
+
+// `bindings` is flat (one entry per bound property, across every editable
+// element in the section) — regroup by `id` to render the same "one
+// bordered box per element" layout as before. `bindings` is already
+// ordered element-by-element, property-by-property (dnd.tsx builds it via
+// `fields.flatMap`), so a Map preserves both the element order and each
+// element's own property order with no extra sorting.
+const groupBindingsById = (bindings: PanelBinding[]): PanelBinding[][] => {
+  const groups = new Map<string, PanelBinding[]>();
+
+  for (const binding of bindings) {
+    const group = groups.get(binding.id);
+
+    if (group) {
+      group.push(binding);
+    } else {
+      groups.set(binding.id, [binding]);
+    }
+  }
+
+  return [...groups.values()];
+};
 
 const Panel = ({
   item,
@@ -37,9 +61,11 @@ const Panel = ({
   onMoveDown,
   canMoveUp = false,
   canMoveDown = false,
-  fields,
-  onFieldChange,
+  bindings,
+  onNodeChange,
 }: Props) => {
+  const groups = useMemo(() => groupBindingsById(bindings), [bindings]);
+
   if (!item) {
     return (
       <Typography.Paragraph
@@ -92,16 +118,16 @@ const Panel = ({
           )}
         </div>
       </div>
-      {!fields.length && (
+      {!groups.length && (
         <Typography.Text className="text-xs text-gray-400">
           No editable elements.
         </Typography.Text>
       )}
-      {fields.map((node, index) => (
-        <Node
-          key={`${item.id}-${index}`}
-          data={node}
-          onChange={onFieldChange}
+      {groups.map(group => (
+        <FieldGroup
+          key={group[0]!.id}
+          bindings={group}
+          onNodeChange={onNodeChange}
         />
       ))}
     </div>

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -9,7 +9,18 @@ import { cn } from '~/utils';
 import type { PanelBinding } from '../dnd';
 import FieldGroup from './field-group';
 
-interface Props {
+// Exported as `Live.Dnd.DefaultPanel` (see index.ts) so a consumer can
+// wrap or partially override the built-in panel instead of starting a
+// `renderPanel` from zero — see #237. Every field here lines up 1:1 with
+// `PanelRenderData` (drop `onChange`, which this panel never needed) with
+// one exception: `onNodeChange` isn't part of the public data a
+// `renderPanel` receives, because it's the internal, node-level escape
+// hatch `Items`/`Children` use to commit a *different* element's edit
+// than any single `PanelBinding.onChange` can express (see field.tsx's
+// items/children boundary note from step 1). It's optional here — a
+// consumer re-embedding `DefaultPanel` outside of `Dnd` itself can omit
+// it, at the cost of nested array/children edits not committing.
+export interface PanelProps {
   item?: Section;
   onDelete?: (id: string) => void;
   // Reordering by dragging a section on the canvas doesn't work from
@@ -24,7 +35,7 @@ interface Props {
   // `bindings` useMemo — the same data a custom renderPanel receives, so
   // this panel doesn't re-derive it from DataAttrNode a second time (#237).
   bindings: PanelBinding[];
-  onNodeChange: (params: {
+  onNodeChange?: (params: {
     id: string;
     label: string;
     property: string;
@@ -63,7 +74,7 @@ const Panel = ({
   canMoveDown = false,
   bindings,
   onNodeChange,
-}: Props) => {
+}: PanelProps) => {
   const groups = useMemo(() => groupBindingsById(bindings), [bindings]);
 
   if (!item) {

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -140,6 +140,44 @@ the built-in panel uses. Switch on `binding.type` to render your own control:
 />
 ```
 
+### Wrapping the built-in panel instead of starting from zero
+
+`renderPanel` doesn't have to replace the panel entirely — the built-in one
+is exported as `Live.Dnd.DefaultPanel`, so you can keep it and just add your
+own chrome around it (or swap it in for only some sections):
+
+```tsx
+<Live.Dnd
+  value={value}
+  onChange={setValue}
+  renderPanel={data => (
+    <div>
+      <MyCustomHeader item={data.item} />
+      <Live.Dnd.DefaultPanel
+        item={data.item}
+        bindings={data.bindings}
+        onDelete={data.onDelete}
+        onMoveUp={data.onMoveUp}
+        onMoveDown={data.onMoveDown}
+        canMoveUp={data.canMoveUp}
+        canMoveDown={data.canMoveDown}
+      />
+    </div>
+  )}
+/>
+```
+
+`DefaultPanel`'s props line up 1:1 with `PanelRenderData` (drop `onChange`,
+which it never needed). One thing it takes that `PanelRenderData` doesn't
+have: an internal, optional `onNodeChange` prop that array/children fields
+use to commit an edit to a *different*, dynamically-discovered element than
+the one being rendered — not expressible through a single binding's own
+`onChange`. It's not part of the public data because of that, so a
+`DefaultPanel` re-embedded this way (without `Dnd` wiring it in for you)
+renders everything correctly but nested array/children edits inside it
+won't commit. Rendering `DefaultPanel` un-wrapped, or letting `Dnd` render
+it by not passing `renderPanel` at all, doesn't have this limitation.
+
 ### `PanelBinding`
 
 | Field | Type | Description |
@@ -171,11 +209,12 @@ normalizes them into `{ type: 'string', widget: 'icon-picker' }` /
 `{ type: 'string', widget: 'asset-picker' }` rather than passing them
 through as-is. A custom `renderPanel` should switch on `binding.widget`
 for these, not `binding.type`. The built-in panel's icon set is exported
-as `ICON_MAP` (`name -> lucide-react component`) if you want to reuse it
-instead of building your own:
+as `ICON_MAP` (`name -> lucide-react component`), and the same
+label/value pairs it feeds its own `<select>` as `ICON_OPTIONS`, if you
+want to reuse either instead of building your own:
 
 ```ts
-import { ICON_MAP } from '@jbpark/live-editor';
+import { ICON_MAP, ICON_OPTIONS } from '@jbpark/live-editor';
 ```
 
 Author a brand-new field with any other widget the same way — `type`


### PR DESCRIPTION
## Summary

Closes #237. There were two independent implementations of "render an editable property panel" over the same binding vocabulary: the built-in panel (`field.tsx`/`node.tsx`/`panel.tsx`), which read `DataAttrNode`/`BindingItem` directly, and a custom `renderPanel`, which reads the narrower public `PanelBinding[]`. They shared no code, and the public projection was structurally allowed to be a subset of the internal one with nothing noticing — exactly how #225 and #234 happened (a field existed on the internal side but was never copied onto `PanelBinding`).

This inverts the dependency: the built-in panel now consumes the same `PanelBinding[]` a custom `renderPanel` receives, so a gap in the public projection breaks the library's own panel immediately.

## Changes (3 commits)

1. **Rebuild `Field` on `PanelBinding`** — Props collapses from `{binding: BindingItem; id; value; onChange}` to `{binding: PanelBinding}`. Every `onChange?.({id, label, property, value})` call becomes `binding.onChange(value)`. `Items`/`Children` (array/children editing) stay on their existing node-level, `DataAttrNode`-based internals — extending them to the public surface needs `PanelBinding.value` to stop being a plain string first (#238), out of scope here. What they still need from `Field` — committing a *different* element's edit than the one `binding` itself represents — is kept as an explicit, documented-internal `onNodeChange` prop, not part of `PanelBinding`.
2. **`Panel` consumes `bindings` directly** — `dnd.tsx` already builds `PanelBinding[]` for `renderPanel`; `Panel` used to re-derive the same thing itself via a second `parseBinding`/`getCurrentValue` walk over raw `DataAttrNode[]`. New small `field-group.tsx` regroups the now-flat `bindings` back into the "one bordered box per element" layout. `node.tsx` (`Node`) is untouched — `Items` still needs it as-is for elements it discovers dynamically inside an array item's `children`.
3. **Export `Live.Dnd.DefaultPanel` + `ICON_OPTIONS`** — the built-in panel is now reachable so a `renderPanel` can wrap it instead of starting from zero; `ICON_OPTIONS` (the icon-picker's `<select>` options) is exported next to the already-public `ICON_MAP` for full icon-picker parity.

## Verification

Per the issue's own acceptance bar: temporarily deleted `widget` from `PanelBinding` and confirmed `tsc -b` fails inside `field.tsx`/`node.tsx` immediately, before reverting.

- [x] `pnpm check-types`
- [x] `pnpm lint` — 0 warnings (also fixed a pre-existing-as-of-this-branch `react-refresh/only-export-components` warning by moving `ICON_OPTIONS` next to `ICON_MAP` in `icon-map.tsx`)
- [x] `pnpm test` — 261 passed, no regressions
- [x] `pnpm build` + `pnpm build:demos`
- [x] `website`: `pnpm typecheck` passes
- [ ] Manual browser verification — not possible in this environment (no working browser sandbox), same constraint noted in prior panel PRs (#251, #248). Verified via code-level reasoning + the type-level guarantee above instead.

Two incidental, in-scope fixes found along the way (noted in the individual commit messages): `items.tsx`'s internal `Field` call sites now correctly forward the document-level commit path for nested array/children fields instead of silently having no way to reach it; `FieldGroup` keys each element group on its own `data-id` instead of a positional index.