### PR TITLE
🐛 fix(ast): patch source at node offsets instead of regenerating the section

### DIFF
--- a/.changeset/loc-based-source-patching.md
+++ b/.changeset/loc-based-source-patching.md
@@ -1,0 +1,11 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Preserve the author's formatting when editing a field, by patching source at node offsets instead of regenerating the section
+
+`update`/`bulkUpdate` previously mutated the AST and re-emitted the whole section through `@babel/generator`, so a single field edit reflowed the author's line breaks and indentation — including the multi-line `data-binding` declaration that drives the edit. They now record the exact source spans to change and patch the original text, leaving every untouched byte identical.
+
+This also removes the `__JSX_<id>__`/`__HTML_<id>__` placeholder mechanism: raw values are written straight into the source, so they no longer have to survive a generate-then-string-replace round trip, and a value containing `$&` or `$$` can no longer be mangled by it.
+
+No public API change — `update`, `bulkUpdate` and `UpdateResult` keep their signatures.

--- a/src/utils/ast/patch.test.ts
+++ b/src/utils/ast/patch.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyEdits } from './patch';
+
+describe('applyEdits', () => {
+  it('returns the source untouched when there are no edits', () => {
+    expect(applyEdits('abc', [])).toBe('abc');
+  });
+
+  it('replaces a span and copies every other byte verbatim', () => {
+    const source = 'const a = 1;\nconst b = 2;\n';
+    const start = source.indexOf('1');
+
+    expect(applyEdits(source, [{ start, end: start + 1, content: '42' }])).toBe(
+      'const a = 42;\nconst b = 2;\n',
+    );
+  });
+
+  it('treats a zero-width span as an insertion', () => {
+    expect(applyEdits('ac', [{ start: 1, end: 1, content: 'b' }])).toBe('abc');
+  });
+
+  it('applies several edits regardless of the order they were recorded in', () => {
+    const source = 'aXbYc';
+    const edits = [
+      { start: 3, end: 4, content: '2' },
+      { start: 1, end: 2, content: '1' },
+    ];
+
+    expect(applyEdits(source, edits)).toBe('a1b2c');
+  });
+
+  it('allows an insertion at the exact end of a preceding replacement', () => {
+    const source = 'abc';
+    const edits = [
+      { start: 0, end: 1, content: '' },
+      { start: 1, end: 1, content: 'Z' },
+    ];
+
+    expect(applyEdits(source, edits)).toBe('Zbc');
+  });
+
+  // A half-applied patch is much harder to diagnose than a thrown error, and
+  // an overlap can only mean the caller's offsets are wrong.
+  it('throws rather than corrupting the source when two edits overlap', () => {
+    const edits = [
+      { start: 0, end: 3, content: 'x' },
+      { start: 2, end: 4, content: 'y' },
+    ];
+
+    expect(() => applyEdits('abcdef', edits)).toThrow(/Overlapping/);
+  });
+
+  it('throws on an out-of-bounds or inverted span', () => {
+    expect(() =>
+      applyEdits('abc', [{ start: 0, end: 99, content: '' }]),
+    ).toThrow(/Invalid source edit/);
+    expect(() =>
+      applyEdits('abc', [{ start: 2, end: 1, content: '' }]),
+    ).toThrow(/Invalid source edit/);
+  });
+
+  describe('indent', () => {
+    it('re-indents a multi-line fragment to the column it lands on', () => {
+      const source = '    style={}\n';
+      const start = source.indexOf('{}');
+
+      expect(
+        applyEdits(source, [
+          {
+            start,
+            end: start + 2,
+            content: '{{\n  color: "red"\n}}',
+            indent: true,
+          },
+        ]),
+      ).toBe('    style={{\n      color: "red"\n    }}\n');
+    });
+
+    it('leaves content byte-for-byte when indent is not set', () => {
+      const source = '    style={}\n';
+      const start = source.indexOf('{}');
+
+      expect(
+        applyEdits(source, [
+          { start, end: start + 2, content: '{{\n  color: "red"\n}}' },
+        ]),
+      ).toBe('    style={{\n  color: "red"\n}}\n');
+    });
+
+    it('is a no-op for single-line content', () => {
+      const source = '    a\n';
+
+      expect(
+        applyEdits(source, [{ start: 4, end: 5, content: 'b', indent: true }]),
+      ).toBe('    b\n');
+    });
+
+    // Babel escapes newlines inside ordinary string literals, so a `<` that
+    // sits inside quotes is still safe to indent around.
+    it('still indents when a `<` only appears inside a string literal', () => {
+      const source = '    html={}\n';
+      const start = source.indexOf('{}');
+
+      expect(
+        applyEdits(source, [
+          {
+            start,
+            end: start + 2,
+            content: '{{\n  __html: "<em>x</em>"\n}}',
+            indent: true,
+          },
+        ]),
+      ).toBe('    html={{\n      __html: "<em>x</em>"\n    }}\n');
+    });
+
+    // A newline inside a template literal or JSX text is part of the value,
+    // not layout — indenting it would rewrite the value.
+    it('skips indenting a fragment containing a template literal', () => {
+      const source = '    items={}\n';
+      const start = source.indexOf('{}');
+      const content = '{[{\n  html: `<p>A</p>\n<p>B</p>`\n}]}';
+
+      expect(
+        applyEdits(source, [{ start, end: start + 2, content, indent: true }]),
+      ).toBe(`    items=${content}\n`);
+    });
+
+    it('skips indenting a fragment containing JSX', () => {
+      const source = '    <ul></ul>\n';
+      const start = source.indexOf('></ul>') + 1;
+      const content = '<pre>a\nb</pre>';
+
+      expect(
+        applyEdits(source, [{ start, end: start, content, indent: true }]),
+      ).toBe('    <ul><pre>a\nb</pre></ul>\n');
+    });
+
+    // A quote inside a comment or a regex must not leave the scanner
+    // thinking it is inside a string, or the backtick after it is missed
+    // and the template literal's own newlines get indented.
+    it.each([
+      ['a line comment', "{[\n  // don't\n  { html: `A\nB` }\n]}"],
+      ['a block comment', "{[{ /* don't */ html: `A\nB` }]}"],
+      ['a regex literal', '{[{ re: /"/, html: `A\nB` }]}'],
+    ])('is not fooled by an apostrophe inside %s', (_name, content) => {
+      const source = '    items={}\n';
+      const start = source.indexOf('{}');
+
+      expect(
+        applyEdits(source, [{ start, end: start + 2, content, indent: true }]),
+      ).toBe(`    items=${content}\n`);
+    });
+
+    // A backslash before a newline is a line continuation, so that newline
+    // is part of the string's raw text even though the string carries no
+    // backtick and no `<`.
+    it('skips indenting a string literal continued onto the next line', () => {
+      const source = '    items={}\n';
+      const start = source.indexOf('{}');
+      const content = '{[{ html: "<p>A</p>\\\n<p>B</p>" }]}';
+
+      expect(
+        applyEdits(source, [{ start, end: start + 2, content, indent: true }]),
+      ).toBe(`    items=${content}\n`);
+    });
+
+    // Babel only ever emits LF, which would leave a CRLF file with mixed
+    // endings.
+    it('adopts the CRLF line ending the source already uses', () => {
+      const source = '<div>\r\n    style={}\r\n</div>';
+      const start = source.indexOf('{}');
+
+      expect(
+        applyEdits(source, [
+          {
+            start,
+            end: start + 2,
+            content: '{{\n  color: "red"\n}}',
+            indent: true,
+          },
+        ]),
+      ).toBe('<div>\r\n    style={{\r\n      color: "red"\r\n    }}\r\n</div>');
+    });
+  });
+});

