### PR TITLE
🔧 chore: trim published dependencies (#282 items 1-2)

### DIFF
--- a/.changeset/deps-hygiene.md
+++ b/.changeset/deps-hygiene.md
@@ -1,0 +1,7 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Trim published dependencies: drop the unused `uuid` runtime dependency and move
+the build-time `@tailwindcss/vite` plugin to devDependencies. Neither is
+imported from `src/`, so consumers no longer install them.

--- a/package.json
+++ b/package.json
@@ -108,13 +108,11 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@jbpark/ui-kit": "^7.1.0",
     "@jbpark/use-hooks": "^4.0.1",
-    "@tailwindcss/vite": "^4.3.3",
     "@uiw/codemirror-theme-vscode": "^4.25.11",
     "@uiw/react-codemirror": "^4.25.11",
     "lucide-react": "^1.31.0",
     "prettier": "^3.9.6",
     "tailwindcss": "^4.3.3",
-    "uuid": "^14.0.1",
     "zod": "^4.4.3"
   },
   "peerDependencies": {
@@ -124,6 +122,7 @@
   "devDependencies": {
     "@changesets/cli": "^3.0.0",
     "@eslint/js": "^9.39.5",
+    "@tailwindcss/vite": "^4.3.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.3",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       '@jbpark/use-hooks':
         specifier: ^4.0.1
         version: 4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tailwindcss/vite':
-        specifier: ^4.3.3
-        version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
       '@uiw/codemirror-theme-vscode':
         specifier: ^4.25.11
         version: 4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)
@@ -57,9 +54,6 @@ importers:
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
-      uuid:
-        specifier: ^14.0.1
-        version: 14.0.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -70,6 +64,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.5
         version: 9.39.5
+      '@tailwindcss/vite':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.2)(jiti@2.7.0)(yaml@2.9.0))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -3648,10 +3645,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
-    hasBin: true
-
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
     peerDependencies:
@@ -7158,8 +7151,6 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:
       react: 19.2.8
-
-  uuid@14.0.1: {}
 
   vaul@1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
Part of #282 (items 1 and 2 — the safe manifest-only edits the issue groups together). Items 3 (`prettier` → optional peer, a behaviour change) and 4 (`.npmrc` + a CI dep linter) are deliberately left for follow-ups, so this does not close the issue.

## Summary

Both packages are declared but never enter `dist`, so every consumer of `@jbpark/live-editor` installs them for nothing.

- **Remove `uuid`** from `dependencies`. It has no `import` anywhere in `src/` — the only occurrence in the tree is a stale mention inside a comment.
- **Move `@tailwindcss/vite`** from `dependencies` to `devDependencies`. It's a build-time Vite plugin used only by `vite.config.ts` and `demos/vite.config.ts`; nothing under `src/` imports it. (Distinct from `tailwindcss` itself, which *is* imported from `src/` and stays a runtime dep.)
- Lockfile updated.

## Test plan

- `uuid` gone from the manifest; `@tailwindcss/vite` present in `devDependencies` only.
- `pnpm lint`, `pnpm check-types`, `pnpm test` (386 passed), `pnpm build` all clean.
- `pnpm build:demos` passes — exercises `demos/vite.config.ts`, which imports `@tailwindcss/vite` from devDependencies, confirming the move didn't break the demo build.

No `src/`/`dist` code changes; the published `dependencies` list shrinks.