### PR TITLE
♻️ refactor: drop the data-binding parse round-trip and honor type annotations

### DIFF
--- a/.changeset/binding-type-annotations.md
+++ b/.changeset/binding-type-annotations.md
@@ -1,0 +1,9 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Honor `satisfies`/`as` type annotations on authored `data-binding` arrays
+
+An authored `data-binding={[...] satisfies BindingItem[]}` (or `as const`, a type assertion, or extra parentheses) previously made the top-level node a `TSSatisfiesExpression`, so the array was not recognized and the whole binding was silently dropped. These build-time-erased wrappers are now unwrapped, so the inline type-safety pattern works end to end.
+
+Internally, `extract` now evaluates `data-binding` straight off the parsed `ArrayExpression` instead of re-serializing it and re-parsing the string — removing the redundant parse round-trip with no change to the parsed result or the value contract.

--- a/src/utils/ast/binding.test.ts
+++ b/src/utils/ast/binding.test.ts
@@ -262,6 +262,22 @@ describe('parseBinding', () => {
     expect(result).toEqual([]);
   });
 
+  it('unwraps a `satisfies BindingItem[]` annotation on the array', () => {
+    const result = parseBinding(
+      "[{ label: 'Title', property: 'innerText' }] satisfies BindingItem[]",
+    );
+
+    expect(result).toEqual([{ label: 'Title', property: 'innerText' }]);
+  });
+
+  it('unwraps an `as const` assertion on the array', () => {
+    const result = parseBinding(
+      "[{ label: 'Title', property: 'innerText' }] as const",
+    );
+
+    expect(result).toEqual([{ label: 'Title', property: 'innerText' }]);
+  });
+
   it('returns an empty array without throwing for malformed binding syntax', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {

--- a/src/utils/ast/binding.test.ts
+++ b/src/utils/ast/binding.test.ts
@@ -1,3 +1,5 @@
+import { parseExpression } from '@babel/parser';
+import * as t from '@babel/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BINDING_PROP, DATA_ATTR } from '../../constants';
@@ -6,8 +8,17 @@ import {
   getCurrentValue,
   getStructuredValue,
   parseBinding,
+  parseBindingExpression,
 } from './binding';
 import type { Attribute, DataAttrNode } from './types';
+
+const arrayExpr = (source: string): t.ArrayExpression => {
+  const ast = parseExpression(source, { plugins: ['jsx', 'typescript'] });
+  if (!t.isArrayExpression(ast)) {
+    throw new Error('expected an array expression');
+  }
+  return ast;
+};
 
 const makeNode = (overrides: Partial<DataAttrNode> = {}): DataAttrNode => ({
   tagName: 'div',
@@ -260,6 +271,32 @@ describe('parseBinding', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+describe('parseBindingExpression', () => {
+  it('produces the same items as parseBinding on the equivalent source', () => {
+    const source =
+      "[{ label: 'Title', property: 'innerText' }," +
+      " { label: 'Count', property: 'count', type: 'number' }]";
+
+    expect(parseBindingExpression(arrayExpr(source))).toEqual(
+      parseBinding(source),
+    );
+  });
+
+  it('evaluates the array expression without a string round-trip', () => {
+    const result = parseBindingExpression(
+      arrayExpr("[{ label: 'Title', property: 'innerText' }]"),
+    );
+
+    expect(result).toEqual([{ label: 'Title', property: 'innerText' }]);
+  });
+
+  it('applies the same validation (drops an item with no label)', () => {
+    expect(
+      parseBindingExpression(arrayExpr("[{ property: 'innerText' }]")),
+    ).toEqual([]);
   });
 });
 

--- a/src/utils/ast/binding.ts
+++ b/src/utils/ast/binding.ts
@@ -125,19 +125,11 @@ const sanitizeRenderMap = (value: unknown): BindingRenderMap | undefined => {
   return Object.keys(map).length > 0 ? map : undefined;
 };
 
-export const parseBinding = (bindingValue: string | null): BindingItem[] => {
-  if (!bindingValue) {
-    return [];
-  }
-
-  const ast = parseArrayExpression(bindingValue);
-
-  if (!ast) {
-    return [];
-  }
-
-  const raw = evaluateLiteral(ast);
-
+// Shared tail of `parseBinding`/`parseBindingExpression`: turn the raw,
+// already-evaluated array literal into validated `BindingItem[]`. The two
+// callers differ only in how they reach this array — from a source string
+// (public API) or straight off an expression AST (extract's hot path).
+const buildBindingItems = (raw: unknown): BindingItem[] => {
   if (!Array.isArray(raw)) {
     return [];
   }
@@ -231,6 +223,29 @@ export const parseBinding = (bindingValue: string | null): BindingItem[] => {
 
   return items;
 };
+
+export const parseBinding = (bindingValue: string | null): BindingItem[] => {
+  if (!bindingValue) {
+    return [];
+  }
+
+  const ast = parseArrayExpression(bindingValue);
+
+  if (!ast) {
+    return [];
+  }
+
+  return buildBindingItems(evaluateLiteral(ast));
+};
+
+// Same result as `parseBinding`, but fed the array-literal expression the
+// parser already produced instead of a source string. `extract` authors
+// `data-binding` as a real JSX object-array expression, so re-serializing it
+// to a string only to `parseExpression` it straight back was a wasted Babel
+// round-trip (#241's "two parsers"); evaluate that AST in place.
+export const parseBindingExpression = (
+  expression: t.ArrayExpression,
+): BindingItem[] => buildBindingItems(evaluateLiteral(expression));
 
 export const getCurrentValue = (
   node: DataAttrNode,

--- a/src/utils/ast/extract.test.ts
+++ b/src/utils/ast/extract.test.ts
@@ -58,6 +58,14 @@ describe('extract', () => {
     expect(node!.tagName).toBe('ui.Button');
   });
 
+  it('extracts a data-binding annotated with `satisfies BindingItem[]`', () => {
+    const [node] = extract(
+      `<div data-id="a" data-binding={[{ label: 'Text', property: 'innerText' }] satisfies BindingItem[]}>Hello</div>`,
+    );
+
+    expect(node!.bindings).toEqual([{ label: 'Text', property: 'innerText' }]);
+  });
+
   it('records rawChildren from generated child code when an innerHTML binding is present', () => {
     const [node] = extract(
       `<span data-id="a" data-binding="[{label:'Html',property:'innerHTML'}]"><b>bold</b> text</span>`,

--- a/src/utils/ast/extract.ts
+++ b/src/utils/ast/extract.ts
@@ -4,7 +4,7 @@ import { nanoid } from 'nanoid';
 
 import { BINDING_PROP, CONFIG, DATA_ATTR } from '../../constants';
 import { createBoundedCache } from '../cache';
-import { parseBinding } from './binding';
+import { parseBinding, parseBindingExpression } from './binding';
 import { traverse } from './document';
 import { attrValue, generateCode, wrap } from './helpers';
 import type { Attribute, BindingItem, DataAttrNode } from './types';
@@ -349,13 +349,43 @@ interface NodeBindingInfo {
 // all — traverse() only records elements with data-* attributes, while
 // extractFromNode always records the children it's asked to (see each call
 // site for details).
+// `data-binding` is authored as a JSX object-array expression, so the
+// original `ArrayExpression` node is still on hand here. Return it so
+// `readNodeBindingInfo` can evaluate bindings straight off the AST instead
+// of re-parsing the stringified form. Null when the attribute is absent or
+// written as a plain string literal (bench/tests) — those still go through
+// `parseBinding(string)`.
+const getBindingExpression = (
+  opening: t.JSXOpeningElement,
+): t.ArrayExpression | null => {
+  for (const attr of opening.attributes) {
+    if (
+      t.isJSXAttribute(attr) &&
+      t.isJSXIdentifier(attr.name) &&
+      attr.name.name === DATA_ATTR.BINDING &&
+      attr.value &&
+      t.isJSXExpressionContainer(attr.value) &&
+      t.isArrayExpression(attr.value.expression)
+    ) {
+      return attr.value.expression;
+    }
+  }
+
+  return null;
+};
+
 const readNodeBindingInfo = (node: t.JSXElement): NodeBindingInfo => {
   const opening = node.openingElement;
   const tagName = getTagName(opening);
   const { allAttrs, dataAttrs } = extractAttributes(opening.attributes);
 
   const bindingAttr = dataAttrs.find(attr => attr.name === DATA_ATTR.BINDING);
-  const bindings = bindingAttr?.value ? parseBinding(bindingAttr.value) : [];
+  const bindingExpr = getBindingExpression(opening);
+  const bindings = bindingExpr
+    ? parseBindingExpression(bindingExpr)
+    : bindingAttr?.value
+      ? parseBinding(bindingAttr.value)
+      : [];
 
   const childrenBinding = bindings.find(
     b => b.property === BINDING_PROP.CHILDREN,

--- a/src/utils/ast/extract.ts
+++ b/src/utils/ast/extract.ts
@@ -8,6 +8,7 @@ import { parseBinding, parseBindingExpression } from './binding';
 import { traverse } from './document';
 import { attrValue, generateCode, wrap } from './helpers';
 import type { Attribute, BindingItem, DataAttrNode } from './types';
+import { unwrapExpression } from './value';
 
 const collectText = (
   children: (
@@ -364,10 +365,15 @@ const getBindingExpression = (
       t.isJSXIdentifier(attr.name) &&
       attr.name.name === DATA_ATTR.BINDING &&
       attr.value &&
-      t.isJSXExpressionContainer(attr.value) &&
-      t.isArrayExpression(attr.value.expression)
+      t.isJSXExpressionContainer(attr.value)
     ) {
-      return attr.value.expression;
+      // Unwrap `satisfies BindingItem[]`/`as const`/parentheses so the array
+      // is still recognized when authored with an editor type annotation.
+      const expression = unwrapExpression(attr.value.expression);
+
+      if (t.isArrayExpression(expression)) {
+        return expression;
+      }
     }
   }
 

--- a/src/utils/ast/index.ts
+++ b/src/utils/ast/index.ts
@@ -15,6 +15,7 @@ export {
   getCurrentValue,
   getStructuredValue,
   parseBinding,
+  parseBindingExpression,
 } from './binding';
 export type {
   EditablePathSegment,

--- a/src/utils/ast/value.ts
+++ b/src/utils/ast/value.ts
@@ -24,11 +24,35 @@ const dedent = (str: string): string => {
     : lines.map(line => line.slice(indent)).join('\n');
 };
 
+// Peel type-only wrappers and parentheses off an expression so the literal
+// underneath can be read. Authored bindings may carry `satisfies BindingItem[]`
+// (or `as const`, a type assertion, ...) for editor type-safety; those are
+// erased at build time and mean nothing to this literal evaluator, so without
+// unwrapping them the value — or the whole binding array — would be silently
+// dropped as "not a literal".
+export const unwrapExpression = (node: t.Node): t.Node => {
+  let current = node;
+
+  while (
+    t.isTSAsExpression(current) ||
+    t.isTSSatisfiesExpression(current) ||
+    t.isTSNonNullExpression(current) ||
+    t.isTSTypeAssertion(current) ||
+    t.isParenthesizedExpression(current)
+  ) {
+    current = current.expression;
+  }
+
+  return current;
+};
+
 // AST 노드를 코드 실행(new Function/eval) 없이 순수 리터럴 구조만 재귀적으로
 // 실제 JS 값으로 변환한다. 함수 호출, 변수 참조 등 리터럴이 아닌 표현식은
 // 평가하지 않고 undefined를 반환한다 — 사용자 코드는 iframe 안에서만 실행한다는
 // 이 저장소의 원칙(AGENTS.md)을 이 패널 UI(메인 문서에서 렌더링됨)에서도 지키기 위함.
-export const evaluateLiteral = (node: t.Node): unknown => {
+export const evaluateLiteral = (rawNode: t.Node): unknown => {
+  const node = unwrapExpression(rawNode);
+
   if (t.isStringLiteral(node)) {
     return node.value;
   }
@@ -415,9 +439,11 @@ export const valueToExpression = (value: unknown): t.Expression | null => {
 
 export const parseArrayExpression = (value: string) => {
   try {
-    const ast = parseExpression(value, {
-      plugins: ['jsx', 'typescript'],
-    });
+    const ast = unwrapExpression(
+      parseExpression(value, {
+        plugins: ['jsx', 'typescript'],
+      }),
+    );
 
     if (!t.isArrayExpression(ast)) {
       return null;


### PR DESCRIPTION
## Summary

Two related improvements to how authored `data-binding` declarations are parsed, both scoped strictly to the `data-binding` attribute (the value contract from #238 is untouched).

- **Skip the parse round-trip (A).** `data-binding` is authored as a JSX object-array expression, so the parser already produced the `ArrayExpression`. Extract used to re-serialize it with `generateCode` and then re-parse that string via `parseBinding` — the wasted "two parsers" round-trip flagged in #241. `parseBinding`'s item validation is now split into `buildBindingItems`, and a new `parseBindingExpression` evaluates the `ArrayExpression` in place. `readNodeBindingInfo` reads the expression straight off the opening element; string-literal-authored bindings (bench/tests) still fall back to `parseBinding(string)`. The attribute's string `value` is kept for JSX reconstruction.
- **Honor `satisfies`/`as` annotations (B).** An authored `data-binding={[...] satisfies BindingItem[]}` (or `as const`, a type assertion, parentheses) made the top AST node a `TSSatisfiesExpression`, so `isArrayExpression` was false and the binding was silently dropped. New `unwrapExpression` peels those build-time-erased wrappers, applied in `evaluateLiteral`, `parseArrayExpression`, and extract's binding fast path — so the inline type-safety pattern actually works end to end.

## Test plan

- `pnpm test` — 279 passed (added `parseBindingExpression` parity tests, `satisfies`/`as const` unwrap tests at both the string and extract levels)
- `pnpm check-types` — clean
- `pnpm lint` — clean