--- a/src/utils/ast/patch.ts
+++ b/src/utils/ast/patch.ts
@@ -1,0 +1,210 @@
+// Positional source patching: the write-side counterpart to `extract`'s
+// read-side `loc`. `update` records the exact byte spans it wants to change
+// and everything else is copied through verbatim, so an edit can no longer
+// reformat code it didn't touch. See #239.
+//
+// Deliberately not `magic-string`: it is the usual tool for this, but it is
+// only available here transitively (via Vite) and would have to become a
+// real runtime dependency shipped to consumers' browsers. Its value is
+// source maps and interleaved insert/move semantics — neither of which this
+// needs. Edits here are non-overlapping span replacements applied in one
+// forward pass, which is the whole implementation below.
+export interface SourceEdit {
+  start: number;
+  end: number;
+  content: string;
+  // Re-indent `content`'s continuation lines to the indentation of the line
+  // it lands on. Opt-in because it must apply to *generated* fragments only:
+  // a generated fragment is printed from column zero and would otherwise
+  // land ragged inside indented markup, whereas a raw user-authored value
+  // (an innerHTML string, a hand-written JSX attribute) has to go in byte
+  // for byte — re-indenting it would silently rewrite the value itself.
+  //
+  // Even within a generated fragment this is applied only when every
+  // newline is provably layout; see `hasOnlyLayoutNewlines`.
+  indent?: boolean;
+}
+
+// Whether every newline in generated code is layout rather than part of a
+// value. Babel escapes newlines inside ordinary string literals, so the only
+// newlines that carry meaning come from a template literal or from JSX text
+// — and both announce themselves with a backtick or a `<`.
+//
+// This matters because indenting a value-newline silently rewrites the
+// value, and the damage compounds: the built-in array editor re-serializes
+// its own output and feeds it back through `update`, so an `innerHTML` leaf
+// stored as a template literal would gain a level of indentation on every
+// single edit.
+//
+// The scan is deliberately conservative. Quotes, comments and regex
+// literals can all hide a backtick, and telling a regex from a division
+// needs real parsing — so anything ambiguous returns false. A false
+// "unsafe" only costs a fragment that isn't re-indented; a false "safe"
+// corrupts the value.
+const hasOnlyLayoutNewlines = (content: string): boolean => {
+  let index = 0;
+
+  while (index < content.length) {
+    const char = content[index];
+
+    // `<` also matches comparison operators and TS generics. Refusing those
+    // is harmless.
+    if (char === '`' || char === '<') {
+      return false;
+    }
+
+    if (char === '"' || char === "'") {
+      const next = skipStringLiteral(content, index);
+
+      if (next === -1) {
+        return false;
+      }
+
+      index = next;
+      continue;
+    }
+
+    if (char === '/') {
+      const following = content[index + 1];
+
+      if (following === '/') {
+        const lineEnd = content.indexOf('\n', index + 2);
+        index = lineEnd === -1 ? content.length : lineEnd;
+        continue;
+      }
+
+      if (following === '*') {
+        const commentEnd = content.indexOf('*/', index + 2);
+
+        if (commentEnd === -1) {
+          return false;
+        }
+
+        index = commentEnd + 2;
+        continue;
+      }
+
+      // Division or a regex literal — indistinguishable without parsing.
+      return false;
+    }
+
+    index++;
+  }
+
+  return true;
+};
+
+// Index just past the closing quote, or -1 if the literal doesn't terminate
+// before the end of its line. Valid generated JS never contains a bare
+// newline inside a string literal, so hitting one means the scan has lost
+// track of where it is and the caller should stop trusting it.
+const skipStringLiteral = (content: string, start: number): number => {
+  const quote = content[start];
+
+  for (let index = start + 1; index < content.length; index++) {
+    const char = content[index];
+
+    if (char === '\\') {
+      // A backslash immediately before a newline is a line continuation:
+      // legal JS, and Babel re-emits it verbatim because it contributes
+      // nothing to the value. The newline is then part of the literal's raw
+      // text, so indenting it would rewrite the string — bail out instead
+      // of treating the continuation as an ordinary escape.
+      const escaped = content[index + 1];
+
+      if (escaped === '\n' || escaped === '\r') {
+        return -1;
+      }
+
+      index++;
+      continue;
+    }
+
+    if (char === quote) {
+      return index + 1;
+    }
+
+    if (char === '\n') {
+      return -1;
+    }
+  }
+
+  return -1;
+};
+
+// Indentation of the line that `offset` falls on.
+const lineIndentAt = (source: string, offset: number): string => {
+  const lineStart = source.lastIndexOf('\n', offset - 1) + 1;
+  const match = /^[ \t]*/.exec(source.slice(lineStart, offset));
+
+  return match?.[0] ?? '';
+};
+
+// Babel always emits LF. Inserting that straight into a CRLF file leaves it
+// with mixed endings, so a generated fragment adopts whichever the file
+// already uses. Only ever applied alongside re-indentation, where the
+// newlines are known to be layout rather than part of a value.
+const lineTerminatorOf = (source: string): string => {
+  return source.includes('\r\n') ? '\r\n' : '\n';
+};
+
+// Applies non-overlapping edits to `source` in a single forward pass.
+// An edit with `start === end` is an insertion at that offset.
+//
+// Throws on overlapping or out-of-bounds edits rather than silently
+// producing corrupt output: callers build spans from parsed node offsets,
+// so an overlap means the caller's model of the tree is wrong, and a
+// half-applied patch would be far harder to diagnose than a failure.
+export const applyEdits = (source: string, edits: SourceEdit[]): string => {
+  if (edits.length === 0) {
+    return source;
+  }
+
+  const ordered = [...edits].sort((a, b) => a.start - b.start || a.end - b.end);
+
+  for (const edit of ordered) {
+    if (
+      !Number.isInteger(edit.start) ||
+      !Number.isInteger(edit.end) ||
+      edit.start < 0 ||
+      edit.end > source.length ||
+      edit.start > edit.end
+    ) {
+      throw new Error(
+        `Invalid source edit [${edit.start}, ${edit.end}) for a source of length ${source.length}`,
+      );
+    }
+  }
+
+  for (let i = 1; i < ordered.length; i++) {
+    const previous = ordered[i - 1]!;
+    const current = ordered[i]!;
+
+    if (current.start < previous.end) {
+      throw new Error(
+        `Overlapping source edits: [${previous.start}, ${previous.end}) and [${current.start}, ${current.end})`,
+      );
+    }
+  }
+
+  let result = '';
+  let cursor = 0;
+  const terminator = lineTerminatorOf(source);
+
+  for (const edit of ordered) {
+    const content =
+      edit.indent &&
+      edit.content.includes('\n') &&
+      hasOnlyLayoutNewlines(edit.content)
+        ? edit.content.replace(
+            /\n/g,
+            `${terminator}${lineIndentAt(source, edit.start)}`,
+          )
+        : edit.content;
+
+    result += source.slice(cursor, edit.start) + content;
+    cursor = edit.end;
+  }
+
+  return result + source.slice(cursor);
+};

