### PR TITLE
🐛 fix: define process.env flags at build time to stop browser crash

### DIFF
--- a/.changeset/fix-process-env-crash.md
+++ b/.changeset/fix-process-env-crash.md
@@ -1,0 +1,15 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fix "process is not defined" crash when importing the published package in browsers
+
+`@babel/types` (bundled into the `document-*` chunk shared by the root entry and
+`@jbpark/live-editor/utils/ast`) reads `process.env.BABEL_TYPES_8_BREAKING` with
+bare, unguarded reads at module-init time. `process` doesn't exist in browsers,
+so any consumer whose bundler doesn't define it crashed on import with
+`ReferenceError: process is not defined`. `tsdown` now substitutes
+`process.env.BABEL_TYPES_8_BREAKING` (`false`) and `process.env.NODE_ENV`
+(`"production"`) at build time, so `dist` is self-contained and no consumer-side
+`process` shim is needed. Behaviour is unchanged (the flag was already falsy),
+and the dead branches tree-shake away.

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -25,6 +25,20 @@ export default defineConfig({
   // `createRequire` from `node:module` — which breaks every browser bundler
   // that consumes the built package (rspack/webpack throw on `node:` schemes).
   platform: 'browser',
+  // `platform: 'browser'` only controls export-condition resolution, not
+  // `process.env` substitution. Bundled deps (notably @babel/types) read
+  // `process.env.BABEL_TYPES_8_BREAKING` at module-init time via bare,
+  // unguarded reads that survive verbatim into the bundle — so a consumer
+  // whose bundler doesn't define `process` crashes on import with
+  // "process is not defined". Substitute the flags at build time so `dist`
+  // is self-contained (no consumer-side shim needed) and the dead branches
+  // tree-shake away. `false` matches prior behaviour: with `process.env`
+  // previously stubbed to `{}` by every in-repo consumer, the value was
+  // already undefined (falsy). See #278.
+  define: {
+    'process.env.BABEL_TYPES_8_BREAKING': 'false',
+    'process.env.NODE_ENV': '"production"',
+  },
   dts: { build: true },
   outDir: 'dist',
   clean: true,


### PR DESCRIPTION
Closes #278

## Problem

`@babel/types` — bundled into the `document-*` chunk that both the root entry (`@jbpark/live-editor`) and the `@jbpark/live-editor/utils/ast` subpath statically import — reads `process.env.BABEL_TYPES_8_BREAKING` with bare, unguarded reads while the module initialises (inside `defineType(...)` calls that run at import time). Browsers have no `process`, so any consumer whose bundler doesn't define it crashed on import:

```
Uncaught ReferenceError: process is not defined
```

The repo never noticed because all three in-repo consumers (root vite, demos vite, Docusaurus client module) stub `process.env` themselves.

## Fix

`tsdown.config.ts` now substitutes the flags at build time so `dist` is self-contained:

```ts
define: {
  'process.env.BABEL_TYPES_8_BREAKING': 'false',
  'process.env.NODE_ENV': '"production"',
},
```

`false` matches prior behaviour (the value was already falsy when stubbed to `{}`), and the dead branches tree-shake away.

## Verification (rebuilt `dist`)

- **Repro before:** `node --input-type=module -e 'delete globalThis.process; await import("./dist/utils/ast/index.js")'` → `ReferenceError: process is not defined`.
- **After:** same command imports cleanly ✅.
- `process.env.BABEL_TYPES_8_BREAKING` reads in the `document-*` chunk: **34 → 0**.
- The 3 remaining `process.env` reads are all guarded and browser-safe: `debug`'s `DEBUG` (`typeof process !== "undefined" && "env" in process`) and `picocolors`' `FORCE_COLOR` ×2 (`typeof process === "object"`).
- `pnpm lint`, `pnpm check-types`, `pnpm test` (359 tests) all pass.

Added a `patch` changeset (the auto-drafter only diffs `src/`, so it can't see this root build-config change).

## Not included

- A `dist`-level import smoke test to prevent regression, and running tests in CI, belong to #277 (CI runs no tests today).
- Consumer-facing README install/usage docs are #281 — with this fix, no `process` shim note is needed there.