### PR TITLE
♻️ refactor: deliver structured PanelBinding values, serialize once at the AST boundary

### DIFF
--- a/.changeset/structured-panel-value.md
+++ b/.changeset/structured-panel-value.md
@@ -1,0 +1,12 @@
+---
+'@jbpark/live-editor': major
+---
+
+Deliver `PanelBinding` values as their real JS type and serialize once at the AST boundary
+
+`PanelBinding.value` is now `unknown` — a real `number`/`boolean`/`object`/`array`/`string` rather than always a string — and a new `PanelBinding.rawValue: string` carries the exact source text. `onChange` now takes `unknown` and serializes the value a single time, at the AST boundary where the declared `type` is known, so there is no string-vs-expression guessing on either side. This fixes a string whose text begins with `{` or `[` being misclassified as a JS expression, and lets `validateBindingValue`'s `min`/`max` compare against an actual number instead of coercing a numeric string.
+
+Breaking change for custom `renderPanel` consumers:
+
+- `binding.value` is no longer a string. Use `binding.rawValue` for an `<input>` `defaultValue`, a `<select>` value, and for `flattenEditableValue`/`setEditableValue`; switch on `binding.value` for its real type.
+- `binding.onChange` accepts the value as its real type (`onChange(42)`, not `onChange('42')`).

--- a/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
+++ b/demos/custom-palette-panel/CustomPalettePanelDemo.tsx
@@ -91,7 +91,7 @@ const ParsedValueEditor = ({
         label={path.join('.')}
         value={value}
         onChange={next =>
-          binding.onChange(setEditableValue(binding.value, path, next))
+          binding.onChange(setEditableValue(binding.rawValue, path, next))
         }
       />
     ))}
@@ -124,10 +124,12 @@ const SliderField = ({ binding }: { binding: PanelBinding }) => {
         step={step}
         defaultValue={Number(binding.value) || 0}
         className="w-full"
-        onChange={e => binding.onChange(e.target.value)}
+        // A number binding takes a real number now (#238) — commit one
+        // directly instead of the numeric string the input event carries.
+        onChange={e => binding.onChange(Number(e.target.value))}
       />
       <span className="w-12 text-right text-xs text-gray-500">
-        {binding.value}
+        {String(binding.value)}
         {unit}
       </span>
     </div>
@@ -149,7 +151,7 @@ const ValidatedField = ({ binding }: { binding: PanelBinding }) => {
           'w-full rounded border px-2 py-1 text-sm',
           error ? 'border-red-400' : 'border-gray-300',
         )}