--- a/src/utils/ast/update.test.ts
+++ b/src/utils/ast/update.test.ts
@@ -198,6 +198,220 @@ describe('update', () => {
       expect(result).toEqual({ code: DUPLICATE_LABEL_CODE, success: false });
     });
   });
+
+  // #239: `update` patches the original source at the parsed node's offsets
+  // instead of re-emitting the section, so anything it didn't explicitly
+  // target comes through byte for byte.
+  describe('formatting preservation (#239)', () => {
+    const FORMATTED = `<section data-name="Hero">
+  {/* keep this comment */}
+  <h1
+    data-id="a"
+    data-binding='[{"label":"Title","property":"innerText"}]'
+    className={cn(
+      'text-4xl',
+      // trailing comment inside cn
+      'font-bold',
+    )}
+  >
+    Old Title
+  </h1>
+</section>`;
+
+    it('changes only the edited value and leaves every other byte identical', () => {
+      const result = update(FORMATTED, 'a', 'Title', 'New Title');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toBe(FORMATTED.replace('Old Title', 'New Title'));
+    });
+
+    it('preserves the indentation surrounding a replaced text node', () => {
+      const result = update(FORMATTED, 'a', 'Title', 'New Title');
+
+      expect(result.code).toContain('\n  >\n    New Title\n  </h1>');
+    });
+
+    // Bindings are authored as JSX expressions now, so whole-node
+    // regeneration used to reformat the declaration that drives the edit.
+    it('leaves a multi-line data-binding declaration untouched', () => {
+      const code = `<div
+  data-id="a"
+  data-binding={[
+    { label: 'Title', property: 'title' },
+    { label: 'Alt', property: 'alt' },
+  ]}
+  title="old"
+  alt="keep"
+>x</div>`;
+
+      const result = update(code, 'a', 'Title', 'new', 'title');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toBe(code.replace('title="old"', 'title="new"'));
+    });
+
+    it('re-indents a generated multi-line fragment to the column it lands on', () => {
+      const code = `<section>
+    <div
+      data-id="a"
+      data-binding={[{ label: 'Style', property: 'style', type: 'object' }]}
+      style={{ color: 'red' }}
+    >x</div>
+</section>`;
+
+      const result = update(code, 'a', 'Style', { color: 'blue' }, 'style');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain(
+        '      style={{\n        "color": "blue"\n      }}',
+      );
+    });
+
+    // The old implementation smuggled raw values past the generator as
+    // `__HTML_<id>__` placeholders and string-replaced them afterwards,
+    // where `$&`/`$$` are special. Source patching inserts them literally.
+    it('writes a raw innerHTML value containing $& and $$ verbatim', () => {
+      const code = `<div data-id="a" data-binding="[{label:'H',property:'innerHTML'}]">old</div>`;
+      const result = update(code, 'a', 'H', '<b>$& and $$</b>');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('<b>$& and $$</b>');
+    });
+
+    // Patching an attribute reuses the parsed name node rather than building
+    // a fresh JSXIdentifier, so dashed and namespaced names survive.
+    it('keeps a dashed attribute name intact', () => {
+      const code = `<div data-id="a" data-binding="[{label:'L',property:'aria-label'}]" aria-label="old">x</div>`;
+      const result = update(code, 'a', 'L', 'new', 'aria-label');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('aria-label="new"');
+    });
+
+    // Replacing innerText targets the text nodes only — same as the old
+    // "splice out every JSXText" mutation, which left other children alone.
+    it('replaces text without disturbing sibling non-text children', () => {
+      const code = `<div data-id="a" data-binding="[{label:'T',property:'innerText'}]">old{/* keep */}</div>`;
+      const result = update(code, 'a', 'T', 'new', 'innerText');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('{/* keep */}');
+      expect(result.code).not.toContain('old');
+    });
+
+    // The text span is measured on the raw source, not on Babel's cooked
+    // JSXText value: the cooked value decodes entities and collapses CRLF,
+    // so its character counts don't match the raw offsets the span uses.
+    it('keeps CRLF line endings and surrounding indentation intact', () => {
+      const code =
+        '<h1\r\n  data-id="a"\r\n  data-binding="[{label:\'T\',property:\'innerText\'}]"\r\n>\r\n  Old Title\r\n</h1>';
+
+      const result = update(code, 'a', 'T', 'New Title');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toBe(code.replace('Old Title', 'New Title'));
+    });
+
+    it('replaces text bounded by HTML entities without cutting into them', () => {
+      const code = `<div data-id="a" data-binding="[{label:'T',property:'innerText'}]">&nbsp;Old&nbsp;</div>`;
+
+      const result = update(code, 'a', 'T', 'New');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('>New<');
+      expect(result.code).not.toContain('&New;');
+    });
+
+    // A generated fragment is re-indented to the column it lands on, but
+    // only when every newline in it is layout. A newline inside a template
+    // literal or JSX text belongs to the value, and indenting it would
+    // rewrite that value — repeatedly, since the built-in array editor
+    // feeds its own serialized output back through `update`.
+    it('leaves newlines inside a template literal value alone across repeated edits', () => {
+      const items = '[{ id: 1, html: `<p>A</p>\n<p>B</p>` }]';
+      const code = `<div
+      data-id="a"
+      data-binding={[{ label: 'I', property: 'items', type: 'array' }]}
+      items={${items}}
+    >x</div>`;
+
+      let current = code;
+
+      for (let pass = 0; pass < 3; pass++) {
+        const serialized = /items=\{(\[[\s\S]*?\])\}/.exec(current)?.[1];
+        current = update(current, 'a', 'I', serialized, 'items').code;
+
+        expect(current).toContain('`<p>A</p>\n<p>B</p>`');
+      }
+    });
+
+    // Babel re-emits comments it parsed out of the authored value, so an
+    // apostrophe in an English comment must not make the indent-safety scan
+    // lose track of the backtick that follows it.
+    it.each([
+      ['a line comment', "[\n  // don't\n  { html: `A\nB` }\n]"],
+      ['a block comment', "[{ /* don't */ html: `A\nB` }]"],
+      ['a regex literal', '[{ re: /"/, html: `A\nB` }]'],
+    ])(
+      'leaves a template literal alone when the value also contains %s',
+      (_name, items) => {
+        const code = `<div
+      data-id="a"
+      data-binding={[{ label: 'I', property: 'items', type: 'array' }]}
+      items={[]}
+    >x</div>`;
+
+        const result = update(code, 'a', 'I', items, 'items');
+
+        expect(result.success).toBe(true);
+        expect(result.code).toContain('`A\nB`');
+      },
+    );
+
+    // A backslash before a newline is a line continuation: the newline is
+    // part of the string's raw text, even though there is no backtick or
+    // `<` anywhere to flag it.
+    it('leaves a line-continued string literal byte-identical', () => {
+      const code = `<div
+      data-id="a"
+      data-binding={[{ label: 'I', property: 'items', type: 'array' }]}
+      items={[]}
+    >x</div>`;
+
+      const result = update(
+        code,
+        'a',
+        'I',
+        '[{ id: 1, html: "<p>A</p>\\\n<p>B</p>" }]',
+        'items',
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('"<p>A</p>\\\n<p>B</p>"');
+    });
+
+    it('leaves newlines inside generated JSX text alone', () => {
+      const code = `<section>
+      <ul data-id="a" data-binding={[{ label: 'K', property: 'children' }]}>
+        <li>x</li>
+      </ul>
+</section>`;
+
+      const value = JSON.stringify([
+        {
+          tagName: 'pre',
+          attributes: [],
+          dataAttributes: [],
+          textContent: 'a\nb',
+        },
+      ]);
+
+      const result = update(code, 'a', 'K', value);
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('<pre>a\nb</pre>');
+    });
+  });
 });
 
 describe('bulkUpdate', () => {
@@ -234,5 +448,35 @@ describe('bulkUpdate', () => {
     expect(result.success).toBe(true);
     expect(result.code).toContain('alt="bulk alt"');
     expect(result.code).toContain('title="t"');
+  });
+
+  // #239: each entry re-parses the already-patched source, so offsets are
+  // always fresh — batching must stay equivalent to applying one at a time.
+  it('produces the same result as applying each entry sequentially', () => {
+    const code = `<div
+  data-id="a"
+  data-binding={[{ label: 'T', property: 'title' }, { label: 'A', property: 'alt' }]}
+  title="t"
+  alt="a"
+>x</div>`;
+
+    const batched = bulkUpdate(code, [
+      { dataId: 'a', label: 'T', value: 't2', property: 'title' },
+      { dataId: 'a', label: 'A', value: 'a2', property: 'alt' },
+    ]);
+
+    const sequential = update(
+      update(code, 'a', 'T', 't2', 'title').code,
+      'a',
+      'A',
+      'a2',
+      'alt',
+    );
+
+    expect(batched.success).toBe(true);
+    expect(batched.code).toBe(sequential.code);
+    expect(batched.code).toBe(
+      code.replace('title="t"', 'title="t2"').replace('alt="a"', 'alt="a2"'),
+    );
   });
 });

