### PR TITLE
♻️ refactor: make prettier an optional peer dependency (#282 item 3)

### DIFF
--- a/.changeset/prettier-optional-peer.md
+++ b/.changeset/prettier-optional-peer.md
@@ -1,0 +1,9 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Make `prettier` an optional peer dependency. Only the `editor` subpath uses it
+(for format-on-save), so consumers who don't need formatting no longer install
+~9.6 MB. `useFormatCode` now loads prettier lazily and, when it's absent,
+returns the code unformatted instead of throwing. Install `prettier` (>=3)
+alongside `@jbpark/live-editor` to keep format-on-save.

--- a/package.json
+++ b/package.json
@@ -111,13 +111,18 @@
     "@uiw/codemirror-theme-vscode": "^4.25.11",
     "@uiw/react-codemirror": "^4.25.11",
     "lucide-react": "^1.31.0",
-    "prettier": "^3.9.6",
     "tailwindcss": "^4.3.3",
     "zod": "^4.4.3"
   },
   "peerDependencies": {
+    "prettier": "^3.0.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "prettier": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@changesets/cli": "^3.0.0",
@@ -141,6 +146,7 @@
     "husky": "^9.1.7",
     "jsdom": "^30.0.1",
     "lint-staged": "^17.3.0",
+    "prettier": "^3.9.6",
     "prettier-plugin-classnames": "^0.10.4",
     "prettier-plugin-merge": "^0.10.1",
     "prettier-plugin-tailwindcss": "^0.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
-      prettier:
-        specifier: ^3.9.6
-        version: 3.9.6
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -121,6 +118,9 @@ importers:
       lint-staged:
         specifier: ^17.3.0
         version: 17.3.0
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
       prettier-plugin-classnames:
         specifier: ^0.10.4
         version: 0.10.4(prettier@3.9.6)

--- a/src/components/editor/use-format-code.test.tsx
+++ b/src/components/editor/use-format-code.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('useFormatCode', () => {
+  it('returns the code unformatted when prettier is not installed (optional peer)', async () => {
+    // Simulate the peer being absent: the dynamic import rejects, and the
+    // hook must degrade to returning the source untouched rather than throw.
+    vi.doMock('prettier', () => {
+      throw new Error("Cannot find package 'prettier'");
+    });
+
+    const { useFormatCode } = await import('./use-format-code');
+    const { result } = renderHook(() => useFormatCode());
+
+    const input = 'const  x=1';
+    const out = await result.current(input);
+
+    expect(out).toBe(input);
+
+    vi.doUnmock('prettier');
+    // Generous timeout: the first import pulls the ~/utils barrel
+    // (@babel/standalone + ui-kit) through Vite's transform, which is slow the
+    // first time but has nothing to do with the assertion.
+  }, 30000);
+});

--- a/src/components/editor/use-format-code.ts
+++ b/src/components/editor/use-format-code.ts
@@ -1,11 +1,24 @@
 import { useCallback, useMemo } from 'react';
 
-import * as prettier from 'prettier';
-import prettierPluginBabel from 'prettier/plugins/babel';
-import prettierPluginEstree from 'prettier/plugins/estree';
-import prettierPluginTypeScript from 'prettier/plugins/typescript';
-
 import { detectTypeScript } from '~/utils';
+
+// prettier is an optional peer dependency (#282): the editor subpath is the
+// only thing that needs it, so consumers who don't use format-on-save
+// shouldn't have to install ~9.6 MB. It's loaded lazily below and its absence
+// degrades gracefully (the code is returned unformatted) instead of throwing.
+const loadPrettier = async () => {
+  const [prettier, babel, estree, typescript] = await Promise.all([
+    import('prettier'),
+    import('prettier/plugins/babel'),
+    import('prettier/plugins/estree'),
+    import('prettier/plugins/typescript'),
+  ]);
+
+  return {
+    format: prettier.format,
+    plugins: [babel.default, estree.default, typescript.default],
+  };
+};
 
 const DEFAULT_PRETTIER_OPTIONS: Record<string, unknown> = {
   tabWidth: 2,
@@ -40,13 +53,20 @@ export const useFormatCode = ({
     async (code: string) => {
       const isTypeScript = detectTypeScript(code);
       const source = fragment ? `<>${code}</>` : code;
+
+      // Only a missing prettier is swallowed here; a genuine format error
+      // (prettier present, but the code is unparseable) still propagates so
+      // the editor's Cmd+S path can surface it via onError.
+      let prettier: Awaited<ReturnType<typeof loadPrettier>>;
+      try {
+        prettier = await loadPrettier();
+      } catch {
+        return code;
+      }
+
       const formatted = await prettier.format(source, {
         parser: isTypeScript ? 'typescript' : 'babel',
-        plugins: [
-          prettierPluginBabel,
-          prettierPluginEstree,
-          prettierPluginTypeScript,
-        ],
+        plugins: prettier.plugins,
         ...prettierConfig,
       });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,5 +17,14 @@ export default defineConfig({
     // collected nothing for `.test.tsx`, so a component test would report
     // "0 failures" while never actually running (#277).
     include: ['src/**/*.test.{ts,tsx}'],
+    // @jbpark/ui-kit ships CSS side-effect imports (e.g. swiper.css). Left
+    // externalized, Node's ESM loader throws "Unknown file extension .css";
+    // inlining routes it through Vite so the CSS resolves to an empty module.
+    // Needed by any hook/component test that reaches ui-kit via ~/utils.
+    server: {
+      deps: {
+        inline: [/@jbpark\/ui-kit/],
+      },
+    },
   },
 });


### PR DESCRIPTION
Part of #282 (item 3). Item 4 (`.npmrc` `shamefully-hoist` + a CI dep linter) remains a separate follow-up, so this does not close the issue.

## Summary

`prettier` (9.6 MB installed) was a hard `dependency`, but only the `editor` subpath uses it — for format-on-save in `useFormatCode`. Consumers using only `/dnd`, `/preview`, etc. downloaded it for nothing. Confirmed as the wanted direction (format-on-save is treated as opt-in, not core).

- **`prettier` → optional peer.** Moved from `dependencies` to `peerDependencies` (`^3.0.0`) with `peerDependenciesMeta.prettier.optional = true`. Kept as a `devDependency` so the repo's own tooling (lint-staged `prettier --write`, tests) is unaffected.
- **Graceful degrade.** `useFormatCode` now loads prettier + its plugins lazily via dynamic `import()`. If the peer is absent, it returns the code **unformatted** instead of throwing. A real format error (prettier present, code unparseable) still propagates, so `core.tsx`'s Cmd+S `onError` path is unchanged.
- **Test.** Adds a jsdom test that mocks prettier's import to fail and asserts the source comes back untouched.
- **Test infra.** `vitest.config.ts` inlines `@jbpark/ui-kit` so its CSS side-effect imports (e.g. `swiper.css`) resolve through Vite — Node's ESM loader otherwise throws `Unknown file extension ".css"` for any hook test that reaches `~/utils`.

## Test plan

- `pnpm check-types`, `pnpm lint`, `pnpm test` (387 passed, incl. the new degrade test), `pnpm build` all clean.
- `dist` inspection: prettier stays a dynamic **external** import (`import("prettier")`, `.../plugins/*`) — not inlined; `dist` size unchanged (~6 MB, dominated by @babel/standalone).
- `prettier` gone from `dependencies`; present as optional peer + devDependency.

## Consumer note

To keep format-on-save, install `prettier` (>=3) alongside `@jbpark/live-editor`. Without it, the editor still works and simply skips formatting.