### PR TITLE
Add richtext example bindings and fix JSX item duplication

### DIFF
--- a/.changeset/feat-richtext-example-template.md
+++ b/.changeset/feat-richtext-example-template.md
@@ -1,0 +1,5 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Add fallback editor for JSX-valued properties without bindings, enabling raw source editing.

--- a/src/components/dnd/panel/items.tsx
+++ b/src/components/dnd/panel/items.tsx
@@ -44,6 +44,11 @@ interface ItemData {
   elementIndex: number;
   editableProperties: Record<string, ItemProperty>;
   jsxBindings: Record<string, DataAttrNode[]>;
+  // JSX-valued properties (e.g. `label`) whose `jsxBindings` extraction came
+  // back empty — no editable binding found inside them at all. Rather than
+  // silently dropping them, the panel falls back to a raw CodeMirror editor
+  // for the property's source, keyed by property name here. See #298.
+  jsxFallbacks: Record<string, string>;
 }
 
 interface PrimitiveItem {
@@ -160,12 +165,13 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
       }
 
       const jsxBindings: Record<string, DataAttrNode[]> = {};
+      const jsxFallbacks: Record<string, string> = {};
 
       element.properties.forEach(prop => {
         if (
           !t.isObjectProperty(prop) ||
           !t.isIdentifier(prop.key) ||
-          !t.isJSXElement(prop.value)
+          !(t.isJSXElement(prop.value) || t.isJSXFragment(prop.value))
         ) {
           return;
         }
@@ -199,6 +205,8 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
 
           if (bindings.length > 0) {
             jsxBindings[propertyName] = bindings;
+          } else {
+            jsxFallbacks[propertyName] = jsxCode;
           }
         } catch (error) {
           console.error(
@@ -214,6 +222,7 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
         elementIndex,
         editableProperties: extractObjectProperties(element),
         jsxBindings,
+        jsxFallbacks,
       });
     });
 
@@ -590,34 +599,63 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
             ))}
           </div>
           <div className="space-y-3 border-t pt-2">