-        defaultValue={binding.value}
+        defaultValue={binding.rawValue}
         onBlur={e => {
           const next = e.target.value;
           const result = validateBindingValue(binding, next);
@@ -266,13 +268,14 @@ const CustomPalettePanelDemo = () => {
                       // ValidatedField either way.
                       const flattened = isMultiline
                         ? null
-                        : flattenEditableValue(binding.value);
+                        : flattenEditableValue(binding.rawValue);
                       const entries =
                         flattened && flattened.length <= MAX_EDITABLE_ENTRIES
                           ? flattened
                           : null;
                       const useTextarea =
-                        isMultiline || (!entries && binding.value.length > 120);
+                        isMultiline ||
+                        (!entries && binding.rawValue.length > 120);
 
                       return (
                         <label
@@ -293,7 +296,7 @@ const CustomPalettePanelDemo = () => {
                             <select
                               className="w-full rounded border border-gray-300
                                 px-2 py-1 text-sm"
-                              value={binding.value}
+                              value={binding.rawValue}
                               onChange={e => binding.onChange(e.target.value)}
                             >
                               {binding.options.map(option => (
@@ -307,7 +310,7 @@ const CustomPalettePanelDemo = () => {
                               className="w-full rounded border border-gray-300
                                 px-2 py-1 text-sm"
                               rows={3}
-                              defaultValue={binding.value}
+                              defaultValue={binding.rawValue}
                               onBlur={e => binding.onChange(e.target.value)}
                             />
                           ) : (

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -31,6 +31,7 @@ import {
   extract,
   fillIds,
   getCurrentValue,
+  getStructuredValue,
   parseBinding,
   update,
 } from '~/utils/ast';
@@ -109,9 +110,9 @@ export interface PanelBinding {
   // their own types — the same map the built-in panel uses to type each
   // nested field instead of falling back to a plain string input.
   render?: BindingRenderMap;
-  // Constraints declared on the binding. `min`/`max` apply even though
-  // `value` below is a string (see `validateBindingValue`, which coerces
-  // numeric strings before comparing).
+  // Constraints declared on the binding. `min`/`max` compare against the
+  // real number `value` delivers for `type: 'number'` bindings (see
+  // `validateBindingValue`).
   min?: number;
   max?: number;
   pattern?: string;
@@ -121,11 +122,19 @@ export interface PanelBinding {
   // can't collide with a future first-class field. Absent when nothing
   // extra was authored. See #234.
   meta?: Record<string, unknown>;
-  // Current serialized value — the same string the built-in field receives.
-  value: string;
+  // Current value as its real JS type — a number for `type: 'number'`, a
+  // boolean for `type: 'boolean'`, an object/array for `object`/`array`,
+  // a string otherwise. Switch on this without re-parsing. See #238.
+  value: unknown;
+  // The exact source text behind `value`, for cases that can't round-trip
+  // through a JS value — `jsx`/`richtext` bindings, or an attribute whose
+  // source is an expression you want to edit as text.
+  rawValue: string;
   // Commit a new value through the same AST-update pipeline the built-in
-  // panel uses (including the error Toast on a bad edit).
-  onChange: (value: string) => void;
+  // panel uses (including the error Toast on a bad edit). Pass the value as
+  // its real type; it's serialized once, at the AST boundary, where the
+  // declared `type` is known — so no string quoting/guessing on your side.
+  onChange: (value: unknown) => void;
 }
 
 export interface Props extends Omit<
@@ -309,7 +318,7 @@ const Dnd = ({
     id: string;
     label: string;
     property: string;
-    value: string;
+    value: unknown;
   }) => {
     const result = update(updatedCode, id, label, fieldValue, property);
 
@@ -359,8 +368,9 @@ const Dnd = ({
         pattern: binding.pattern,
         required: binding.required,
         meta: binding.meta,
-        value: getCurrentValue(node, binding.property),
-        onChange: (value: string) =>
+        value: getStructuredValue(node, binding.property, binding.type),
+        rawValue: getCurrentValue(node, binding.property),
+        onChange: (value: unknown) =>
           onFieldChange({
             id: dataId,
             label: binding.label,

--- a/src/components/dnd/panel/children.tsx
+++ b/src/components/dnd/panel/children.tsx
@@ -18,7 +18,7 @@ interface Props {
     id: string;
     label: string;
     property: string;
-    value: string;
+    value: unknown;
   }) => void;
 }
 

--- a/src/components/dnd/panel/field-group.tsx
+++ b/src/components/dnd/panel/field-group.tsx
@@ -7,7 +7,7 @@ interface Props {
     id: string;
     label: string;
     property: string;
-    value: string;
+    value: unknown;
   }) => void;
 }
 

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   Checkbox,
@@ -33,7 +33,7 @@ interface Props {
     id: string;
     label: string;
     property: string;
-    value: string;
+    value: unknown;
   }) => void;
 }
 
@@ -149,11 +149,10 @@ const ColorPickerField = ({ value, onChange }: ColorPickerFieldProps) => {
 };
 
 const Field = ({ binding, onNodeChange }: Props) => {
-  const { id, value, onChange } = binding;
-
-  const parsedValue = useMemo(() => {
-    return parseValue(value);
-  }, [value]);
+  // `value` is already structured (its real JS type); `rawValue` is the exact
+  // source text used for the raw editors (Items/code/textarea) and as the
+  // <input> defaultValue. See #238.
+  const { id, value, rawValue, onChange } = binding;
 
   const [validationError, setValidationError] = useState<string | null>(null);
 
@@ -164,7 +163,7 @@ const Field = ({ binding, onNodeChange }: Props) => {
   ) {
     return (
       <Items
-        value={value}
+        value={rawValue}
         render={binding.render}
         onChange={onChange}
         onChildChange={onNodeChange}
@@ -175,9 +174,9 @@ const Field = ({ binding, onNodeChange }: Props) => {
   if (binding.type === 'richtext') {
     return (
       <TiptapEditor
-        value={value}
+        value={rawValue}
         onChange={next => {
-          if (next !== value) {
+          if (next !== rawValue) {
             onChange(next);
           }
         }}
@@ -190,12 +189,12 @@ const Field = ({ binding, onNodeChange }: Props) => {
 
     return (
       <CoreEditor
-        value={value}
+        value={rawValue}
         height="150px"
         fragment={!isHTML}
         raw={isHTML}
         onSave={next => {
-          if (next !== value) {
+          if (next !== rawValue) {
             onChange(next);
           }
         }}
@@ -203,24 +202,18 @@ const Field = ({ binding, onNodeChange }: Props) => {
     );
   }
 
-  if (binding.property === 'children' && Array.isArray(parsedValue)) {
+  if (binding.property === 'children' && Array.isArray(value)) {
     return (
-      <Children
-        value={parsedValue}
-        onChange={onChange}
-        onNodeChange={onNodeChange}
-      />
+      <Children value={value} onChange={onChange} onNodeChange={onNodeChange} />
     );
   }
 
-  if (
-    typeof parsedValue === 'object' &&
-    parsedValue !== null &&
-    !Array.isArray(parsedValue)
-  ) {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const objectValue = value as Record<string, unknown>;
+
     return (
       <div className="space-y-2 rounded border border-gray-200 bg-gray-50 p-2">
-        {Object.entries(parsedValue).map(([key, val]) => (
+        {Object.entries(objectValue).map(([key, val]) => (
           <div key={key} className="space-y-1">
             <label className="block text-xs font-medium text-gray-600">
               {key}
@@ -242,17 +235,13 @@ const Field = ({ binding, onNodeChange }: Props) => {
                   binding.render?.[key] && !('type' in binding.render[key])
                     ? (binding.render[key] as PanelBinding['render'])
                     : undefined,
-                value:
-                  typeof val === 'object' ? JSON.stringify(val) : String(val),
+                value: val,
+                rawValue:
+                  typeof val === 'object' && val !== null
+                    ? JSON.stringify(val)
+                    : String(val),
                 onChange: next => {
-                  const convertedValue = parseValue(next);
-
-                  const updated = {
-                    ...parsedValue,
-                    [key]: convertedValue,
-                  };
-
-                  onChange(JSON.stringify(updated));
+                  onChange({ ...objectValue, [key]: next });
                 },
               }}
               onNodeChange={onNodeChange}
@@ -263,18 +252,18 @@ const Field = ({ binding, onNodeChange }: Props) => {
     );
   }
 
-  if (binding.type === 'boolean' || typeof parsedValue === 'boolean') {
+  if (binding.type === 'boolean' || typeof value === 'boolean') {
     return (
       <Checkbox
-        checked={parsedValue === true || parsedValue === 'true'}
+        checked={value === true || value === 'true'}
         onChange={checked => {
-          onChange(checked.toString());
+          onChange(checked);
         }}
       />
     );
   }
 
-  const stringValue = String(value);
+  const stringValue = rawValue;
 
   if (binding.options && Array.isArray(binding.options)) {
     return (
@@ -433,7 +422,7 @@ const Field = ({ binding, onNodeChange }: Props) => {
     );
   }
 
-  if (typeof parsedValue === 'number') {
+  if (binding.type === 'number' || typeof value === 'number') {
     return (
       <div>
         <Input
@@ -441,7 +430,14 @@ const Field = ({ binding, onNodeChange }: Props) => {
           defaultValue={stringValue}
           placeholder="Enter a numeric value"
           onBlur={e => {
-            const next = e.target.value.trim();
+            const raw = e.target.value.trim();
+            // Commit a real number, not a numeric string — the AST boundary
+            // and `validateBindingValue` (its `min`/`max`) both expect the
+            // value as its declared type now. An unparseable entry falls
+            // back to the raw text so a genuine mistake still round-trips
+            // rather than becoming `NaN`.
+            const next: unknown =
+              raw !== '' && !Number.isNaN(Number(raw)) ? Number(raw) : raw;
             const result = validateBindingValue(binding, next);
 
             if (!result.valid) {
@@ -466,10 +462,16 @@ const Field = ({ binding, onNodeChange }: Props) => {
   return (
     <div>
       <Input.TextArea
-        defaultValue={value}
+        defaultValue={rawValue}
         placeholder="Enter a value"
         onBlur={e => {
-          const next = e.target.value.trim();
+          const raw = e.target.value.trim();
+          // Untyped field: infer the value's type from the text the user
+          // entered (so `42` commits as a number), the way the old boundary
+          // did — but here, in the presentation layer, not by re-guessing in
+          // the AST pipeline. A declared string-family type keeps the text
+          // verbatim, so `"{x}"` stays a string.
+          const next: unknown = binding.type ? raw : parseValue(raw);
           const result = validateBindingValue(binding, next);
 
           if (!result.valid) {
@@ -479,7 +481,7 @@ const Field = ({ binding, onNodeChange }: Props) => {
 
           setValidationError(null);
 
-          if (next !== value) {
+          if (next !== rawValue) {
             onChange(next);
           }
         }}

--- a/src/components/dnd/panel/items.tsx
+++ b/src/components/dnd/panel/items.tsx
@@ -58,7 +58,7 @@ interface Props {
     id: string;
     label: string;
     property: string;
-    value: string;
+    value: unknown;
   }) => void;
 }
 
@@ -233,7 +233,7 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
     isPrimitive ? primitiveItems.length : objectItems.length,
   );
 
-  const updatePrimitive = (index: number, next: string) => {
+  const updatePrimitive = (index: number, next: unknown) => {
     const ast = parseArrayExpression(value);
 
     if (!ast) {
@@ -617,7 +617,8 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
                 id: `primitive-${item.id}`,
                 label: `item-${i}`,
                 property: item.type,
-                value: String(item.value ?? ''),
+                value: item.value ?? '',
+                rawValue: String(item.value ?? ''),
                 onChange: next => updatePrimitive(item.index, next),
               }}
               onNodeChange={onChildChange}
@@ -721,7 +722,8 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
                           : render?.[key] && !('type' in render[key])
                             ? (render[key] as BindingRenderMap)
                             : undefined,
-                      value: String(prop.value),
+                      value: parseValue(String(prop.value)),
+                      rawValue: String(prop.value),
                       onChange: next =>
                         updateProperty(item.index, key, parseValue(next)),
                     }}

--- a/src/components/dnd/panel/node.tsx
+++ b/src/components/dnd/panel/node.tsx
@@ -1,4 +1,9 @@
-import { type DataAttrNode, getCurrentValue, parseBinding } from '~/utils/ast';
+import {
+  type DataAttrNode,
+  getCurrentValue,
+  getStructuredValue,
+  parseBinding,
+} from '~/utils/ast';
 
 import Field from './field';
 
@@ -8,7 +13,7 @@ export interface FieldEditorProps {
     id: string;
     label: string;
     property: string;
-    value: string;
+    value: unknown;
   }) => void;
 }
 
@@ -32,6 +37,11 @@ const Node = ({ data, onChange }: FieldEditorProps) => {
       <div className="space-y-1">
         {bindings.map(binding => {
           const currentValue = getCurrentValue(data, binding.property);
+          const structuredValue = getStructuredValue(
+            data,
+            binding.property,
+            binding.type,
+          );
 
           return (
             <div key={binding.label} className="space-y-1">
@@ -53,7 +63,8 @@ const Node = ({ data, onChange }: FieldEditorProps) => {
                   pattern: binding.pattern,
                   required: binding.required,
                   meta: binding.meta,
-                  value: currentValue,
+                  value: structuredValue,
+                  rawValue: currentValue,
                   onChange: next =>
                     onChange?.({
                       id: dataId,

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -39,7 +39,7 @@ export interface PanelProps {
     id: string;
     label: string;
     property: string;
-    value: string;
+    value: unknown;
   }) => void;
 }
 

--- a/src/utils/ast/binding.test.ts
+++ b/src/utils/ast/binding.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { BINDING_PROP, DATA_ATTR } from '../../constants';
-import { findEditableChildren, getCurrentValue, parseBinding } from './binding';
+import {
+  findEditableChildren,
+  getCurrentValue,
+  getStructuredValue,
+  parseBinding,
+} from './binding';
 import type { Attribute, DataAttrNode } from './types';
 
 const makeNode = (overrides: Partial<DataAttrNode> = {}): DataAttrNode => ({
@@ -304,6 +309,48 @@ describe('getCurrentValue', () => {
     });
 
     expect(getCurrentValue(node, BINDING_PROP.INNER_HTML)).toBe('hi there');
+  });
+});
+
+// #238: the structured counterpart delivers the value as its real JS type.
+describe('getStructuredValue', () => {
+  it('recovers a numeric expression attribute as a number', () => {
+    const node = makeNode({
+      attributes: [{ name: 'count', value: '3', isStringLiteral: false }],
+    });
+
+    expect(getStructuredValue(node, 'count')).toBe(3);
+  });
+
+  it('recovers an object expression attribute as an object', () => {
+    const node = makeNode({
+      attributes: [
+        { name: 'style', value: '{ padding: 4 }', isStringLiteral: false },
+      ],
+    });
+
+    expect(getStructuredValue(node, 'style')).toEqual({ padding: 4 });
+  });
+
+  it('keeps a string-literal attribute as a string even when it looks like an expression', () => {
+    const node = makeNode({
+      attributes: [
+        { name: 'title', value: '{not an expression}', isStringLiteral: true },
+      ],
+    });
+
+    expect(getStructuredValue(node, 'title')).toBe('{not an expression}');
+  });
+
+  it('keeps a declared string-family type as text, without re-parsing', () => {
+    const node = makeNode({
+      attributes: [{ name: 'label', value: '42', isStringLiteral: false }],
+    });
+
+    // No declared type: inferred to a number.
+    expect(getStructuredValue(node, 'label')).toBe(42);
+    // Declared `string`: stays the literal text.
+    expect(getStructuredValue(node, 'label', 'string')).toBe('42');
   });
 });
 

--- a/src/utils/ast/binding.ts
+++ b/src/utils/ast/binding.ts
@@ -8,9 +8,10 @@ import {
   type BindingItem,
   type BindingOption,
   type BindingRenderMap,
+  type BindingType,
   type DataAttrNode,
 } from './types';
-import { evaluateLiteral, parseArrayExpression } from './value';
+import { evaluateLiteral, parseArrayExpression, parseValue } from './value';
 
 const bindingTypeSchema = z.enum(BINDING_TYPES);
 
@@ -289,6 +290,61 @@ export const getCurrentValue = (
       const value = customAttr?.value || '';
 
       return value;
+    }
+  }
+};
+
+// Declared types whose value is genuinely text — never re-parsed into a
+// number/object/array even when the text happens to look like one. `jsx`
+// and `richtext` carry source that is an expression, not a literal, so they
+// stay as their exact source string too (the update pipeline re-inserts
+// them as expressions, not string literals).
+const STRING_VALUED_TYPES: ReadonlySet<BindingType> = new Set([
+  'string',
+  'url',
+  'date',
+  'color',
+  'jsx',
+  'richtext',
+  'icon-picker',
+  'asset-picker',
+]);
+
+// Structured counterpart to `getCurrentValue`: returns the value as its real
+// JS type (number/boolean/object/array/string) rather than always as a
+// string, so both the built-in panel and a custom `renderPanel` receive
+// `PanelBinding.value` already typed. `getCurrentValue` still supplies the
+// exact source text (`PanelBinding.rawValue`). See #238.
+//
+// The string-vs-structure decision is made *here*, from information the AST
+// still has — an attribute that was a string literal in source is a genuine
+// string whatever its contents, so `"{not an expression}"` stays a string
+// instead of being re-parsed into an object. Only genuine expressions
+// (`count={3}`, `data={[...]}`) are recovered into their real shape.
+export const getStructuredValue = (
+  node: DataAttrNode,
+  property: string,
+  type?: BindingType,
+): unknown => {
+  switch (property) {
+    case BINDING_PROP.INNER_TEXT:
+    case BINDING_PROP.INNER_HTML: {
+      return getCurrentValue(node, property);
+    }
+
+    case BINDING_PROP.CHILDREN: {
+      return node.children ?? [];
+    }
+
+    default: {
+      const raw = getCurrentValue(node, property);
+      const attr = node.attributes.find(a => a.name === property);
+
+      if (attr?.isStringLiteral || (type && STRING_VALUED_TYPES.has(type))) {
+        return raw;
+      }
+
+      return parseValue(raw);
     }
   }
 };

--- a/src/utils/ast/index.ts
+++ b/src/utils/ast/index.ts
@@ -10,7 +10,12 @@ export type {
   NodeValueType,
 } from './types';
 
-export { findEditableChildren, getCurrentValue, parseBinding } from './binding';
+export {
+  findEditableChildren,
+  getCurrentValue,
+  getStructuredValue,
+  parseBinding,
+} from './binding';
 export type {
   EditablePathSegment,
   EditablePrimitive,

--- a/src/utils/ast/update.test.ts
+++ b/src/utils/ast/update.test.ts
@@ -93,11 +93,39 @@ describe('update', () => {
     expect(result.code).toContain('placeholder="new placeholder"');
   });
 
-  it('updates a plain attribute with a numeric expression value', () => {
-    const result = update(CODE, 'g', 'Count', '42');
+  // #238: the value crosses the boundary as its real JS type and is
+  // serialized once, here, by that type — no first-character guessing.
+  it('serializes a real number as a numeric expression', () => {
+    const result = update(CODE, 'g', 'Count', 42);
 
     expect(result.success).toBe(true);
     expect(result.code).toContain('count={42}');
+  });
+
+  it('serializes a real boolean as a boolean expression', () => {
+    const result = update(CODE, 'g', 'Count', false);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('count={false}');
+  });
+
+  // The bug #238 fixes: a genuine string whose text begins with `{` used to
+  // be misclassified as a JS expression by the `startsWith('{')` heuristic.
+  // A string is now always a string literal, whatever it contains.
+  it('keeps a string that looks like an expression as a string literal', () => {
+    const result = update(CODE, 'f', 'Placeholder', '{not an expression}');
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('placeholder="{not an expression}"');
+    expect(result.code).not.toContain('placeholder={');
+  });
+
+  it('serializes a structured object/array binding as an expression', () => {
+    const code = `<Chart data-id="h" data-binding="[{label:'Data',property:'data',type:'array'}]" data={[1]} />`;
+    const result = update(code, 'h', 'Data', [1, 2, 3], 'data');
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('data={[1, 2, 3]}');
   });
 
   it('returns success: false and the original code when the data-id is not found', () => {

--- a/src/utils/ast/update.ts
+++ b/src/utils/ast/update.ts
@@ -1,14 +1,15 @@
-import { parse } from '@babel/parser';
+import { parse, parseExpression } from '@babel/parser';
 import type { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
 import { nanoid } from 'nanoid';
 
-import { BINDING_PROP, DATA_ATTR, REGEX } from '../../constants';
+import { BINDING_PROP, DATA_ATTR } from '../../constants';
 import { parseBinding } from './binding';
 import { traverse } from './document';
 import { nodeToJSX } from './extract';
-import { attrValue, generateCode, unwrap, wrap } from './helpers';
-import type { DataAttrNode } from './types';
+import { generateCode, unwrap, wrap } from './helpers';
+import type { BindingType, DataAttrNode } from './types';
+import { valueToExpression } from './value';
 
 const updateInnerText = (
   path: NodePath<t.JSXElement>,
@@ -65,10 +66,12 @@ const updateInnerHTML = (
 
 const updateChildren = (
   path: NodePath<t.JSXElement>,
-  value: string,
+  value: unknown,
 ): boolean => {
   try {
-    const childrenData = JSON.parse(value) as DataAttrNode[];
+    const childrenData = (
+      typeof value === 'string' ? JSON.parse(value) : value
+    ) as DataAttrNode[];
 
     path.node.children.length = 0;
 
@@ -118,10 +121,49 @@ const updateRichtext = (
   return true;
 };
 
+// Serialize a structured value into a JSX attribute value, once, at the AST
+// boundary — the single point where the declared `type` is known. Replaces
+// the old first-character heuristic (`startsWith('{')` ...) that guessed
+// string-vs-expression and then let `attrValue` guess again. See #238.
+const buildAttributeValue = (
+  value: unknown,
+  type?: BindingType,
+): t.JSXAttribute['value'] => {
+  // Declared object/array bindings: an expression container. A string here
+  // is already-serialized source text (from the built-in Items/flatten
+  // editor, which re-emits the whole array/object as code) — parse it back
+  // to an expression rather than quoting it as a literal.
+  if (type === 'array' || type === 'object') {
+    if (typeof value === 'string') {
+      try {
+        return t.jsxExpressionContainer(
+          parseExpression(value.trim(), { plugins: ['jsx', 'typescript'] }),
+        );
+      } catch {
+        return t.stringLiteral(value);
+      }
+    }
+
+    const expr = valueToExpression(value);
+    return expr ? t.jsxExpressionContainer(expr) : t.stringLiteral('');
+  }
+
+  // Everything else maps one JS type to one literal kind — no guessing. A
+  // string stays a string literal whatever it contains, so a genuine
+  // `"{not an expression}"` no longer becomes a JSX expression container.
+  if (typeof value === 'string') {
+    return t.stringLiteral(value);
+  }
+
+  const expr = valueToExpression(value);
+  return expr ? t.jsxExpressionContainer(expr) : t.stringLiteral(String(value));
+};
+
 const updateAttribute = (
   opening: t.JSXOpeningElement,
   propertyName: string,
-  value: string,
+  value: unknown,
+  type?: BindingType,
 ): boolean => {
   const customAttr = opening.attributes.find(
     attr =>
@@ -131,19 +173,7 @@ const updateAttribute = (
   );
 
   if (customAttr && t.isJSXAttribute(customAttr)) {
-    const trimmed = value.trim();
-    const isExpression =
-      trimmed.startsWith('[') ||
-      trimmed.startsWith('{') ||
-      REGEX.NUMBER.test(trimmed) ||
-      REGEX.BOOLEAN_OR_NULL.test(trimmed);
-
-    customAttr.value = attrValue({
-      name: propertyName,
-      value,
-      isStringLiteral: !isExpression,
-    });
-
+    customAttr.value = buildAttributeValue(value, type);
     return true;
   }
 
@@ -166,7 +196,7 @@ export const update = (
   code: string,
   dataId: string,
   label: string,
-  value: string,
+  value: unknown,
   property?: string,
 ): UpdateResult => {
   try {
@@ -242,15 +272,15 @@ export const update = (
 
         switch (propertyBinding.property) {
           case BINDING_PROP.INNER_TEXT: {
-            changed = updateInnerText(path, value);
+            changed = updateInnerText(path, String(value));
             break;
           }
 
           case BINDING_PROP.INNER_HTML: {
             if (propertyBinding.type === 'richtext') {
-              changed = updateRichtext(path, value);
+              changed = updateRichtext(path, String(value));
             } else {
-              changed = updateInnerHTML(path, value, jsxPlaceholders);
+              changed = updateInnerHTML(path, String(value), jsxPlaceholders);
             }
             break;
           }
@@ -272,7 +302,7 @@ export const update = (
               if (attr && t.isJSXAttribute(attr)) {
                 attr.value = injectPlaceholder(
                   'JSX',
-                  value.trim(),
+                  String(value).trim(),
                   jsxPlaceholders,
                 );
                 changed = true;
@@ -282,6 +312,7 @@ export const update = (
                 opening,
                 propertyBinding.property,
                 value,
+                propertyBinding.type,
               );
             }
 
@@ -315,7 +346,7 @@ export const bulkUpdate = (
   entries: {
     dataId: string;
     label: string;
-    value: string;
+    value: unknown;
     property?: string;
   }[],
 ): UpdateResult => {

--- a/src/utils/ast/validate.test.ts
+++ b/src/utils/ast/validate.test.ts
@@ -92,28 +92,17 @@ describe('validateBindingValue', () => {
     ).toEqual({ valid: true });
   });
 
-  // PanelBinding.value (what a custom renderPanel receives) is always a
-  // string, even for type: 'number' bindings — see #225. These pin that
-  // min/max apply to the numeric-string form the same way they already do
-  // for an actual number.
-  it('fails when a numeric string is below min', () => {
-    const result = validateBindingValue(makeBinding({ min: 10 }), '5');
-
-    expect(result.valid).toBe(false);
-    expect(result.message).toContain('10');
-  });
-
-  it('fails when a numeric string is above max', () => {
-    const result = validateBindingValue(makeBinding({ max: 100 }), '150');
-
-    expect(result.valid).toBe(false);
-    expect(result.message).toContain('100');
-  });
-
-  it('passes when a numeric string is within min/max bounds', () => {
-    expect(validateBindingValue(makeBinding({ min: 0, max: 10 }), '5')).toEqual(
-      { valid: true },
-    );
+  // Since #238, PanelBinding.value is delivered as its real JS type, so a
+  // `type: 'number'` binding passes an actual number here. min/max no longer
+  // coerce a numeric string — a string is not range-checked, only compared
+  // by pattern/url/date rules. The number cases above are the live path.
+  it('does not range-check a numeric string (no coercion)', () => {
+    expect(validateBindingValue(makeBinding({ min: 10 }), '5')).toEqual({
+      valid: true,
+    });
+    expect(validateBindingValue(makeBinding({ max: 100 }), '150')).toEqual({
+      valid: true,
+    });
   });
 
   it('does not apply min/max to a whitespace-only string', () => {

--- a/src/utils/ast/validate.ts
+++ b/src/utils/ast/validate.ts
@@ -20,27 +20,15 @@ export const validateBindingValue = (
     return VALID;
   }
 
-  // `PanelBinding.value` (the value a custom renderPanel gets) is always a
-  // string, even for `type: 'number'` bindings — coerce a numeric string
-  // the same way the built-in field does today (see field.tsx's ad-hoc
-  // `Number(next)`), so min/max apply to both callers instead of silently
-  // no-op'ing on the string form. A non-numeric string (`NaN`) or
-  // whitespace-only string is left alone; `isEmpty` above already handles
-  // the plain empty-string case.
-  const numericValue =
-    typeof value === 'number'
-      ? value
-      : typeof value === 'string' &&
-          value.trim() !== '' &&
-          !Number.isNaN(Number(value))
-        ? Number(value)
-        : undefined;
-
-  if (numericValue !== undefined) {
-    if (binding.min !== undefined && numericValue < binding.min) {
+  // `min`/`max` compare against a real number. Since #238, a `type:
+  // 'number'` binding delivers an actual number across the panel boundary,
+  // so callers pass one here directly — no string coercion to re-derive the
+  // type. A non-number value simply isn't range-checked.
+  if (typeof value === 'number') {
+    if (binding.min !== undefined && value < binding.min) {
       return { valid: false, message: `Must be at least ${binding.min}.` };
     }
-    if (binding.max !== undefined && numericValue > binding.max) {
+    if (binding.max !== undefined && value > binding.max) {
       return { valid: false, message: `Must be at most ${binding.max}.` };
     }
   }

--- a/src/utils/ast/value.test.ts
+++ b/src/utils/ast/value.test.ts
@@ -12,6 +12,7 @@ import {
   parseArrayExpression,
   parseValue,
   setEditableValue,
+  valueToExpression,
 } from './value';
 
 describe('parseValue', () => {
@@ -345,5 +346,39 @@ describe('setEditableValue', () => {
       { path: [1], value: 99 },
       { path: [2], value: 3 },
     ]);
+  });
+});
+
+// #238: the single serialization point. Each JS type maps to exactly one
+// literal kind — the inverse of evaluateLiteral, with no guessing.
+describe('valueToExpression', () => {
+  const gen = (value: unknown) => {
+    const expr = valueToExpression(value);
+    return expr ? generateCode(expr) : null;
+  };
+
+  it('maps a string to a string literal, whatever it contains', () => {
+    expect(gen('hello')).toBe('"hello"');
+    // A string that looks like an expression is still just a string.
+    expect(gen('{not an expression}')).toBe('"{not an expression}"');
+  });
+
+  it('maps numbers (including negatives), booleans, and null', () => {
+    expect(gen(42)).toBe('42');
+    expect(gen(-7)).toBe('-7');
+    expect(gen(true)).toBe('true');
+    expect(gen(null)).toBe('null');
+  });
+
+  it('rebuilds nested arrays and objects', () => {
+    expect(gen([1, 'a', true])).toBe('[1, "a", true]');
+    expect(gen({ padding: 4, color: 'red' })).toBe(
+      '{\n  "padding": 4,\n  "color": "red"\n}',
+    );
+  });
+
+  it('omits object properties whose value has no literal form', () => {
+    expect(gen({ a: 1, b: undefined })).toBe('{\n  "a": 1\n}');
+    expect(valueToExpression(undefined)).toBeNull();
   });
 });

--- a/src/utils/ast/value.ts
+++ b/src/utils/ast/value.ts
@@ -362,6 +362,57 @@ export const createNodeFromValue = (
   }
 };
 
+// Faithfully rebuilds a JS value into an AST expression node — the inverse
+// of `evaluateLiteral`, and the single serialization point #238 moves the
+// panel's value contract onto. Because the caller already knows what the
+// value *is* (a real number/boolean/object/array, not a string that has to
+// be re-guessed), there is no string-vs-expression heuristic here: each JS
+// type maps to exactly one literal kind. Values with no literal form
+// (`undefined`, functions, symbols) are dropped — an object property whose
+// value is `undefined` is omitted rather than emitted as `undefined`,
+// mirroring `flattenEditableValue`, which also treats them as absent.
+export const valueToExpression = (value: unknown): t.Expression | null => {
+  if (typeof value === 'string') {
+    return t.stringLiteral(value);
+  }
+
+  if (typeof value === 'number') {
+    return value < 0
+      ? t.unaryExpression('-', t.numericLiteral(-value))
+      : t.numericLiteral(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return t.booleanLiteral(value);
+  }
+
+  if (value === null) {
+    return t.nullLiteral();
+  }
+
+  if (Array.isArray(value)) {
+    return t.arrayExpression(
+      value.map(item => valueToExpression(item) ?? t.nullLiteral()),
+    );
+  }
+
+  if (typeof value === 'object') {
+    const properties: t.ObjectProperty[] = [];
+
+    for (const [key, item] of Object.entries(value)) {
+      const expr = valueToExpression(item);
+      if (expr === null) {
+        continue;
+      }
+      properties.push(t.objectProperty(t.stringLiteral(key), expr));
+    }
+
+    return t.objectExpression(properties);
+  }
+
+  return null;
+};
+
 export const parseArrayExpression = (value: string) => {
   try {
     const ast = parseExpression(value, {

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -113,7 +113,7 @@ the built-in panel uses. Switch on `binding.type` to render your own control:
           <span>{binding.label}</span>
           {binding.options ? (
             <select
-              value={binding.value}
+              value={binding.rawValue}
               onChange={e => binding.onChange(e.target.value)}
             >
               {binding.options.map(o => (
@@ -124,12 +124,12 @@ the built-in panel uses. Switch on `binding.type` to render your own control:
             </select>
           ) : binding.type === 'jsx' || binding.type === 'richtext' ? (
             <textarea
-              defaultValue={binding.value}
+              defaultValue={binding.rawValue}
               onBlur={e => binding.onChange(e.target.value)}
             />
           ) : (
             <input
-              defaultValue={binding.value}
+              defaultValue={binding.rawValue}
               onBlur={e => binding.onChange(e.target.value)}
             />
           )}
@@ -189,13 +189,14 @@ it by not passing `renderPanel` at all, doesn't have this limitation.
 | `widget` | `string?` | The declared presentation — how to *render* it. An open string, not `BindingType`: the library can't enumerate controls it doesn't implement, so a custom `renderPanel` is free to declare and switch on any value it wants (e.g. `'slider'`). The built-in panel only recognizes `'icon-picker'`/`'asset-picker'`. |
 | `options` | `BindingOption[]?` | Present when the binding defines a fixed option set (render a `<select>`). |
 | `render` | `BindingRenderMap?` | Present on `object`/`array` bindings whose nested keys/items declare their own types — walk it to type each nested field instead of treating the value as an opaque string. |
-| `min` | `number?` | Minimum value for a `number` binding. Applies to `value` below even though it's a string — pass it straight to `validateBindingValue`, which coerces numeric strings. |
-| `max` | `number?` | Maximum value for a `number` binding, same coercion as `min`. |
+| `min` | `number?` | Minimum value for a `number` binding. Compared against the real number `value` delivers — pass it straight to `validateBindingValue`. |
+| `max` | `number?` | Maximum value for a `number` binding. |
 | `pattern` | `string?` | A regex source the value must match. |
 | `required` | `boolean?` | Whether an empty value should fail validation. |
 | `meta` | `Record<string, unknown>?` | Any authored key that isn't one of the fields above (a step increment, a unit suffix, a group name, ...) — see below. `undefined` when nothing extra was authored, not an empty object. |
-| `value` | `string` | Current serialized value. |
-| `onChange` | `(value: string) => void` | Commit an edit through the same AST-update pipeline (including the error toast on a bad edit). |
+| `value` | `unknown` | Current value as its real JS type — a `number` for a `number` binding, a `boolean`, an `object`/`array`, a `string` otherwise. Switch on it without re-parsing. |
+| `rawValue` | `string` | The exact source text behind `value`, for cases that can't round-trip through a JS value (`jsx`/`richtext`, or an expression attribute you want to edit as text). Use it for an `<input>` `defaultValue` and for `flattenEditableValue`/`setEditableValue`. |
+| `onChange` | `(value: unknown) => void` | Commit an edit through the same AST-update pipeline (including the error toast on a bad edit). Pass the value as its real type — it's serialized once, at the AST boundary, where the declared `type` is known, so no string quoting on your side. |
 
 `BindingType` is a closed union of 12 values: `array`, `object`, `string`,
 `number`, `boolean`, `color`, `jsx`, `richtext`, `date`, `url`,
@@ -229,7 +230,7 @@ bindings.map(binding => {
       min={binding.min}
       max={binding.max}
       step={step}
-      defaultValue={binding.value}
+      defaultValue={binding.rawValue}
       onChange={e => binding.onChange(e.target.value)}
     />
   ) : (
@@ -272,12 +273,12 @@ bindings.map(binding =>
       type="range"
       min={binding.min}
       max={binding.max}
-      defaultValue={binding.value}
+      defaultValue={binding.rawValue}
       onChange={e => binding.onChange(e.target.value)}
     />
   ) : (
     // ...fall back to type-based defaults
-    <input defaultValue={binding.value} onBlur={e => binding.onChange(e.target.value)} />
+    <input defaultValue={binding.rawValue} onBlur={e => binding.onChange(e.target.value)} />
   ),
 );
 ```
@@ -325,15 +326,15 @@ mechanism Editor mode itself commits through.
 
 ### Editing `object`/`array` values
 
-`binding.value` is always a string — for an `object`/`array` binding, that
-string is a serialized structure, not a scalar. A binding's own declared
-`render` map (above) is one way to know how to decompose it, but most
-content doesn't declare one; e.g. the shipped Hero item's "Background
-Style" binding on `style` has no `type` or `render` at all, since `style`
-is just naturally object-shaped.
+For an `object`/`array` binding, `binding.value` is already the parsed
+object or array, and `binding.rawValue` is its serialized source text. A
+binding's own declared `render` map (above) is one way to know how to
+decompose it, but most content doesn't declare one; e.g. the shipped Hero
+item's "Background Style" binding on `style` has no `type` or `render` at
+all, since `style` is just naturally object-shaped.
 
-`flattenEditableValue(value)` recovers editable structure straight from
-the value itself, with no declaration required: it parses the string
+`flattenEditableValue(rawValue)` recovers editable structure straight from
+the source text, with no declaration required: it parses the string
 (the same way `parseValue` does) and, if the result is an object or array,
 recursively walks it, returning one `{ path, value }` entry per primitive
 leaf found. `path` is a list of keys/indices you can hand to
@@ -348,7 +349,7 @@ being decomposed further, exactly like `parseValue` already treats JSX
 elsewhere.
 
 ```tsx
-const entries = flattenEditableValue(binding.value);
+const entries = flattenEditableValue(binding.rawValue);
 // null if the value isn't an object/array, or is empty
 
 entries?.map(({ path, value }) => (
@@ -356,7 +357,7 @@ entries?.map(({ path, value }) => (
     key={path.join('.')}
     defaultValue={String(value)}
     onBlur={e =>
-      binding.onChange(setEditableValue(binding.value, path, e.target.value))
+      binding.onChange(setEditableValue(binding.rawValue, path, e.target.value))
     }
   />
 ));


### PR DESCRIPTION
Closes #238.

## Summary

`PanelBinding.value` was always a `string`, so every consumer re-derived what the value actually was: `validateBindingValue` coerced numeric strings, an entire re-parsing subsystem recovered structure, and `update()` guessed string-vs-expression from the first character (then `attrValue` guessed again). This moves the value contract onto the value's real JS type and serializes once, at the AST boundary, where the declared `type` is known.

**Breaking change to the public `PanelBinding`** → next release is a major (`2.0.0`).

## Changes

- `PanelBinding.value` is now `unknown` (a real `number`/`boolean`/`object`/`array`/`string`); added `rawValue: string` for the exact source text; `onChange` takes `unknown`.
- New single serialization point `buildAttributeValue` in `update.ts`, keyed on the declared type — removed the `startsWith('{')` first-character heuristic **and** `attrValue`'s duplicate guess.
- The string-vs-structure decision now comes from `isStringLiteral` at extraction (`getStructuredValue`), so a genuine `"{not an expression}"` stays a string literal instead of being misclassified as a JSX expression container.
- `validateBindingValue` compares real numbers, dropping the numeric-string coercion branch.
- Migrated the built-in panel (`field`/`node`/`items`/`children`/`panel`/`field-group`), the `custom-palette-panel` demo, and the docs to `value`/`rawValue`.

## Migration (custom `renderPanel`)

- Use `binding.rawValue` for an `<input>` `defaultValue`, a `<select>` value, and for `flattenEditableValue`/`setEditableValue`; switch on `binding.value` for its real type.
- Pass the value as its real type to `onChange` (`onChange(42)`, not `onChange('42')`).

## How to verify

- A `type: 'number'` binding delivers a JS number to `renderPanel`; `min`/`max` work without the coercion branch in `validate.ts`.
- A string value of `"{not an expression}"` round-trips as a string literal, not a JSX expression container (this failed before).
- `getStructuredValue`/`valueToExpression` and the misclassification case are covered by new tests.

## Test plan

- `pnpm check-types` ✅
- `pnpm test` — 273 passed ✅
- `pnpm lint` ✅
- `pnpm build` + `pnpm build:demos` ✅