### PR TITLE
Make Dnd's desktop palette/canvas/panel layout resizable via Splitter

### DIFF
--- a/.changeset/feat-jax.md
+++ b/.changeset/feat-jax.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add splitter layout for desktop view, separating palette, canvas, and panel content into resizable panels.

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -17,7 +17,14 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { Button, Drawer, Space, Toast, Typography } from '@jbpark/ui-kit';
+import {
+  Button,
+  Drawer,
+  Space,
+  Splitter,
+  Toast,
+  Typography,
+} from '@jbpark/ui-kit';
 import { useResponsiveSize } from '@jbpark/use-hooks';
 import { LayoutGrid } from 'lucide-react';
 
@@ -510,6 +517,73 @@ const Dnd = ({
     );
   };
 
+  // Shared between the mobile (full-width) and desktop (Splitter middle
+  // panel) layouts below, so the drop target/sortable-list markup isn't
+  // duplicated per branch.
+  const canvas = (
+    <div
+      className="relative h-full w-full overflow-y-auto"
+      data-frame-container
+      style={{
+        isolation: 'isolate',
+        contain: 'layout style',
+        transform: 'translateZ(0)',
+      }}
+    >
+      <Droppable
+        className={cn(
+          !sections.length && 'h-full',
+          //
+        )}
+      >
+        {!sections.length ? (
+          <div
+            className={cn(
+              'flex items-center justify-center',
+              'h-full',
+              'text-gray-500',
+            )}
+          >
+            <Space orientation="vertical" align="center">
+              <Typography.Paragraph>No sections available</Typography.Paragraph>
+              <Typography.Text>
+                {isMobile
+                  ? 'Tap a component to add it'
+                  : 'Drag a component from the left to add it'}
+              </Typography.Text>
+            </Space>
+          </div>
+        ) : (
+          <SortableContext
+            items={sections.map(s => s.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            {sections.map((section, index) => (
+              <Sortable
+                key={section.id}
+                id={section.id}
+                name={section.name}
+                selected={selectedId === section.id}
+                onClick={() => onSelect(section.id)}
+                onDelete={onDelete}
+                onCopy={onCopy}
+              >
+                <Renderer
+                  preview={previews[index]!}
+                  modules={modules}
+                  frame={frame}
+                  dynamicTailwind={dynamicTailwind}
+                  provider={provider}
+                  {...props}
+                />
+              </Sortable>
+            ))}
+          </SortableContext>
+        )}
+      </Droppable>
+    </div>
+  );
+
   return (
     <>
       <DndContext
@@ -525,86 +599,37 @@ const Dnd = ({
       >
         <div
           className={cn(
-            'relative flex w-full',
+            'relative flex h-full w-full',
             className,
             //
           )}
           {...restProps}
         >
-          <div className="hidden w-1/5 overflow-y-auto md:block">
-            <div className="h-full bg-gray-50 p-4">
-              {renderPaletteItems(addItem)}
-            </div>
-          </div>
-          <div
-            className={cn(
-              'relative',
-              'h-full w-full md:w-3/5',
-              'overflow-y-auto',
-              //
-            )}
-            data-frame-container
-            style={{
-              isolation: 'isolate',
-              contain: 'layout style',
-              transform: 'translateZ(0)',
-            }}
-          >
-            <Droppable
-              className={cn(
-                !sections.length && 'h-full',
-                //
-              )}
-            >
-              {!sections.length ? (
-                <div
-                  className={cn(
-                    'flex items-center justify-center',
-                    'h-full',
-                    'text-gray-500',
-                  )}
-                >
-                  <Space orientation="vertical" align="center">
-                    <Typography.Paragraph>
-                      No sections available
-                    </Typography.Paragraph>
-                    <Typography.Text>
-                      {isMobile
-                        ? 'Tap a component to add it'
-                        : 'Drag a component from the left to add it'}
-                    </Typography.Text>
-                  </Space>
+          {isMobile ? (
+            canvas
+          ) : (
+            <Splitter withHandle orientation="horizontal">
+              <Splitter.Panel
+                defaultSize="20%"
+                minSize="15%"
+                maxSize="35%"
+                collapsible
+              >
+                <div className="h-full overflow-y-auto bg-gray-50 p-4">
+                  {renderPaletteItems(addItem)}
                 </div>
-              ) : (
-                <SortableContext
-                  items={sections.map(s => s.id)}
-                  strategy={verticalListSortingStrategy}
-                >
-                  {sections.map((section, index) => (
-                    <Sortable
-                      key={section.id}
-                      id={section.id}
-                      name={section.name}
-                      selected={selectedId === section.id}
-                      onClick={() => onSelect(section.id)}
-                      onDelete={onDelete}
-                      onCopy={onCopy}
-                    >
-                      <Renderer
-                        preview={previews[index]!}
-                        modules={modules}
-                        frame={frame}
-                        dynamicTailwind={dynamicTailwind}
-                        provider={provider}
-                        {...props}
-                      />
-                    </Sortable>
-                  ))}
-                </SortableContext>
-              )}
-            </Droppable>
-          </div>
-          <div className="hidden w-1/5 md:block">{renderPanelContent()}</div>
+              </Splitter.Panel>
+              <Splitter.Panel defaultSize="60%">{canvas}</Splitter.Panel>
+              <Splitter.Panel
+                defaultSize="20%"
+                minSize="15%"
+                maxSize="35%"
+                collapsible
+              >
+                {renderPanelContent()}
+              </Splitter.Panel>
+            </Splitter>
+          )}
           <Button
             type="primary"
             shape="circle"

--- a/src/pages/editor/index.tsx
+++ b/src/pages/editor/index.tsx
@@ -121,9 +121,9 @@ const App = () => {
                 orientation={isMobile ? 'vertical' : 'horizontal'}
               >
                 <Splitter.Panel
-                  defaultSize={50}
-                  minSize={20}
-                  maxSize={80}
+                  defaultSize="50%"
+                  minSize="20%"
+                  maxSize="80%"
                   collapsible
                 >
                   <div className="h-full overflow-auto p-2">

--- a/website/src/components/PreviewModesDemo.module.css
+++ b/website/src/components/PreviewModesDemo.module.css
@@ -1,0 +1,33 @@
+/**
+ * Plain hand-written CSS rather than Tailwind utility classes: this site
+ * doesn't run its own Tailwind build (see src/pages/index.module.css), so
+ * utility classes used here would only render if live-editor's own compiled
+ * style.css happened to include them too.
+ */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+
+@media screen and (min-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.label {
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.box {
+  height: 16rem;
+  overflow: hidden;
+  border-radius: var(--radius, var(--ifm-global-radius));
+  border: 1px solid var(--border, var(--ifm-color-emphasis-300));
+}

--- a/website/src/components/PreviewModesDemo.tsx
+++ b/website/src/components/PreviewModesDemo.tsx
@@ -1,6 +1,8 @@
 import Preview from '@jbpark/live-editor/preview';
 import Context from '@jbpark/live-editor/provider';
 
+import styles from './PreviewModesDemo.module.css';
+
 const SAMPLE_CODE = `
 import * as ui from 'ui-kit';
 
@@ -21,14 +23,11 @@ export default App;
 // wired to an editor), so #164's threat model doesn't apply here the way it
 // does for the editor-mode/custom-editor/dnd demos. See #206.
 const PreviewModesDemo = () => {
-  const label = 'mb-1 text-sm font-semibold text-gray-700';
-  const box = 'h-64 overflow-hidden rounded-lg border border-gray-200';
-
   return (
-    <div className="grid grid-cols-1 gap-4 p-4 md:grid-cols-2">
+    <div className={styles.grid}>
       <div>
-        <div className={label}>iframe</div>
-        <div className={box}>
+        <div className={styles.label}>iframe</div>
+        <div className={styles.box}>
           <Context>
             <Preview
               code={SAMPLE_CODE}
@@ -39,8 +38,8 @@ const PreviewModesDemo = () => {
         </div>
       </div>
       <div>
-        <div className={label}>shadow</div>
-        <div className={box}>
+        <div className={styles.label}>shadow</div>
+        <div className={styles.box}>
           <Context>
             <Preview
               code={SAMPLE_CODE}


### PR DESCRIPTION
## Summary
- Make Dnd's desktop palette/canvas/panel layout resizable via `Splitter`
- Fix `Splitter.Panel` size properties to use percentage values
- Replace raw tailwind classes in `PreviewModesDemo` with a CSS module

## Test plan
- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gx1xtBkrPSafsXZ9HSgGiE