### PR TITLE
🐛 fix: report structured update() failure reasons

### DIFF
--- a/.changeset/update-failure-reasons.md
+++ b/.changeset/update-failure-reasons.md
@@ -1,0 +1,11 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Report why an `update()` failed instead of collapsing every cause into one
+`success: false`. `UpdateResult` now carries a structured `failure`
+(`element-not-found`, `no-binding`, `binding-not-declared`,
+`duplicate-binding`, `attribute-not-found`, `parse-error`), and `bulkUpdate`
+returns per-entry `failures`. The panel's error toast now names the actual
+problem — usually a wrong `property`/`label` in the element's `data-binding` —
+and only says "check the console" on paths that actually log there.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -35,6 +35,7 @@ import {
   parseBinding,
   update,
 } from '~/utils/ast';
+import type { UpdateFailure } from '~/utils/ast';
 
 import { DEFAULT_TEMPLATE } from '../../constants';
 import { cn, preloadScripts } from '../../utils';
@@ -47,6 +48,61 @@ import Panel from './panel';
 import Renderer from './renderer';
 import Sortable from './sortable';
 import { useSectionDocument } from './use-section-document';
+
+// Turn a structured `update` failure into a toast that names the actual
+// fault. Before #270 every failure showed "Failed to update this field /
+// Check the console for details" — but nothing was logged, so the console
+// was empty. Most of these are a wrong `property`/`label` in the element's
+// `data-binding`, not the value the author just typed, so the message points
+// there. `description` is only set for paths that genuinely log (parse
+// errors), so "check the console" is never a dead end again.
+const describeUpdateFailure = (
+  failure: UpdateFailure | undefined,
+  label: string,
+): { title: string; description?: string } => {
+  switch (failure?.reason) {
+    case 'attribute-not-found':
+      return {
+        title: `Failed to update "${label}"`,
+        description: `This element has no "${failure.property}" attribute — check the property in its data-binding.`,
+      };
+    case 'binding-not-declared':
+      return {
+        title: `Failed to update "${label}"`,
+        description: `No binding for ${
+          failure.property
+            ? `property "${failure.property}"`
+            : `label "${label}"`
+        } is declared on this element's data-binding.`,
+      };
+    case 'duplicate-binding':
+      return {
+        title: `Failed to update "${label}"`,
+        description: `${failure.count} bindings share ${
+          failure.property
+            ? `property "${failure.property}"`
+            : `label "${label}"`
+        } on this element — remove the duplicate in its data-binding.`,
+      };
+    case 'no-binding':
+      return {
+        title: `Failed to update "${label}"`,
+        description: 'This element has no data-binding declaration.',
+      };
+    case 'element-not-found':
+      return {
+        title: `Failed to update "${label}"`,
+        description: 'The target element could not be found in this section.',
+      };
+    case 'parse-error':
+      return {
+        title: `Failed to update "${label}"`,
+        description: 'Check the console for details.',
+      };
+    default:
+      return { title: `Failed to update "${label}"` };
+  }
+};
 
 export interface PaletteRenderData {
   items: Section[];
@@ -323,9 +379,11 @@ const Dnd = ({
     const result = update(updatedCode, id, label, fieldValue, property);
 
     if (!result.success) {
-      Toast.error('Failed to update this field', {
-        description: 'Check the console for details.',
-      });
+      const { title, description } = describeUpdateFailure(
+        result.failure,
+        label,
+      );
+      Toast.error(title, description ? { description } : undefined);
       return;
     }
 

--- a/src/utils/ast/index.ts
+++ b/src/utils/ast/index.ts
@@ -58,6 +58,7 @@ export {
   replaceDocumentSections,
 } from './document';
 export { bulkUpdate, update } from './update';
+export type { UpdateFailure, UpdateResult } from './update';
 export { clone, fillIds, replaceIds } from './tree';
 export type { ValidationResult } from './validate';
 export { validateBindingValue } from './validate';

--- a/src/utils/ast/update.test.ts
+++ b/src/utils/ast/update.test.ts
@@ -131,13 +131,25 @@ describe('update', () => {
   it('returns success: false and the original code when the data-id is not found', () => {
     const result = update(CODE, 'does-not-exist', 'Text', 'nope');
 
-    expect(result).toEqual({ code: CODE, success: false });
+    expect(result).toEqual({
+      code: CODE,
+      success: false,
+      failure: { reason: 'element-not-found', dataId: 'does-not-exist' },
+    });
   });
 
   it('returns success: false and the original code when the label does not match any binding', () => {
     const result = update(CODE, 'a', 'NoSuchLabel', 'nope');
 
-    expect(result).toEqual({ code: CODE, success: false });
+    expect(result).toEqual({
+      code: CODE,
+      success: false,
+      failure: {
+        reason: 'binding-not-declared',
+        dataId: 'a',
+        label: 'NoSuchLabel',
+      },
+    });
   });
 
   // #240: label is a display string, not an identifier — these pin
@@ -187,7 +199,17 @@ describe('update', () => {
 
       const result = update(ambiguousPropertyCode, 'x', 'A', 'next', 'dup');
 
-      expect(result).toEqual({ code: ambiguousPropertyCode, success: false });
+      expect(result).toEqual({
+        code: ambiguousPropertyCode,
+        success: false,
+        failure: {
+          reason: 'duplicate-binding',
+          dataId: 'x',
+          label: 'A',
+          property: 'dup',
+          count: 2,
+        },
+      });
     });
 
     it('fails safe on the label fallback too when two bindings share a label — the #240 repro', () => {
@@ -195,7 +217,82 @@ describe('update', () => {
       // "alt" was never touched, and the caller still got success: true.
       const result = update(DUPLICATE_LABEL_CODE, 'b', 'Same', 'zzz');
 
-      expect(result).toEqual({ code: DUPLICATE_LABEL_CODE, success: false });
+      expect(result).toEqual({
+        code: DUPLICATE_LABEL_CODE,
+        success: false,
+        failure: {
+          reason: 'duplicate-binding',
+          dataId: 'b',
+          label: 'Same',
+          count: 2,
+        },
+      });
+    });
+  });
+
+  // #270: every failure used to collapse into a bare `success: false` with an
+  // empty console. Each path now reports a distinct, structured reason.
+  describe('failure reasons (#270)', () => {
+    it('A: attribute-not-found when the declared property has no matching attribute', () => {
+      const code = `<div data-id="a" data-binding="[{label:'Title',property:'nonexistent'}]" title="hi">x</div>`;
+      const result = update(code, 'a', 'Title', 'new', 'nonexistent');
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe(code);
+      expect(result.failure).toEqual({
+        reason: 'attribute-not-found',
+        dataId: 'a',
+        property: 'nonexistent',
+      });
+    });
+
+    it('B: binding-not-declared when the requested binding is not on the element', () => {
+      const code = `<div data-id="a" data-binding="[{label:'Title',property:'title'}]" title="hi">x</div>`;
+      const result = update(code, 'a', 'Other', 'new', 'other');
+
+      expect(result.failure).toEqual({
+        reason: 'binding-not-declared',
+        dataId: 'a',
+        label: 'Other',
+        property: 'other',
+      });
+    });
+
+    it('C: element-not-found when no element carries the data-id', () => {
+      const code = `<div data-id="a" data-binding="[{label:'Title',property:'title'}]" title="hi">x</div>`;
+      const result = update(code, 'zzz', 'Title', 'new', 'title');
+
+      expect(result.failure).toEqual({
+        reason: 'element-not-found',
+        dataId: 'zzz',
+      });
+    });
+
+    it('D: duplicate-binding when one element declares the property twice', () => {
+      const code = `<div data-id="a" data-binding="[{label:'T1',property:'title'},{label:'T2',property:'title'}]" title="hi">x</div>`;
+      const result = update(code, 'a', 'T1', 'new', 'title');
+
+      expect(result.failure).toEqual({
+        reason: 'duplicate-binding',
+        dataId: 'a',
+        label: 'T1',
+        property: 'title',
+        count: 2,
+      });
+    });
+
+    it('E: no-binding when the element has no data-binding attribute', () => {
+      const code = `<div data-id="a" title="hi">x</div>`;
+      const result = update(code, 'a', 'Title', 'new', 'title');
+
+      expect(result.failure).toEqual({ reason: 'no-binding', dataId: 'a' });
+    });
+
+    it('control: a successful update carries no failure', () => {
+      const result = update(CODE, 'a', 'Text', 'new text', 'innerText');
+
+      expect(result.success).toBe(true);
+      expect(result.failure).toBeUndefined();
     });
   });
 
@@ -436,6 +533,9 @@ describe('bulkUpdate', () => {
 
     expect(result.success).toBe(false);
     expect(result.code).toContain('>bulk text<');
+    expect(result.failures).toEqual([
+      { reason: 'element-not-found', dataId: 'missing' },
+    ]);
   });
 
   it("threads an entry's optional property through to update, same as calling it directly (#240)", () => {

--- a/src/utils/ast/update.ts
+++ b/src/utils/ast/update.ts
@@ -322,9 +322,40 @@ const editAttribute = (
   ];
 };
 
+// Why an edit failed. Before #270 every one of these collapsed into a bare
+// `success: false`, so the panel showed one generic "Failed to update this
+// field / check the console" toast for structurally different problems — and
+// nothing was ever logged, so the console it pointed at was empty. Each
+// variant carries the identifiers a caller needs to name the real fault
+// (usually a wrong `property`/`label` in the element's `data-binding`, not
+// the value the author just typed).
+export type UpdateFailure =
+  | { reason: 'element-not-found'; dataId: string }
+  | { reason: 'no-binding'; dataId: string }
+  | {
+      reason: 'binding-not-declared';
+      dataId: string;
+      label: string;
+      property?: string;
+    }
+  | {
+      reason: 'duplicate-binding';
+      dataId: string;
+      label: string;
+      property?: string;
+      count: number;
+    }
+  | { reason: 'attribute-not-found'; dataId: string; property: string }
+  | { reason: 'parse-error'; error: unknown };
+
 export interface UpdateResult {
   code: string;
   success: boolean;
+  // Present iff `success === false`. `bulkUpdate` reports per-entry failures
+  // via `failures` instead, since one boolean can't say how many of several
+  // entries failed or which ones.
+  failure?: UpdateFailure;
+  failures?: UpdateFailure[];
 }
 
 // `label` is a display string — reworded, duplicated, or translated at
@@ -349,13 +380,15 @@ export const update = (
     });
 
     let changed = false;
+    let failure: UpdateFailure | undefined;
     const edits: SourceEdit[] = [];
 
-    // Records an editor's outcome. `null` is a failure (leave `changed`
-    // alone so the caller sees success: false); anything else counts as
-    // handled, even when it produces no edits.
-    const collect = (result: EditResult) => {
+    // Records an editor's outcome. `null` is a failure — the caller passes
+    // the reason so it isn't discarded; anything else counts as handled,
+    // even when it produces no edits.
+    const collect = (result: EditResult, onNull: () => UpdateFailure) => {
       if (!result) {
+        failure = onNull();
         return;
       }
 
@@ -390,6 +423,7 @@ export const update = (
         );
 
         if (!bindingAttr?.value) {
+          failure = { reason: 'no-binding', dataId };
           return;
         }
 
@@ -400,7 +434,8 @@ export const update = (
         } else if (t.isJSXExpressionContainer(bindingAttr.value)) {
           try {
             bindingValue = generateCode(bindingAttr.value.expression);
-          } catch {
+          } catch (error) {
+            failure = { reason: 'parse-error', error };
             return;
           }
         }
@@ -418,15 +453,31 @@ export const update = (
             : binding.label === label,
         );
 
-        if (matches.length !== 1) {
+        if (matches.length === 0) {
+          failure = { reason: 'binding-not-declared', dataId, label, property };
+          return;
+        }
+
+        if (matches.length > 1) {
+          failure = {
+            reason: 'duplicate-binding',
+            dataId,
+            label,
+            property,
+            count: matches.length,
+          };
           return;
         }
 
         const propertyBinding = matches[0]!;
+        const prop = propertyBinding.property;
 
-        switch (propertyBinding.property) {
+        switch (prop) {
           case BINDING_PROP.INNER_TEXT: {
-            collect(editInnerText(wrapped, path.node, String(value)));
+            collect(editInnerText(wrapped, path.node, String(value)), () => ({
+              reason: 'parse-error',
+              error: new Error(`could not update "${prop}"`),
+            }));
             break;
           }
 
@@ -435,25 +486,32 @@ export const update = (
               propertyBinding.type === 'richtext'
                 ? editRichtext(path.node, String(value))
                 : editInnerHTML(path.node, String(value)),
+              () => ({
+                reason: 'parse-error',
+                error: new Error(`could not update "${prop}"`),
+              }),
             );
             break;
           }
 
           case BINDING_PROP.CHILDREN: {
-            collect(editChildren(path.node, value));
+            // editChildren logs the underlying JSON/AST error itself, so the
+            // console genuinely has details for this path.
+            collect(editChildren(path.node, value), () => ({
+              reason: 'parse-error',
+              error: new Error(`could not update "${prop}"`),
+            }));
             break;
           }
 
           default: {
+            // The declared `property` names a JSX attribute that isn't on
+            // this element — the binding declaration is wrong, not the value.
             collect(
               propertyBinding.type === 'jsx'
-                ? editJsxAttribute(opening, propertyBinding.property, value)
-                : editAttribute(
-                    opening,
-                    propertyBinding.property,
-                    value,
-                    propertyBinding.type,
-                  ),
+                ? editJsxAttribute(opening, prop, value)
+                : editAttribute(opening, prop, value, propertyBinding.type),
+              () => ({ reason: 'attribute-not-found', dataId, property: prop }),
             );
             break;
           }
@@ -462,7 +520,13 @@ export const update = (
     });
 
     if (!changed) {
-      return { code, success: false };
+      return {
+        code,
+        success: false,
+        // No specific reason recorded means the traversal never reached the
+        // target element at all.
+        failure: failure ?? { reason: 'element-not-found', dataId },
+      };
     }
 
     // Patch the original source instead of re-emitting the tree: every byte
@@ -473,7 +537,7 @@ export const update = (
     return { code: unwrap(applyEdits(wrapped, edits)), success: true };
   } catch (error) {
     console.error('❌ Code update error:', error);
-    return { code, success: false };
+    return { code, success: false, failure: { reason: 'parse-error', error } };
   }
 };
 
@@ -487,7 +551,7 @@ export const bulkUpdate = (
   }[],
 ): UpdateResult => {
   let current = raw;
-  let allSucceeded = true;
+  const failures: UpdateFailure[] = [];
 
   for (const entry of entries) {
     const result = update(
@@ -498,8 +562,12 @@ export const bulkUpdate = (
       entry.property,
     );
     current = result.code;
-    allSucceeded = allSucceeded && result.success;
+    if (!result.success && result.failure) {
+      failures.push(result.failure);
+    }
   }
 
-  return { code: current, success: allSucceeded };
+  return failures.length > 0
+    ? { code: current, success: false, failures }
+    : { code: current, success: true };
 };


### PR DESCRIPTION
Closes #270.

## Summary

`update()` collapsed at least five structurally different failures into one `success: false`, and the panel turned every one into the same toast — "Failed to update this field / Check the console for details" — while nothing was ever logged, so the console it pointed at was empty. An author who typo'd a `property` in a `data-binding` got a generic message with no hint that the *binding declaration*, not the value they typed, was at fault.

- **Structured failure reason.** `UpdateResult` gains an optional `failure: UpdateFailure` (present iff `success === false`), a discriminated union: `element-not-found`, `no-binding`, `binding-not-declared`, `duplicate-binding`, `attribute-not-found`, `parse-error`. Each early-return/null path in `update()` now records its specific reason instead of a bare `return`. Exported from `~/utils/ast`. Additive — no existing caller breaks.
- **`bulkUpdate` per-entry failures.** Returns `failures: UpdateFailure[]` so several entries no longer reduce to one boolean.
- **Meaningful toast.** `dnd.tsx` maps the reason to a message that names the offending `property`/`label` and points at the `data-binding`. "Check the console for details" now appears **only** on `parse-error` paths that actually log there (the outer catch and `editChildren`).

Deliberately out of scope (per the issue): parse-time validation of `property` against attributes, and the `items.tsx` toast (being relocated by #247).

## Test plan

- New `describe('failure reasons (#270)')` pins one assertion per cause (A–E) plus a control that a successful update carries no `failure` — matching the issue's repro table.
- Existing exact-match failure assertions updated to include the new `failure`; `bulkUpdate`'s failing-entry test asserts `failures`.
- `pnpm test` → **384 passed** (was 378). `pnpm check-types`, `pnpm lint`, `pnpm build` all clean.