### PR TITLE
🐛 fix: reconcile multi-select set on per-item delete/move in Items

### DIFF
--- a/.changeset/fix-items-selection-reconcile.md
+++ b/.changeset/fix-items-selection-reconcile.md
@@ -1,0 +1,13 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fix per-item delete/move in the array editor leaving a stale multi-select set
+
+The multi-select set holds positional indices. Bulk operations re-synced it after
+mutating the array, but the per-item delete/move buttons did not — and removing or
+moving an item shifts the positions of the items after it. An active selection
+silently ended up pointing at different items than the user picked, so a later bulk
+action targeted the wrong elements. The four single-item handlers (`deletePrimitive`,
+`deleteItem`, `movePrimitive`, `moveItem`) now clear the selection after they mutate,
+matching what the bulk delete already does.

--- a/src/components/dnd/panel/items.tsx
+++ b/src/components/dnd/panel/items.tsx
@@ -276,6 +276,10 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
     }
 
     commit(moveArrayItem(value, from, target.elementIndex));
+    // Positions shift after a move, but count is unchanged so useMultiSelect
+    // never reconciles the set — clear it so a later bulk action can't target
+    // the wrong elements. See #285.
+    selection.clear();
   };
 
   const deleteSelectedPrimitives = (indices: Set<number>) => {
@@ -290,6 +294,9 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
 
   const deletePrimitive = (elementIndex: number) => {
     commit(removeArrayItems(value, new Set([elementIndex]), 'primitive'));
+    // Removing an item shifts every position after it; clear the selection so
+    // a later bulk action can't target the wrong elements. See #285.
+    selection.clear();
   };
 
   const addPrimitive = () => {
@@ -331,6 +338,10 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
     }
 
     commit(moveArrayItem(value, from, target.elementIndex));
+    // Positions shift after a move, but count is unchanged so useMultiSelect
+    // never reconciles the set — clear it so a later bulk action can't target
+    // the wrong elements. See #285.
+    selection.clear();
   };
 
   const updateProperty = (
@@ -351,6 +362,9 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
 
   const deleteItem = (elementIndex: number) => {
     commit(removeArrayItems(value, new Set([elementIndex]), 'object'));
+    // Removing an item shifts every position after it; clear the selection so
+    // a later bulk action can't target the wrong elements. See #285.
+    selection.clear();
   };
 
   const addItem = () => {


### PR DESCRIPTION
Closes #285

## Problem

In the array editor (`src/components/dnd/panel/items.tsx`), the multi-select set holds **positional indices**. The bulk operations re-sync it after mutating the array, but the **per-item** delete/move buttons didn't. Removing or moving an item shifts the positions of the items after it, so an active selection silently ends up pointing at different items than the user picked — and the next bulk action operates on the wrong elements.

`useMultiSelect` only drops indices that fall out of range when `count` shrinks; it never *shifts* the remaining ones, and a pure move doesn't change `count` at all, so the stale indices survive untouched.

## Fix

Option A from the issue (recommended): clear the selection in each single-item handler after it mutates, matching what bulk delete already does. Applied to all four:

- `deletePrimitive`, `deleteItem` — clear after removal (positions shift down).
- `movePrimitive`, `moveItem` — clear after move (positions shift, `count` unchanged so `useMultiSelect` wouldn't reconcile).

Early-return paths (no target / no mutation) don't clear.

## Test plan

- `pnpm lint`, `pnpm check-types`, `pnpm test` (359 tests) all pass.
- Manual (no component harness yet — see #277): select item at position 2 in a 4+ item array, click the per-item X on position 0, then *Delete selected* — the intended item is removed rather than a shifted one.

Added a `patch` changeset.