### PR TITLE
🐛 fix: make panel text/number/date/url/asset inputs controlled

### DIFF
--- a/.changeset/fix-panel-inputs-controlled.md
+++ b/.changeset/fix-panel-inputs-controlled.md
@@ -1,0 +1,14 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fix panel text/number/date/url/asset inputs ignoring external value changes
+
+The panel's text-like inputs were uncontrolled (`defaultValue`), so once mounted
+they ignored later changes to their incoming value. When the source changed under
+a still-selected element — an undo/redo, or another field touching the same binding
+— the input kept showing the pre-change text, and blurring re-committed that stale
+text back into the source, clobbering the undo. The url/asset/number/textarea inputs
+now hold local live state with a render-phase reset when the canonical value changes
+(the pattern `ColorPickerField` already used), and the date picker binds the value
+directly, so the displayed value always tracks the source of truth.

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -156,6 +156,23 @@ const Field = ({ binding, onNodeChange }: Props) => {
 
   const [validationError, setValidationError] = useState<string | null>(null);
 
+  // The text-like inputs below (url/asset/number/textarea) commit on blur, so
+  // they need local live state to hold what the user is typing. Left
+  // uncontrolled (`defaultValue`), they ignored later changes to the canonical
+  // value — an undo/redo or another field touching the same binding — because
+  // `Field` reconciles rather than remounts (stable `key={binding.label}`).
+  // The stale text then got re-committed on blur, clobbering the undo. Track
+  // the canonical `rawValue` with a render-phase reset, the same pattern
+  // `ColorPickerField` uses above. See #284. (The date picker commits on
+  // change, not blur, so it can bind the prop directly with no local state.)
+  const [text, setText] = useState(rawValue);
+  const [prevRawValue, setPrevRawValue] = useState(rawValue);
+
+  if (rawValue !== prevRawValue) {
+    setPrevRawValue(rawValue);
+    setText(rawValue);
+  }
+
   if (
     binding.property === 'items' ||
     binding.property === 'data' ||
@@ -292,7 +309,7 @@ const Field = ({ binding, onNodeChange }: Props) => {
     return (
       <div>
         <DatePicker
-          defaultValue={parseDateValue(stringValue)}
+          value={parseDateValue(stringValue)}
           onChange={date => {
             const next = date ? formatDateValue(date) : '';
             const result = validateBindingValue(binding, next);
@@ -321,7 +338,8 @@ const Field = ({ binding, onNodeChange }: Props) => {
       <div>
         <Input
           type="url"
-          defaultValue={stringValue}
+          value={text}
+          onChange={e => setText(e.target.value)}
           placeholder="https://example.com"
           onBlur={e => {
             const next = e.target.value.trim();
@@ -384,7 +402,8 @@ const Field = ({ binding, onNodeChange }: Props) => {
     return (
       <div className="space-y-2">
         <Input
-          defaultValue={stringValue}
+          value={text}
+          onChange={e => setText(e.target.value)}
           placeholder="Enter an image URL"
           onBlur={e => {
             const next = e.target.value.trim();
@@ -427,7 +446,8 @@ const Field = ({ binding, onNodeChange }: Props) => {
       <div>
         <Input
           type="number"
-          defaultValue={stringValue}
+          value={text}
+          onChange={e => setText(e.target.value)}
           placeholder="Enter a numeric value"
           onBlur={e => {
             const raw = e.target.value.trim();
@@ -462,7 +482,8 @@ const Field = ({ binding, onNodeChange }: Props) => {
   return (
     <div>
       <Input.TextArea
-        defaultValue={rawValue}
+        value={text}
+        onChange={e => setText(e.target.value)}
         placeholder="Enter a value"
         onBlur={e => {
           const raw = e.target.value.trim();


### PR DESCRIPTION
Closes #284

## Problem

The panel's text-like inputs in `src/components/dnd/panel/field.tsx` (date, url, asset, number, textarea) were **uncontrolled** (`defaultValue`), so once mounted they ignored later changes to the incoming value. `Field` is keyed by `binding.label`, so an undo/redo (or another field touching the same binding) that leaves the element selected makes React **reconcile rather than remount** — the changed `defaultValue`/`rawValue` prop is dropped. The input kept showing the pre-change text, and blurring **re-committed that stale text back into the source**, silently clobbering the undo.

`Select`/`Checkbox`/`ColorPicker` were already controlled; only the raw text inputs were left uncontrolled.

## Fix

Apply the pattern `ColorPickerField` already uses in this file — local live state + a render-phase reset when the canonical value changes:

```tsx
const [text, setText] = useState(rawValue);
const [prevRawValue, setPrevRawValue] = useState(rawValue);
if (rawValue !== prevRawValue) { setPrevRawValue(rawValue); setText(rawValue); }
```

- url / asset / number / textarea → `value={text}` + `onChange={e => setText(e.target.value)}`; commit-on-blur unchanged (so a no-op blur no longer writes a stale value).
- date picker commits on change, not blur, so it binds the prop directly (`value={parseDateValue(stringValue)}`) — no local state needed.

Cursor/IME state is preserved (no key-remount approach).

## Test plan

- `pnpm lint`, `pnpm check-types`, `pnpm test` (359 tests) all pass.
- Manual (no component harness yet — see #277): type a new value + blur, undo → the panel input shows the restored value; blurring without editing no longer re-commits the undone value.

Added a `patch` changeset.