### PR TITLE
✨ feat(ast): carry consumer-defined binding metadata through as meta

### DIFF
--- a/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
+++ b/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
@@ -102,21 +102,37 @@ const ParsedValueEditor = ({
 // on it to render whatever control it wants; the built-in panel only knows
 // `icon-picker`/`asset-picker`, so anything else (like `'slider'` here) is
 // exclusively this demo's own choice, not a value the library defines.
-const SliderField = ({ binding }: { binding: PanelBinding }) => (
-  <div className="flex items-center gap-2">
-    <input
-      type="range"
-      min={binding.min ?? 0}
-      max={binding.max ?? 100}
-      defaultValue={Number(binding.value) || 0}
-      className="w-full"
-      onChange={e => binding.onChange(e.target.value)}
-    />
-    <span className="w-8 text-right text-xs text-gray-500">
-      {binding.value}
-    </span>
-  </div>
-);
+//
+// `step`/`unit` aren't fields PanelBinding declares either — they're
+// whatever this demo's own binding happened to author (see the Hero
+// section's "Content Spacing" field), carried through under `binding.meta`
+// instead of being stripped during parsing (#234). `meta`'s values are
+// `unknown` on purpose (the library can't know what shape a consumer's own
+// metadata takes), so narrow them before use rather than trusting the type.
+const SliderField = ({ binding }: { binding: PanelBinding }) => {
+  const metaStep = binding.meta?.step;
+  const step = typeof metaStep === 'number' ? metaStep : 1;
+  const metaUnit = binding.meta?.unit;
+  const unit = typeof metaUnit === 'string' ? metaUnit : '';
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="range"
+        min={binding.min ?? 0}
+        max={binding.max ?? 100}
+        step={step}
+        defaultValue={Number(binding.value) || 0}
+        className="w-full"
+        onChange={e => binding.onChange(e.target.value)}
+      />
+      <span className="w-12 text-right text-xs text-gray-500">
+        {binding.value}
+        {unit}
+      </span>
+    </div>
+  );
+};
 
 // The plain-input fallback field, running `binding.min`/`max`/`pattern`/
 // `required` through the exported `validateBindingValue` before

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -116,6 +116,11 @@ export interface PanelBinding {
   max?: number;
   pattern?: string;
   required?: boolean;
+  // Consumer-defined keys carried straight through from the authored
+  // data-binding — namespaced instead of spread onto PanelBinding so they
+  // can't collide with a future first-class field. Absent when nothing
+  // extra was authored. See #234.
+  meta?: Record<string, unknown>;
   // Current serialized value — the same string the built-in field receives.
   value: string;
   // Commit a new value through the same AST-update pipeline the built-in
@@ -353,6 +358,7 @@ const Dnd = ({
         max: binding.max,
         pattern: binding.pattern,
         required: binding.required,
+        meta: binding.meta,
         value: getCurrentValue(node, binding.property),
         onChange: (value: string) =>
           onFieldChange({

--- a/src/components/dnd/panel/node.tsx
+++ b/src/components/dnd/panel/node.tsx
@@ -52,6 +52,7 @@ const Node = ({ data, onChange }: FieldEditorProps) => {
                   max: binding.max,
                   pattern: binding.pattern,
                   required: binding.required,
+                  meta: binding.meta,
                   value: currentValue,
                   onChange: next =>
                     onChange?.({

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -91,6 +91,12 @@ export const DRAGGABLE_ITEMS: Section[] = [
               widget: 'slider',
               min: 0,
               max: 40,
+              // step/unit aren't fields this library knows about — they
+              // survive parsing under binding.meta instead of being
+              // stripped, so a custom renderPanel can read its own
+              // per-field configuration back out. See #234.
+              step: 4,
+              unit: 'px',
             },
           ]}
           style={{

--- a/src/utils/ast/binding.test.ts
+++ b/src/utils/ast/binding.test.ts
@@ -111,7 +111,7 @@ describe('parseBinding', () => {
     });
   });
 
-  it('drops a nested render leaf with an unrecognized type instead of keeping it as-is', () => {
+  it('degrades a nested render leaf with an unrecognized type to untyped instead of dropping the key', () => {
     const result = parseBinding(`
       [{
         label: 'Items',
@@ -125,6 +125,7 @@ describe('parseBinding', () => {
 
     expect(result[0]!.render).toEqual({
       icon: { type: 'string', property: 'innerText' },
+      bogus: { type: undefined, property: 'innerText' },
     });
   });
 

--- a/src/utils/ast/binding.test.ts
+++ b/src/utils/ast/binding.test.ts
@@ -129,6 +129,45 @@ describe('parseBinding', () => {
     });
   });
 
+  it('keeps `type` as a real key on a degraded render leaf, not just an equal-to-undefined value', () => {
+    // `toEqual` above treats a missing key the same as one set to
+    // `undefined`, so it can't catch a regression back to "delete the key
+    // entirely" — items.tsx's own leaf-vs-nested-map check depends on `in`,
+    // not just the value, since sanitizeRenderMap uses the same `'type' in
+    // raw` test to decide a value is a leaf at all.
+    const result = parseBinding(`
+      [{
+        label: 'Items',
+        property: 'items',
+        render: {
+          bogus: { type: 'not-a-real-type' }
+        }
+      }]
+    `);
+
+    expect('type' in result[0]!.render!.bogus!).toBe(true);
+  });
+
+  it('carries unrecognized keys under a namespaced meta object instead of dropping them', () => {
+    const result = parseBinding(
+      `[{ label: 'Size', property: 'size', type: 'number', step: 5, unit: 'px', group: 'layout' }]`,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveProperty('meta', {
+      step: 5,
+      unit: 'px',
+      group: 'layout',
+    });
+  });
+
+  it('does not add a meta field when no extra keys are authored', () => {
+    const result = parseBinding("[{label: 'Title', property: 'innerText'}]");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).not.toHaveProperty('meta');
+  });
+
   it('extracts min/max/pattern/required constraints when present', () => {
     const result = parseBinding(
       "[{label: 'Age', property: 'data-age', type: 'number', min: 0, max: 120, pattern: '^[0-9]+$', required: true}]",

--- a/src/utils/ast/binding.ts
+++ b/src/utils/ast/binding.ts
@@ -28,17 +28,42 @@ const bindingRenderLeafSchema = z.object({
 // unrecognized widget is expected (a renderPanel consumer's own value, not
 // this library's), so unlike `type` there is no "drop it" failure mode to
 // design for.
-const rawBindingItemSchema = z.object({
-  label: z.string(),
-  property: z.string().optional(),
-  type: bindingTypeSchema.optional(),
-  widget: z.string().optional(),
-  options: z.array(bindingOptionSchema).optional(),
-  min: z.number().optional(),
-  max: z.number().optional(),
-  pattern: z.string().optional(),
-  required: z.boolean().optional(),
-});
+//
+// `.passthrough()` (rather than the default `.strip()`) keeps any key this
+// schema doesn't know about instead of silently discarding it — see #234.
+// A consumer's own metadata (`step`, `unit`, a widget hint, ...) survives
+// parsing and is surfaced separately as `meta` below, namespaced instead of
+// spread onto the item, so it can't collide with a future first-class field.
+const rawBindingItemSchema = z
+  .object({
+    label: z.string(),
+    property: z.string().optional(),
+    type: bindingTypeSchema.optional(),
+    widget: z.string().optional(),
+    options: z.array(bindingOptionSchema).optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+    pattern: z.string().optional(),
+    required: z.boolean().optional(),
+  })
+  .passthrough();
+
+// Every key `rawBindingItemSchema` declares, plus `render` (handled by
+// `sanitizeRenderMap` separately, never through this schema) — anything
+// else surviving `.passthrough()` is consumer-defined and belongs in `meta`,
+// not treated as one of this library's own fields.
+const KNOWN_BINDING_KEYS = new Set([
+  'label',
+  'property',
+  'type',
+  'widget',
+  'options',
+  'render',
+  'min',
+  'max',
+  'pattern',
+  'required',
+]);
 
 // The two BINDING_TYPES entries that describe a control, not a data kind —
 // see the type/widget split in #236. Normalized below into `widget` instead
@@ -167,6 +192,12 @@ export const parseBinding = (bindingValue: string | null): BindingItem[] => {
 
     const render = sanitizeRenderMap(rawItem.render);
 
+    const metaEntries = Object.entries(parsed.data).filter(
+      ([key]) => !KNOWN_BINDING_KEYS.has(key),
+    );
+    const meta =
+      metaEntries.length > 0 ? Object.fromEntries(metaEntries) : undefined;
+
     items.push({
       label,
       property: property ?? BINDING_PROP.INNER_HTML,
@@ -178,6 +209,7 @@ export const parseBinding = (bindingValue: string | null): BindingItem[] => {
       ...(max !== undefined && { max }),
       ...(pattern !== undefined && { pattern }),
       ...(required !== undefined && { required }),
+      ...(meta && { meta }),
     });
   }
 

--- a/src/utils/ast/binding.ts
+++ b/src/utils/ast/binding.ts
@@ -19,8 +19,10 @@ const bindingOptionSchema = z.object({
   value: z.string(),
 });
 
+// `type` is validated separately in sanitizeRenderMap (like the top-level
+// item's own type) so an unrecognized value degrades the leaf to untyped
+// instead of failing this whole schema — see #234.
 const bindingRenderLeafSchema = z.object({
-  type: bindingTypeSchema,
   property: z.string().optional(),
 });
 
@@ -90,11 +92,24 @@ const sanitizeRenderMap = (value: unknown): BindingRenderMap | undefined => {
     }
 
     if ('type' in raw) {
+      // Drop an unrecognized `type` down to untyped instead of dropping the
+      // whole entry — matches the top-level item's own behavior at
+      // `bindingTypeSchema.safeParse(rawItem.type)` above. Keeping the
+      // entry (rather than deleting the key) is what #234 asked for: a
+      // typo'd/future leaf type still shows up as a plain field instead of
+      // vanishing, and `'type' in leaf` stays true either way since `type`
+      // is always set below, even to `undefined`.
+      const sanitizedType = bindingTypeSchema.safeParse(raw.type);
       const leaf = bindingRenderLeafSchema.safeParse(raw);
 
       if (leaf.success) {
         const render = sanitizeRenderMap(raw.render);
-        map[key] = render ? { ...leaf.data, render } : leaf.data;
+        const typedLeaf = {
+          ...leaf.data,
+          type: sanitizedType.success ? sanitizedType.data : undefined,
+        };
+
+        map[key] = render ? { ...typedLeaf, render } : typedLeaf;
       }
       continue;
     }

--- a/src/utils/ast/types.ts
+++ b/src/utils/ast/types.ts
@@ -51,7 +51,10 @@ export const BINDING_TYPES = [
 export type BindingType = (typeof BINDING_TYPES)[number];
 
 export interface BindingRenderLeaf {
-  type: BindingType;
+  // Optional, matching the top-level BindingItem.type — an unrecognized
+  // leaf type degrades to untyped instead of dropping the entry (see
+  // sanitizeRenderMap in binding.ts and #234).
+  type?: BindingType;
   property?: string;
   render?: BindingRenderMap;
 }

--- a/src/utils/ast/types.ts
+++ b/src/utils/ast/types.ts
@@ -80,6 +80,12 @@ export interface BindingItem {
   max?: number;
   pattern?: string;
   required?: boolean;
+  // Consumer-defined keys that aren't one of the fields above (`step`,
+  // `unit`, a widget hint, ...) — namespaced here rather than spread onto
+  // the item itself so they can't collide with a future first-class field.
+  // Undefined when nothing extra was authored, not an empty object. See
+  // #234: `parseBinding` used to silently strip these.
+  meta?: Record<string, unknown>;
 }
 
 export type NodeValueType =

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -193,6 +193,7 @@ it by not passing `renderPanel` at all, doesn't have this limitation.
 | `max` | `number?` | Maximum value for a `number` binding, same coercion as `min`. |
 | `pattern` | `string?` | A regex source the value must match. |
 | `required` | `boolean?` | Whether an empty value should fail validation. |
+| `meta` | `Record<string, unknown>?` | Any authored key that isn't one of the fields above (a step increment, a unit suffix, a group name, ...) — see below. `undefined` when nothing extra was authored, not an empty object. |
 | `value` | `string` | Current serialized value. |
 | `onChange` | `(value: string) => void` | Commit an edit through the same AST-update pipeline (including the error toast on a bad edit). |
 
@@ -201,6 +202,47 @@ it by not passing `renderPanel` at all, doesn't have this limitation.
 `icon-picker`, `asset-picker`. Switching on it alone is enough for the
 scalar types; for `object`/`array` values, see `flattenEditableValue`
 below rather than treating them as plain text.
+
+An authored `type` this library doesn't recognize (a typo, or a future
+value) doesn't reject the binding — it's dropped, so `binding.type` is
+simply `undefined` rather than the string you wrote. The same degrade,
+not delete, behavior applies one level down: an unrecognized `type`
+inside a `render` map leaves that leaf's own `type` `undefined` instead
+of removing the leaf entirely.
+
+Any other key you author on a binding beyond the ones in the table
+above — one this library doesn't declare at all, like a step increment or
+a unit suffix — isn't dropped either; it survives under `binding.meta`,
+namespaced there instead of spread onto the binding itself so it can't
+collide with a future first-class field:
+
+```tsx
+// data-binding={[{ label: 'Spacing', property: 'size', type: 'number', widget: 'slider', min: 0, max: 40, step: 4, unit: 'px' }]}
+
+bindings.map(binding => {
+  const step = typeof binding.meta?.step === 'number' ? binding.meta.step : 1;
+  const unit = typeof binding.meta?.unit === 'string' ? binding.meta.unit : '';
+
+  return binding.widget === 'slider' ? (
+    <input
+      type="range"
+      min={binding.min}
+      max={binding.max}
+      step={step}
+      defaultValue={binding.value}
+      onChange={e => binding.onChange(e.target.value)}
+    />
+  ) : (
+    // ...
+    null
+  );
+});
+```
+
+`meta`'s values are typed `unknown` — the library can't know what shape a
+consumer's own metadata takes — so narrow them, as above, before use.
+The shipped Custom Palette & Panel demo's "Content Spacing" field does
+exactly this; drag it in the embedded demo above to see it live.
 
 `icon-picker` and `asset-picker` are kept in `BindingType` only so
 existing authored content (`data-binding={[{ type: 'icon-picker', ... }]}`)
@@ -244,6 +286,42 @@ Constraints declared on a binding (`min`/`max`/`pattern`/`required`) aren't
 enforced automatically — call the exported `validateBindingValue(binding,
 value)` yourself before committing an edit, the same way the built-in panel
 does.
+
+### Authoring constraints
+
+Two things a `data-binding` entry has to satisfy for its edits to actually
+commit, neither enforced at parse time:
+
+- **`property` must already exist as an attribute on the element.** `binding.onChange` writes through the same AST-update pipeline the built-in panel uses, which updates an existing JSX attribute — it doesn't add a new one. A binding whose `property` names something not already present in the markup (as a prop, or as the element's own `innerText`/`children`/etc.) parses fine and shows up in `bindings`, but every `onChange` call fails silently on the built-in panel's side (a "Failed to update this field" toast) or returns `success: false` if you're calling `update()` yourself.
+- **`label` must be unique per element.** `label` is a display string, not an identifier, but where a binding doesn't declare `property` it's still how the built-in AST utilities resolve *which* binding you mean. Two bindings on the same element sharing a label is an authoring mistake `update()` refuses to silently guess at — it returns `success: false` instead of writing whichever one happened to match first.
+
+### Escaping the binding system entirely
+
+`data-binding` covers declared, per-property edits. For anything else —
+restructuring markup, adding a whole new element, editing something with no
+binding declared at all — `PanelRenderData.item.code` is the section's full
+current source, and the exported `extract()` walks it into the same
+`DataAttrNode` tree the built-in panel reads (including custom, entirely
+undeclared `data-*` attributes, which `extract()` passes through intact).
+Commit any string back with `onChange({ code })`:
+
+```tsx
+import { extract } from '@jbpark/live-editor/utils/ast';
+
+renderPanel={({ item, onChange }) => {
+  if (!item) return null;
+
+  const nodes = extract(item.code); // read whatever you need
+  return (
+    <button onClick={() => onChange({ code: item.code.replace(/foo/, 'bar') })}>
+      Edit raw source
+    </button>
+  );
+}}
+```
+
+This is a full escape hatch, not a fallback of last resort — it's the same
+mechanism Editor mode itself commits through.
 
 ### Editing `object`/`array` values
 


### PR DESCRIPTION
## Summary

Closes #234. `parseBinding` was designed as a sanitizer for this library's own fixed schema, not as a transport for consumer-defined data — any key on a `data-binding` entry beyond the fixed set (a step increment, a unit suffix, a group name, ...) was silently dropped, and the identical situation one level down inside a `render` map deleted the whole entry instead of degrading it, contradicting the top-level's own documented behavior.

Also confirmed and left alone: the issue's second "consistency fix" (`update()` disambiguating same-label bindings) was already done by #240, with existing test coverage.

## Changes (5 commits)

1. **`meta` passthrough** — `rawBindingItemSchema` switches to `.passthrough()`; unrecognized keys survive parsing and land under a new, namespaced `BindingItem.meta`/`PanelBinding.meta: Record<string, unknown>` instead of being stripped or spread onto the item. Absent (not an empty object) when nothing extra was authored.
2. **`sanitizeRenderMap` consistency fix** — an unrecognized `type` inside a `render` map now degrades the leaf to untyped instead of deleting the key, matching the top-level item's own behavior. `BindingRenderLeaf.type` becomes optional to allow this.
3. **Tests** — meta presence/absence, and a dedicated `'type' in leaf` check (not just `toEqual`, which can't distinguish "key present with value `undefined`" from "key absent" — and `items.tsx`'s own leaf-vs-nested-map discriminator depends on exactly that distinction).
4. **Demo extension** — the Custom Palette & Panel demo's "Content Spacing" slider (from #236) now also authors `step`/`unit` and reads them back via `binding.meta`, so the shipped demo actually exercises the new path. Verified live in a real browser (Playwright): the slider's `step` attribute reads from `meta.step`, dragging it shows `meta.unit` next to the value and visibly resizes the section on canvas (a real AST commit); the built-in panel, sharing the same binding, keeps rendering a plain number input and silently ignores `meta` — no console errors either way.
5. **Docs** — `custom-palette-panel.mdx` gains: a `meta` row on the `PanelBinding` table with a worked example, the unrecognized-type-drops explanation (previously unstated), a new "Authoring constraints" section (`property` must already exist as a markup attribute or the edit fails; `label` must be unique per element), and a new "Escaping the binding system entirely" section documenting the `item.code` + `extract()` full bypass, which existed but was undocumented.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm test` — 264 passed (3 new, 1 existing test updated to match the new degrade-not-delete behavior — it was asserting the exact bug this PR fixes)
- [x] `pnpm build` + `pnpm build:demos`
- [x] `website`: `pnpm typecheck`
- [x] Manual browser verification (Playwright, headless Chromium) of the demo extension — see commit 4's message for the full walkthrough