### PR TITLE
🐛 fix: isolate ui-kit's imported CSS into its own cascade layer

### DIFF
--- a/.changeset/fix-ui-kit-css-layer.md
+++ b/.changeset/fix-ui-kit-css-layer.md
@@ -1,0 +1,9 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fix `@jbpark/ui-kit`'s bundled CSS silently overriding this library's own responsive utility classes (#259).
+
+`src/index.css` pulled in `@jbpark/ui-kit/style.css` as a bare `@import`, which merges the two stylesheets' identically-named `theme`/`base`/`components`/`utilities` cascade layers into one. Since ui-kit's own compiled CSS is itself a full Tailwind build, any utility class both stylesheets emit (nearly all of them, since ui-kit uses the same Tailwind utility set) resolved by import order instead of by the responsive variant actually intended to win — most visibly, `hidden md:block` (used for the built-in `Live.Dnd` panel's desktop layout) stayed hidden at any width, because ui-kit's own unconditional `.hidden` landed after `md:block` in the merged layer.
+
+`@import '@jbpark/ui-kit/style.css' layer(ui-kit);`, with `ui-kit` declared between `components` and `utilities` in the layer order, nests ui-kit's own layers under a dedicated `ui-kit` layer instead of merging them into this library's own. This library's own utility classes now always win over ui-kit's identically-named ones, regardless of import order, while ui-kit's internal cascade stays internally consistent.

--- a/demos/custom-editor/main.tsx
+++ b/demos/custom-editor/main.tsx
@@ -1,8 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import '@jbpark/ui-kit/style.css';
-
+// `~/index.css` already pulls in @jbpark/ui-kit's stylesheet (properly
+// layered — see its own comment) — a separate direct import here duplicated
+// it unlayered, ahead of everything else, which is exactly the ordering
+// this repo's own layer fix (#259) exists to prevent. Don't re-add it.
 import '~/index.css';
 
 import '../shared.css';

--- a/demos/custom-palette-panel/main.tsx
+++ b/demos/custom-palette-panel/main.tsx
@@ -1,8 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import '@jbpark/ui-kit/style.css';
-
+// `~/index.css` already pulls in @jbpark/ui-kit's stylesheet (properly
+// layered — see its own comment) — a separate direct import here duplicated
+// it unlayered, ahead of everything else, which is exactly the ordering
+// this repo's own layer fix (#259) exists to prevent. Don't re-add it.
 import '~/index.css';
 
 import '../shared.css';

--- a/demos/dnd/main.tsx
+++ b/demos/dnd/main.tsx
@@ -1,8 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import '@jbpark/ui-kit/style.css';
-
+// `~/index.css` already pulls in @jbpark/ui-kit's stylesheet (properly
+// layered — see its own comment) — a separate direct import here duplicated
+// it unlayered, ahead of everything else, which is exactly the ordering
+// this repo's own layer fix (#259) exists to prevent. Don't re-add it.
 import '~/index.css';
 
 import '../shared.css';

--- a/demos/editor-mode/main.tsx
+++ b/demos/editor-mode/main.tsx
@@ -1,8 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import '@jbpark/ui-kit/style.css';
-
+// `~/index.css` already pulls in @jbpark/ui-kit's stylesheet (properly
+// layered — see its own comment) — a separate direct import here duplicated
+// it unlayered, ahead of everything else, which is exactly the ordering
+// this repo's own layer fix (#259) exists to prevent. Don't re-add it.
 import '~/index.css';
 
 import '../shared.css';

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@
  * Consumers that run their own Tailwind still get preflight from their own
  * build, so this library's chrome is unaffected either way.
  */
-@layer theme, base, components, utilities;
+@layer theme, base, components, ui-kit, utilities;
 @import 'tailwindcss/theme.css' layer(theme);
 @import 'tailwindcss/utilities.css' layer(utilities);
 
@@ -26,8 +26,24 @@
  * import now carries both this library's own [data-editor-mode] styles and
  * ui-kit's, so nothing else needs to change for consumers already following
  * the docs.
+ *
+ * Imported into its own `ui-kit` layer rather than left unlayered — ui-kit's
+ * stylesheet declares its own `theme`/`base`/`components`/`utilities` layers
+ * internally, and an unlayered `@import` merges those straight into this
+ * file's SAME-NAMED layers, appended after this file's own content. Any
+ * class both sheets emit (Tailwind's own utility classes, since ui-kit is
+ * built with the same Tailwind) then resolves by import order instead of by
+ * the responsive variant actually intended to win — e.g. `hidden md:block`
+ * silently stayed hidden at any width, because ui-kit's own unconditional
+ * `.hidden` landed after this file's `.md\:block` in the merged utilities
+ * layer (see #259). `layer(ui-kit)` nests ui-kit's internal layers under
+ * this one instead (`ui-kit.utilities`, etc. — see the CSS Cascading and
+ * Layering spec's import-with-layer-name behavior), and declaring `ui-kit`
+ * before `utilities` above keeps this file's own utilities the tie-breaker
+ * regardless of import order, without discarding ui-kit's own internal
+ * layer structure.
  */
-@import '@jbpark/ui-kit/style.css';
+@import '@jbpark/ui-kit/style.css' layer(ui-kit);
 
 @layer utilities {
   /* 편집 모드 기본 설정 */


### PR DESCRIPTION
## Summary

Fixes #259. `src/index.css` pulled in `@jbpark/ui-kit/style.css` as a bare `@import`, merging its `theme`/`base`/`components`/`utilities` cascade layers into this file's identically-named ones. Since ui-kit's compiled CSS is itself a full Tailwind build, any class both stylesheets emit resolved by import order instead of by the responsive variant meant to win — `hidden md:block` (`Live.Dnd`'s desktop palette/panel) stayed hidden at any width, because ui-kit's own unconditional `.hidden` landed after `md:block` once merged.

## Changes

- **`src/index.css`**: `@import '@jbpark/ui-kit/style.css' layer(ui-kit);`, with `ui-kit` declared between `components` and `utilities` in the layer order. This nests ui-kit's own layers under a dedicated `ui-kit` layer (per the CSS spec's import-with-layer-name behavior) instead of merging them into this file's own — so this library's own utilities always win over ui-kit's identically-named ones, regardless of import order, without touching ui-kit's own internal cascade.
- **`demos/*/main.tsx`** (all 4): dropped a redundant direct `import '@jbpark/ui-kit/style.css'` — `~/index.css` already pulls it in, correctly layered now. Found this because it re-introduced the same collision by a different path once the direct + transitive imports of the same file stopped being deduplicated identically after the layer change above.

## Scope confirmed before fixing

Only the root `src/pages/editor` reference app (`pnpm dev` / `pnpm build:demo`) was actually affected. The deployed docs site (`demos/*/main.tsx`'s build, what `vercel.json` deploys) happened to avoid the collision by import order — confirmed by directly comparing compiled CSS from both builds. No end user or published-package-consumer impact before this fix; landing it anyway since it makes `pnpm dev` misleading for anyone testing `Dnd`'s desktop layout locally, and to close the same risk in `dist/style.css` for any consumer whose own markup happens to hit the same collision pattern.

## Test plan

Verified with Playwright (headless Chromium) against real build output, not just dev-server behavior:

- [x] `pnpm build:demo` (root app): `.w-1/5` panel element computes `display: block` at 1400px width with zero CSS overrides (was `display: none` before this fix)
- [x] `pnpm build:demos` (the docs site's actual demo bundles): same check on all 4 demos (`dnd`, `custom-editor`, `custom-palette-panel`, `editor-mode`) — `display: block`, zero console errors, screenshots match pre-fix appearance (no visual regression from the layer change)
- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm test` — 261 passed
- [x] `pnpm build` + `pnpm build:demos`
- [x] `website`: `pnpm typecheck`