--- a/src/utils/ast/update.ts
+++ b/src/utils/ast/update.ts
@@ -1,124 +1,261 @@
 import { parse, parseExpression } from '@babel/parser';
-import type { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
-import { nanoid } from 'nanoid';
 
 import { BINDING_PROP, DATA_ATTR } from '../../constants';
 import { parseBinding } from './binding';
 import { traverse } from './document';
 import { nodeToJSX } from './extract';
 import { generateCode, unwrap, wrap } from './helpers';
+import { type SourceEdit, applyEdits } from './patch';
 import type { BindingType, DataAttrNode } from './types';
 import { valueToExpression } from './value';
 
-const updateInnerText = (
-  path: NodePath<t.JSXElement>,
-  value: string,
-): boolean => {
-  const jsxChildren = path.node.children;
+// Every editor below returns the source spans it wants to change rather
+// than mutating the tree, so `update` can patch the original text and leave
+// untouched bytes byte-identical. An empty array means "nothing to write,
+// but this counts as handled"; `null` means the edit failed. See #239.
+type EditResult = SourceEdit[] | null;
 
-  for (let i = jsxChildren.length - 1; i >= 0; i--) {
-    if (t.isJSXText(jsxChildren[i])) {
-      jsxChildren.splice(i, 1);
+// The span between `>` and `</`, i.e. everything the element encloses.
+// `null` for a self-closing element, which has nowhere to put children.
+const childrenRange = (
+  element: t.JSXElement,
+): { start: number; end: number } | null => {
+  const { openingElement, closingElement } = element;
+
+  if (
+    !closingElement ||
+    openingElement.end == null ||
+    closingElement.start == null
+  ) {
+    return null;
+  }
+
+  return { start: openingElement.end, end: closingElement.start };
+};
+
+const findAttribute = (
+  opening: t.JSXOpeningElement,
+  propertyName: string,
+): t.JSXAttribute | undefined => {
+  return opening.attributes.find(
+    (attr): attr is t.JSXAttribute =>
+      t.isJSXAttribute(attr) &&
+      t.isJSXIdentifier(attr.name) &&
+      attr.name.name === propertyName,
+  );
+};
+
+// Where a brand-new attribute should be inserted: after the last existing
+// attribute, or straight after the element name when there are none.
+const attributeInsertPoint = (opening: t.JSXOpeningElement): number | null => {
+  const last = opening.attributes[opening.attributes.length - 1];
+
+  return last?.end ?? opening.name.end ?? null;
+};
+
+// Drops the element's JSXText children and writes `value` just before the
+// closing tag — the positional equivalent of the previous "splice out every
+// JSXText, then push a new one" mutation, including its handling of mixed
+// children (a nested element stays, the text around it doesn't).
+//
+// The common case — a single text child — is narrowed further: only the
+// text's *trimmed* span is replaced, so the author's line breaks and
+// indentation around it survive. Rewriting the whole children region would
+// collapse
+//
+//   >
+//     Old Title
+//   </h1>
+//
+// down to `>New Title</h1>`, which is exactly the formatting loss #239 is
+// about, just at a smaller scale.
+//
+// A self-closing element yields no edits: there is no children region to
+// write into. That matches the old behaviour, which pushed onto a `children`
+// array the generator then ignored — a silent no-op still reported as
+// success. Left as-is here deliberately; it is a reporting bug, tracked
+// with the rest of that class in #270.
+const editInnerText = (
+  source: string,
+  element: t.JSXElement,
+  value: string,
+): EditResult => {
+  const range = childrenRange(element);
+
+  if (!range) {
+    return [];
+  }
+
+  const [only] = element.children;
+
+  if (
+    element.children.length === 1 &&
+    t.isJSXText(only) &&
+    only.start != null &&
+    only.end != null
+  ) {
+    // Measured on the raw source slice, never on `only.value`: the latter is
+    // Babel's *cooked* text, with HTML entities decoded and CRLF collapsed
+    // to LF, so its character counts don't line up with the raw offsets the
+    // span is built from. `&nbsp;Old&nbsp;` would put the span six bytes
+    // inside the entity (yielding `&New;`), and a CRLF file would lose a
+    // byte off each end of every innerText edit.
+    const raw = source.slice(only.start, only.end);
+
+    if (raw.trim() !== '') {
+      const leading = raw.length - raw.trimStart().length;
+      const trailing = raw.length - raw.trimEnd().length;
+
+      return [
+        {
+          start: only.start + leading,
+          end: only.end - trailing,
+          content: value,
+        },
+      ];
     }
   }
 
-  jsxChildren.push(t.jsxText(value));
-  return true;
+  const edits: SourceEdit[] = [];
+
+  for (const child of element.children) {
+    if (t.isJSXText(child) && child.start != null && child.end != null) {
+      edits.push({ start: child.start, end: child.end, content: '' });
+    }
+  }
+
+  edits.push({ start: range.end, end: range.end, content: value });
+
+  return edits;
 };
 
-// Injects a `{__PREFIX_<id>__}` JSX expression container as a placeholder,
-// then records how the placeholder's *generated source text* should be
-// string-replaced with the real value once generateCode() has run — used
-// for values (raw HTML, arbitrary JSX/expressions) that can't be
-// represented as AST literals, so we can't just build the real node here.
-//
-// `asRawContent: true` replaces the placeholder *including* its enclosing
-// braces, so the raw value lands as literal children content instead of a
-// JS expression (used for innerHTML). Leaving it false replaces only the
-// identifier inside the braces, so the value is inserted as the expression
-// itself (used for a `type: 'jsx'` attribute value).
-const injectPlaceholder = (
-  prefix: string,
-  value: string,
-  placeholders: Map<string, string>,
-  { asRawContent = false }: { asRawContent?: boolean } = {},
-): t.JSXExpressionContainer => {
-  const name = `__${prefix}_${nanoid(6)}__`;
-  const container = t.jsxExpressionContainer(t.identifier(name));
+// Raw HTML replaces the children region verbatim. This is what the old
+// `__HTML_<id>__` placeholder existed to achieve: the value can't be
+// represented as an AST literal, so it had to be smuggled past the
+// generator and string-substituted back in afterwards. Writing directly
+// into the source removes that round-trip — and with it the `$&`/`$$`
+// substitution hazard that the replacement step had to guard against.
+const editInnerHTML = (element: t.JSXElement, value: string): EditResult => {
+  const range = childrenRange(element);
 
-  placeholders.set(asRawContent ? `{${name}}` : name, value);
+  if (!range) {
+    return [];
+  }
 
-  return container;
+  return [{ start: range.start, end: range.end, content: value }];
 };
 
-const updateInnerHTML = (
-  path: NodePath<t.JSXElement>,
-  value: string,
-  placeholders: Map<string, string>,
-): boolean => {
-  path.node.children = [
-    injectPlaceholder('HTML', value, placeholders, { asRawContent: true }),
-  ];
-
-  return true;
-};
-
-const updateChildren = (
-  path: NodePath<t.JSXElement>,
-  value: unknown,
-): boolean => {
+const editChildren = (element: t.JSXElement, value: unknown): EditResult => {
   try {
     const childrenData = (
       typeof value === 'string' ? JSON.parse(value) : value
     ) as DataAttrNode[];
 
-    path.node.children.length = 0;
+    const range = childrenRange(element);
 
-    childrenData.forEach(childData => {
-      const jsxElement = nodeToJSX(childData);
-      if (jsxElement) {
-        path.node.children.push(jsxElement);
-      }
-    });
+    if (!range) {
+      return [];
+    }
 
-    return true;
+    // These children are new, so there is no source text to preserve —
+    // generating the fragment is correct here. The point of #239 is to
+    // generate *only* the fragment, never the enclosing tree.
+    const content = childrenData
+      .map(childData => nodeToJSX(childData))
+      .filter((node): node is t.JSXElement | t.JSXFragment => node !== null)
+      .map(node => generateCode(node))
+      .join('');
+
+    return [{ start: range.start, end: range.end, content, indent: true }];
   } catch (error) {
     console.error('❌ Children update error:', error);
-    return false;
+    return null;
   }
 };
 
-const updateRichtext = (
-  path: NodePath<t.JSXElement>,
-  value: string,
-): boolean => {
-  path.node.children = [];
+const editRichtext = (element: t.JSXElement, value: string): EditResult => {
+  const edits: SourceEdit[] = [];
+  const range = childrenRange(element);
 
-  const opening = path.node.openingElement;
-  const htmlObject = t.objectExpression([
-    t.objectProperty(t.identifier('__html'), t.stringLiteral(value)),
-  ]);
-
-  const existingAttr = opening.attributes.find(
-    a =>
-      t.isJSXAttribute(a) &&
-      t.isJSXIdentifier(a.name) &&
-      a.name.name === 'dangerouslySetInnerHTML',
-  );
-
-  if (existingAttr && t.isJSXAttribute(existingAttr)) {
-    existingAttr.value = t.jsxExpressionContainer(htmlObject);
-  } else {
-    opening.attributes.push(
-      t.jsxAttribute(
-        t.jsxIdentifier('dangerouslySetInnerHTML'),
-        t.jsxExpressionContainer(htmlObject),
-      ),
-    );
+  // richtext owns the element's content, so any prior markup goes.
+  if (range && range.start !== range.end) {
+    edits.push({ start: range.start, end: range.end, content: '' });
   }
 
-  return true;
+  const opening = element.openingElement;
+  const attribute = t.jsxAttribute(
+    t.jsxIdentifier('dangerouslySetInnerHTML'),
+    t.jsxExpressionContainer(
+      t.objectExpression([
+        t.objectProperty(t.identifier('__html'), t.stringLiteral(value)),
+      ]),
+    ),
+  );
+  const content = generateCode(attribute);
+  const existing = findAttribute(opening, 'dangerouslySetInnerHTML');
+
+  if (existing && existing.start != null && existing.end != null) {
+    edits.push({
+      start: existing.start,
+      end: existing.end,
+      content,
+      indent: true,
+    });
+
+    return edits;
+  }
+
+  const insertAt = attributeInsertPoint(opening);
+
+  if (insertAt == null) {
+    return null;
+  }
+
+  edits.push({
+    start: insertAt,
+    end: insertAt,
+    content: ` ${content}`,
+    indent: true,
+  });
+
+  return edits;
+};
+
+// A `type: 'jsx'` value is arbitrary user-authored JSX, so it goes in as
+// written rather than being parsed into nodes and printed back out.
+const editJsxAttribute = (
+  opening: t.JSXOpeningElement,
+  propertyName: string,
+  value: unknown,
+): EditResult => {
+  const attribute = findAttribute(opening, propertyName);
+
+  if (!attribute) {
+    return null;
+  }
+
+  const content = `{${String(value).trim()}}`;
+
+  if (attribute.value?.start != null && attribute.value.end != null) {
+    return [
+      {
+        start: attribute.value.start,
+        end: attribute.value.end,
+        content,
+      },
+    ];
+  }
+
+  // Valueless shorthand (`<Icon icon />`): there is no value span to
+  // overwrite, so append one after the attribute name.
+  const insertAt = attribute.name.end;
+
+  if (insertAt == null) {
+    return null;
+  }
+
+  return [{ start: insertAt, end: insertAt, content: `=${content}` }];
 };
 
 // Serialize a structured value into a JSX attribute value, once, at the AST
@@ -159,25 +296,30 @@ const buildAttributeValue = (
   return expr ? t.jsxExpressionContainer(expr) : t.stringLiteral(String(value));
 };
 
-const updateAttribute = (
+const editAttribute = (
   opening: t.JSXOpeningElement,
   propertyName: string,
   value: unknown,
   type?: BindingType,
-): boolean => {
-  const customAttr = opening.attributes.find(
-    attr =>
-      t.isJSXAttribute(attr) &&
-      t.isJSXIdentifier(attr.name) &&
-      attr.name.name === propertyName,
-  );
+): EditResult => {
+  const attribute = findAttribute(opening, propertyName);
 
-  if (customAttr && t.isJSXAttribute(customAttr)) {
-    customAttr.value = buildAttributeValue(value, type);
-    return true;
+  if (!attribute || attribute.start == null || attribute.end == null) {
+    return null;
   }
 
-  return false;
+  // Generate the whole attribute rather than just its value, so Babel's
+  // JSX-attribute printing path decides the quoting and escaping — the same
+  // path that produced this text before, when the enclosing tree was
+  // regenerated. Reuses the parsed name node instead of building a fresh
+  // identifier so namespaced/dashed names survive untouched.
+  const content = generateCode(
+    t.jsxAttribute(attribute.name, buildAttributeValue(value, type)),
+  );
+
+  return [
+    { start: attribute.start, end: attribute.end, content, indent: true },
+  ];
 };
 
 export interface UpdateResult {
@@ -207,7 +349,19 @@ export const update = (
     });
 
     let changed = false;
-    const jsxPlaceholders = new Map<string, string>();
+    const edits: SourceEdit[] = [];
+
+    // Records an editor's outcome. `null` is a failure (leave `changed`
+    // alone so the caller sees success: false); anything else counts as
+    // handled, even when it produces no edits.
+    const collect = (result: EditResult) => {
+      if (!result) {
+        return;
+      }
+
+      edits.push(...result);
+      changed = true;
+    };
 
     traverse(ast, {
       JSXElement(path) {
@@ -272,50 +426,35 @@ export const update = (
 
         switch (propertyBinding.property) {
           case BINDING_PROP.INNER_TEXT: {
-            changed = updateInnerText(path, String(value));
+            collect(editInnerText(wrapped, path.node, String(value)));
             break;
           }
 
           case BINDING_PROP.INNER_HTML: {
-            if (propertyBinding.type === 'richtext') {
-              changed = updateRichtext(path, String(value));
-            } else {
-              changed = updateInnerHTML(path, String(value), jsxPlaceholders);
-            }
+            collect(
+              propertyBinding.type === 'richtext'
+                ? editRichtext(path.node, String(value))
+                : editInnerHTML(path.node, String(value)),
+            );
             break;
           }
 
           case BINDING_PROP.CHILDREN: {
-            changed = updateChildren(path, value);
+            collect(editChildren(path.node, value));
             break;
           }
 
           default: {
-            if (propertyBinding.type === 'jsx') {
-              const attr = opening.attributes.find(
-                a =>
-                  t.isJSXAttribute(a) &&
-                  t.isJSXIdentifier(a.name) &&
-                  a.name.name === propertyBinding.property,
-              );
-
-              if (attr && t.isJSXAttribute(attr)) {
-                attr.value = injectPlaceholder(
-                  'JSX',
-                  String(value).trim(),
-                  jsxPlaceholders,
-                );
-                changed = true;
-              }
-            } else {
-              changed = updateAttribute(
-                opening,
-                propertyBinding.property,
-                value,
-                propertyBinding.type,
-              );
-            }
-
+            collect(
+              propertyBinding.type === 'jsx'
+                ? editJsxAttribute(opening, propertyBinding.property, value)
+                : editAttribute(
+                    opening,
+                    propertyBinding.property,
+                    value,
+                    propertyBinding.type,
+                  ),
+            );
             break;
           }
         }
@@ -326,15 +465,12 @@ export const update = (
       return { code, success: false };
     }
 
-    let result = unwrap(generateCode(ast));
-
-    for (const [placeholder, original] of jsxPlaceholders) {
-      // 두 번째 인자가 문자열이면 $&, $$ 같은 특수 치환 패턴으로 해석되어
-      // original 안에 그런 문자가 있으면 결과가 깨진다 — 함수형 치환자로 방지.
-      result = result.replace(placeholder, () => original);
-    }
-
-    return { code: result, success: true };
+    // Patch the original source instead of re-emitting the tree: every byte
+    // outside a recorded span is copied through unchanged, so an edit to
+    // one field can no longer reflow the author's formatting elsewhere in
+    // the section — including the `data-binding` array itself, which is now
+    // authored as a JSX expression. See #239.
+    return { code: unwrap(applyEdits(wrapped, edits)), success: true };
   } catch (error) {
     console.error('❌ Code update error:', error);
     return { code, success: false };


### PR DESCRIPTION
## Summary

Closes #239. `update`/`bulkUpdate` now patch the original source at the parsed nodes' offsets instead of re-emitting the whole section through `@babel/generator`, so a single field edit no longer reflows the author's formatting. The repro from the issue comes back byte-identical apart from the value that was edited.

## Changes

- Add `src/utils/ast/patch.ts` — `SourceEdit` plus `applyEdits`, a single forward pass that copies untouched bytes verbatim and throws on overlapping or out-of-bounds spans rather than half-applying a patch.
- Rewrite `update()`'s traversal to record spans instead of mutating the tree. Each operation (innerText, innerHTML, children, richtext, `type: 'jsx'` attributes, plain attributes) returns the spans it wants to change; only genuinely new content is generated, and only as a fragment.
- Delete the `__JSX_<id>__` / `__HTML_<id>__` placeholder mechanism. It existed solely because raw values could not survive `@babel/generator`; they are now written straight into the source. This also removes the `$&`/`$$` substitution hazard the post-generation `String.replace` had to guard against.
- Re-indent generated multi-line fragments to the column they land on, gated on every newline in the fragment being provably layout rather than part of a value.

### Before / after

Editing only the `Title` field:

```jsx
// before — comments survive, layout does not
<h1 data-id="a" data-binding='[{"label":"Title","property":"innerText"}]' className={cn('text-4xl',
  // trailing comment inside cn
  'font-bold')}>New Title</h1>

// after — identical to the input except `Old Title` → `New Title`
<h1
  data-id="a"
  data-binding='[{"label":"Title","property":"innerText"}]'
  className={cn(
    'text-4xl',
    // trailing comment inside cn
    'font-bold',
  )}
>
  New Title
</h1>
```

This matters more now than when #239 was filed: bindings are authored as JSX expressions since `v1.19.0`, so whole-node regeneration was reformatting the `data-binding` declaration that drives the edit.

## Notes for reviewers

**No `magic-string`.** The issue recommended it. It is only present here transitively via Vite, so using it would mean adding a runtime dependency shipped to consumers' browsers, and its value — source maps and interleaved insert/move semantics — is not needed. The edits are non-overlapping span replacements applied in one pass, which is the whole of `applyEdits`. The reasoning is recorded at the top of `patch.ts`.

**No measurable performance change**, contrary to the issue's expectation of an improvement. Generation turned out to be roughly 6% of an edit (~0.084 ms of ~1.29 ms at 40 sections); traversal and per-element `parseBinding` dominate. Measured over 200 iterations after warmup: 5 sections 0.24 → 0.25 ms, 40 sections ~1.29 → ~1.28 ms. No regression, no meaningful win.

**Four value-corruption bugs were found in review and fixed**, each pinned with regression tests at both the `applyEdits` unit level and end-to-end through `update`:

| Bug | Effect |
| --- | --- |
| Trim offsets measured on Babel's *cooked* `JSXText` value but applied to *raw* source offsets | `&nbsp;Old&nbsp;` → `&New;`; every `innerText` edit in a CRLF file lost a byte off each end |
| Blanket re-indentation of generated fragments | Newlines inside template literals and JSX text are part of the value; the array editor round-trips its own output, so an `innerHTML` leaf gained a level of indentation on *every* edit |
| Quote state leaking out of comments and regex literals | An apostrophe in an English comment (`// don't`) hid the following backtick, re-opening the bug above |
| Line continuations (`\` + newline) treated as ordinary escapes | A string continued across two lines was accepted as layout-only, so indentation was injected into the string's value |

The indent-safety scan is deliberately conservative: anything ambiguous (a `/` that is not a comment, an unterminated string) refuses to indent. A false "unsafe" costs only a fragment that is not re-indented; a false "safe" corrupts a value.

**Behaviour deliberately preserved:** a self-closing element still reports `success: true` while writing nothing for an `innerText`/`children` binding. That is a pre-existing reporting bug and belongs to #270, not here.

## Type of Change

- [x] 🐛 fix — bug fix
- [x] ♻️ refactor — code structure improvement

## Scope

- [x] AST transform (`src/utils/ast`)

## Validation

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`
- [x] Manual verification completed

313 tests passing (13 files), up from 295 — 18 new tests covering formatting preservation, the four bugs above, and `applyEdits` itself. Behaviour was also diffed against the previous implementation across 15 hand-built shapes (mixed children, self-closing elements, quote/newline/unicode escaping, shorthand and dashed attributes, nested and sibling duplicate `data-id`), with the only differences being the intended indentation improvements.

## Checklist

- [x] Commit messages follow gitmoji + conventional-commit style
- [x] Updated docs when behavior/API changed — no public API change; `update`, `bulkUpdate` and `UpdateResult` keep their signatures, so the changeset is a patch
- [x] Added or updated tests when needed
- [x] No unrelated changes included
