### PR TITLE
🔧 build: type-check demos and the remaining build configs

### DIFF
--- a/.changeset/typecheck-demos-and-configs.md
+++ b/.changeset/typecheck-demos-and-configs.md
@@ -1,0 +1,9 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Type-check `demos/` and the remaining build configs. `tsconfig.app.json` now
+includes `demos` and `tsconfig.node.json` includes `vitest.config.ts`,
+`tsdown.config.ts`, and `demos/vite.config.ts`, so `tsc -b` (and CI's type
+check) covers them instead of silently skipping ~1k LOC of demo code and three
+of the four config files.

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -28,5 +28,6 @@
       "~/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "demos"],
+  "exclude": ["demos/vite.config.ts"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -22,5 +22,10 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "tsdown.config.ts",
+    "demos/vite.config.ts"
+  ]
 }


### PR DESCRIPTION
Closes #280.

## Summary

`tsc -b` (and CI's `Type check` step) only covered `src/**` and `vite.config.ts`. The four docs demos (~1k LOC of real React that imports library source via the `~` alias) and three of the four build configs (`vitest.config.ts`, `tsdown.config.ts`, `demos/vite.config.ts`) were outside every project's `include`, so a type error in any of them could not fail CI.

- **`tsconfig.node.json`**: add `vitest.config.ts`, `tsdown.config.ts`, `demos/vite.config.ts` to `include`.
- **`tsconfig.app.json`**: add `demos` to `include`. `demos/vite.config.ts` is excluded here since the node project owns it (avoids the same file living in two referenced projects). The demos already import library source through the `~` → `src` alias, so holding them to the app project's strictness is exactly right.

Type-aware ESLint (`recommendedTypeChecked`, issue's option c) is intentionally left out — larger/slower, worth a separate evaluation.

## Test plan

Verified against the issue's checks:

- Configs compiled: `tsc -b --listFiles | grep -E '(vite|vitest|tsdown)\.config\.ts'` → **4** files (was 1).
- Demos compiled: `tsc -b --listFiles | grep -c /demos/` → **9** (was 0).
- Gate proven: appending `const _bad: number = 'nope';` to `demos/dnd/DndDemo.tsx` now fails with TS2322 (previously passed silently); reverted.
- `pnpm check-types` clean, `pnpm lint` clean, `pnpm test` → 378 passed.

No production/`dist` code changed.