### PR TITLE
🔧 chore: modernize CI action versions to Node 24 majors

### DIFF
--- a/.github/workflows/changeset-draft.yml
+++ b/.github/workflows/changeset-draft.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
         node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # v6+ is required for npm's OIDC "Trusted Publishing" used below.
       # No built-in `cache: 'pnpm'` here on purpose — this job skips
@@ -33,7 +33,7 @@ jobs:
       # step below is scoped to the same already_tagged condition as
       # Install dependencies.
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Setup pnpm cache
         if: steps.tag_check.outputs.already_tagged == 'false'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -160,7 +160,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.tag_check.outputs.already_tagged == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.tag_check.outputs.version }}
           body: ${{ steps.changelog.outputs.body || format('Release {0}', steps.tag_check.outputs.version) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag }}
@@ -56,7 +56,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.inputs.tag }}
           body: ${{ steps.changelog.outputs.body || format('Release {0}', github.event.inputs.tag) }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

Bumps every GitHub Action still declaring a deprecated Node runtime to its newest major that ships on Node 24. Same class of fix as ui-kit #331.

- `actions/checkout` v4 → v7
- `actions/setup-node` v4/v6 → v7 (was inconsistent: publish.yml on v6, others on v4)
- `actions/cache` v4 → v6
- `pnpm/action-setup` v4 → v6
- `softprops/action-gh-release` v1 → v3

The runner already forces Node 24 (Node 16/20 shims are on borrowed time), so these were latent — the steps stop running once GitHub drops the shim.

## Not changed (intentional)

- `changesets/action@v1` — already runs on Node 24.
- **No pnpm-version work needed here** (unlike ui-kit #331): `pnpm/action-setup` has no `version:` input, so it already resolves pnpm from `packageManager` (pnpm@10.29.3), and `engines.pnpm` is already `>=10`.

## Test plan

- All 5 workflows parse as valid YAML.
- `grep -rn "uses: " .github/workflows/` shows no action older than its Node 24 major (only `changesets/action@v1`, which is already Node 24).
- On the next runs: no `Node 20 is being deprecated` annotation; `ci`/`version`/`publish`/`changeset-draft` still pass.