### PR TITLE
🔖 chore: add missing changeset for the meta passthrough PR

### DIFF
--- a/.changeset/binding-meta-passthrough.md
+++ b/.changeset/binding-meta-passthrough.md
@@ -1,0 +1,11 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Carry consumer-defined `data-binding` keys through as `BindingItem.meta`/`PanelBinding.meta` instead of silently stripping them, and degrade an unrecognized `type` inside a `render` map to untyped instead of dropping the whole entry (#234).
+
+`parseBinding` was designed as a sanitizer for this library's own fixed schema, not as a transport for consumer-defined data — any key on a `data-binding` entry beyond the fixed set (a step increment, a unit suffix, a group name, ...) was silently dropped, giving a custom `renderPanel` no supported way to declare its own per-field configuration. `rawBindingItemSchema` now uses `.passthrough()`, and anything it doesn't declare survives under a new, namespaced `meta?: Record<string, unknown>` field on `BindingItem`/`PanelBinding` — absent (not an empty object) when nothing extra was authored, so existing content and existing `PanelBinding` consumers see no shape change unless they actually author extra keys.
+
+Also fixes an inconsistency one level down: an authored `type` inside a binding's `render` map that this library doesn't recognize used to delete that key entirely, contradicting the top-level binding's own documented behavior (an unrecognized top-level `type` degrades to `undefined` rather than dropping the item). `BindingRenderLeaf.type` is now optional, matching `BindingItem.type`, so a `render` map leaf can legitimately be untyped instead of missing.
+
+No breaking change: both are additive, and every previously-valid `data-binding` literal still produces the same effective behavior.


### PR DESCRIPTION
## Summary

#263 (meta passthrough, #234) merged without a changeset — an oversight from splitting the original 6-step plan into 5 and dropping the 6th ("changeset + full verification"). This adds the missing `minor` changeset so the next Version PR actually reflects that already-shipped public API addition (`BindingItem.meta`/`PanelBinding.meta`, and the `sanitizeRenderMap` consistency fix).

No code changes — changeset file only.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm test` — 264 passed