-            {Object.entries(item.jsxBindings).length > 0 ? (
-              Object.entries(item.jsxBindings).map(
-                ([propertyName, bindings]) => (
-                  <div key={propertyName} className="space-y-2">
-                    <div className="text-xs font-medium text-blue-700">
-                      {propertyName} Bindings ({bindings.length}):
-                    </div>
-                    {bindings.map((bindingNode, idx) => {
-                      const nodeId = bindingNode.dataAttributes.find(
-                        a => a.name === 'data-id',
-                      )?.value;
+            {Object.entries(item.jsxBindings).length > 0 ||
+            Object.entries(item.jsxFallbacks).length > 0 ? (
+              <>
+                {Object.entries(item.jsxBindings).map(
+                  ([propertyName, bindings]) => (
+                    <div key={propertyName} className="space-y-2">
+                      <div className="text-xs font-medium text-blue-700">
+                        {propertyName} Bindings ({bindings.length}):
+                      </div>
+                      {bindings.map((bindingNode, idx) => {
+                        const nodeId = bindingNode.dataAttributes.find(
+                          a => a.name === 'data-id',
+                        )?.value;
 
-                      return (
-                        <div
-                          key={`binding-${item.id}-${propertyName}-${nodeId || idx}`}
-                          className="rounded border border-blue-100 bg-blue-50
-                            p-2"
-                        >
-                          <div className="mb-1 text-xs text-blue-600">
-                            &lt;{bindingNode.tagName || 'element'}&gt;
+                        return (
+                          <div
+                            key={`binding-${item.id}-${propertyName}-${nodeId || idx}`}
+                            className="rounded border border-blue-100 bg-blue-50
+                              p-2"
+                          >
+                            <div className="mb-1 text-xs text-blue-600">
+                              &lt;{bindingNode.tagName || 'element'}&gt;
+                            </div>
+                            <Node data={bindingNode} onChange={onChildChange} />
                           </div>
-                          <Node data={bindingNode} onChange={onChildChange} />
-                        </div>
-                      );
-                    })}
-                  </div>
-                ),
-              )
+                        );
+                      })}
+                    </div>
+                  ),
+                )}
+                {Object.entries(item.jsxFallbacks).map(
+                  ([propertyName, code]) => (
+                    <div key={propertyName} className="space-y-2">
+                      <div className="text-xs font-medium text-blue-700">
+                        {propertyName}
+                      </div>
+                      <Field
+                        binding={{
+                          id: `item-${item.id}-${propertyName}-jsx`,
+                          label: propertyName,
+                          property: propertyName,
+                          type: 'jsx',
+                          value: code,
+                          rawValue: code,
+                          onChange: next =>
+                            updateProperty(
+                              item.elementIndex,
+                              propertyName,
+                              next,
+                            ),
+                        }}
+                        onNodeChange={onChildChange}
+                      />
+                    </div>
+                  ),
+                )}
+              </>
             ) : (
               <div className="text-xs text-gray-500">
                 ✓ No JSX bindings found

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -413,7 +413,7 @@ export const DRAGGABLE_ITEMS: Section[] = [
           data-binding={[
             {
               label: 'Description 1',
-              property: 'innerText',
+              type: 'richtext',
             },
           ]}
           className={cn(
@@ -431,7 +431,7 @@ export const DRAGGABLE_ITEMS: Section[] = [
           data-binding={[
             {
               label: 'Description 2',
-              property: 'innerText',
+              type: 'richtext',
             },
           ]}
           className={cn(
@@ -1151,7 +1151,7 @@ export const DRAGGABLE_ITEMS: Section[] = [
                     data-binding={[
                       {
                         label: 'Answer 1',
-                        property: 'innerText',
+                        type: 'richtext',
                       },
                     ]}
                     className={cn('text-gray-600')}
@@ -1184,7 +1184,7 @@ export const DRAGGABLE_ITEMS: Section[] = [
                     data-binding={[
                       {
                         label: 'Answer 2',
-                        property: 'innerText',
+                        type: 'richtext',
                       },
                     ]}
                     className={cn('text-gray-600')}
@@ -1217,7 +1217,7 @@ export const DRAGGABLE_ITEMS: Section[] = [
                     data-binding={[
                       {
                         label: 'Answer 3',
-                        property: 'innerText',
+                        type: 'richtext',
                       },
                     ]}
                     className={cn('text-gray-600')}
@@ -1250,7 +1250,7 @@ export const DRAGGABLE_ITEMS: Section[] = [
                     data-binding={[
                       {
                         label: 'Answer 4',
-                        property: 'innerText',
+                        type: 'richtext',
                       },
                     ]}
                     className={cn('text-gray-600')}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -130,7 +130,7 @@ export const DRAGGABLE_ITEMS: Section[] = [
             data-binding={[
               {
                 label: 'Description',
-                property: 'innerText',
+                type: 'richtext',
               },
             ]}
             className={cn(
@@ -138,7 +138,7 @@ export const DRAGGABLE_ITEMS: Section[] = [
               //
             )}
           >
-            Build dynamic components with drag & drop
+            Build <strong>dynamic components</strong> with drag & drop
           </p>
           <ui.Button
             data-id=""

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -825,6 +825,8 @@ export const DRAGGABLE_ITEMS: Section[] = [
           )}
         >
           <h2
+            data-id=""
+            data-binding={[{ label: 'Title', property: 'innerText' }]}
             className={cn(
               'mb-12 text-center text-4xl font-bold text-gray-800',
               //

--- a/src/utils/ast/items.test.ts
+++ b/src/utils/ast/items.test.ts
@@ -88,6 +88,16 @@ describe('updateArrayItemProperty', () => {
     ).toContain('icon: <New a={1 > 0} />');
   });
 
+  // The items panel's fallback editor (see #298) edits a JSX-valued
+  // property's raw source with no `render` declaration for it — the current
+  // AST value being JSX has to be enough to route the commit through the
+  // jsx parse path instead of the scalar-string one.
+  it('parses a jsx value with no render declaration, from its current JSX value', () => {
+    expect(
+      updateArrayItemProperty(WITH_JSX, 0, 'icon', '<New a={1 > 0} />'),
+    ).toContain('icon: <New a={1 > 0} />');
+  });
+
   it('treats a non-markup jsx value as a plain string', () => {
     expect(
       updateArrayItemProperty(WITH_JSX, 0, 'icon', 'plain text', jsxRender),

--- a/src/utils/ast/items.ts
+++ b/src/utils/ast/items.ts
@@ -177,7 +177,16 @@ const buildPropertyValue = (
     );
   }
 
-  if (renderLeaf?.type === 'jsx') {
+  // A declared `render[key].type === 'jsx'` covers a schema-declared JSX
+  // property; a property whose *current* value is already JSX (e.g. the
+  // items panel's fallback editor for a JSX-valued property with no
+  // extractable bindings, see #298) needs the same treatment even without
+  // that declaration, so it round-trips as JSX rather than as a string.
+  if (
+    renderLeaf?.type === 'jsx' ||
+    t.isJSXElement(current) ||
+    t.isJSXFragment(current)
+  ) {
     const trimmed = String(value).trim();
 
     // Anything that isn't markup is a plain string for this property.

--- a/src/utils/ast/value.test.ts
+++ b/src/utils/ast/value.test.ts
@@ -241,6 +241,20 @@ describe('extractObjectProperties', () => {
     expect(properties.a).toMatchObject({ type: 'number', value: 1 });
     expect(properties.b).toMatchObject({ type: 'string', value: 'x' });
   });
+
+  // See #298: a JSX-valued property (e.g. `label`) used to fall through to
+  // `extractNodeValue`, which stringifies the whole subtree into a raw-source
+  // textarea that duplicated `items.tsx`'s own jsxBindings/fallback editor.
+  it('skips any JSX- or fragment-valued property, not just children', () => {
+    const ast = parseExpression(
+      '{a: 1, label: <span>hi</span>, note: <>hi</>, b: "x"}',
+      { plugins: ['jsx'] },
+    ) as t.ObjectExpression;
+
+    const properties = extractObjectProperties(ast);
+
+    expect(Object.keys(properties).sort()).toEqual(['a', 'b']);
+  });
 });
 
 describe('arrayExpressionToCode', () => {

--- a/src/utils/ast/value.ts
+++ b/src/utils/ast/value.ts
@@ -466,7 +466,15 @@ export const extractObjectProperties = (
     if (t.isObjectProperty(prop) && t.isIdentifier(prop.key)) {
       const key = prop.key.name;
 
-      if (key === 'children') {
+      // `children` and any other JSX-valued property (e.g. `label`) are
+      // handled separately, via `items.tsx`'s `jsxBindings`/fallback
+      // extraction, which parses the JSX subtree properly instead of
+      // stringifying it into a raw-source textarea. See #298.
+      if (
+        key === 'children' ||
+        t.isJSXElement(prop.value) ||
+        t.isJSXFragment(prop.value)
+      ) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- Switch the Hero section's Description binding to `type: 'richtext'` and seed it with an inline `<strong>` tag so the formatting toolbar is exercised as soon as the section is added
- Switch About's two Description bindings and FAQ's four Answer bindings from `property: 'innerText'` to `type: 'richtext'` for their longer, multi-sentence copy
- Fix #298: a JSX-valued item property (e.g. FAQ's `label`) no longer duplicates as a raw-source textarea alongside the panel's clean `jsxBindings` view; a JSX property with no extractable bindings now falls back to a syntax-aware CodeMirror editor instead of a plain textarea or being silently dropped
- Add a `Title (innerText)` binding to the Key Features example, which previously had no bindings at all

## Test plan
- [x] `pnpm check-types`
- [x] `pnpm test` (386 passing, including 2 new cases covering the JSX-skip in `extractObjectProperties` and the render-less JSX commit round-trip)
- [x] Verified in the browser (Drag & Drop mode): Hero/About/FAQ richtext fields render the RichTextEditor toolbar with original text intact; FAQ's `label` now shows only the clean "Bindings" view with no duplicate raw-source field; a JSX `label` with no bindings renders the CodeMirror fallback editor and edits round-trip correctly; Key Features now shows a Title binding

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HefgCVEnJbWok41uGauAy3