### PR TITLE
🐛 fix: log nvidia-chat diagnostics to stderr, not stdout

### DIFF
--- a/.github/scripts/nvidia-chat.mjs
+++ b/.github/scripts/nvidia-chat.mjs
@@ -61,7 +61,7 @@ async function fetchModel(model, apiKey, body) {
     if (attempt === MAX_ATTEMPTS) return response;
 
     const delayMs = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
-    console.log(
+    console.error(
       `NVIDIA API [${model}] returned ${response.status}, retrying in ${delayMs}ms` +
       ` (attempt ${attempt}/${MAX_ATTEMPTS})...`,
     );
@@ -86,13 +86,13 @@ export async function nvidiaChat(apiKey, body) {
       response = await fetchModel(model, apiKey, body);
     } catch (err) {
       lastError = err;
-      console.log(`NVIDIA API [${model}] network error: ${err.message} — trying next candidate`);
+      console.error(`NVIDIA API [${model}] network error: ${err.message} — trying next candidate`);
       continue;
     }
 
     if (GONE_STATUSES.has(response.status)) {
       const detail = await response.text().catch(() => '');
-      console.log(
+      console.error(
         `NVIDIA API [${model}] returned ${response.status} (model gone) — trying next candidate.\n  ${detail}`,
       );
       lastError = new Error(`Model gone: ${response.status} — ${detail}`);
@@ -115,7 +115,7 @@ export async function nvidiaChat(apiKey, body) {
     }
 
     const content = stripThinkBlock(raw);
-    console.log(`NVIDIA API: used model ${model}`);
+    console.error(`NVIDIA API: used model ${model}`);
     return content;
   }
 


### PR DESCRIPTION
## Summary

`nvidia-chat.mjs` logged diagnostics (`NVIDIA API: used model …`, retry/fallback messages) with `console.log`, i.e. **stdout**. `polish-release-notes.mjs` captures stdout as the GitHub Release body, so those lines leaked into release notes — observed at the top of live-editor's v2.0.2 release (since cleaned up).

Routes all diagnostics in the shared module to `console.error` (stderr): still visible in Actions logs, no longer captured into the polished release body. The returned content is unchanged.

## Test plan
- `node --check` passes.
- No behavioral change beyond log stream; draft-changeset (writes a file) is unaffected, polish-release-notes now emits only the model content on stdout.