### PR TITLE
📝 docs: add LICENSE and consumer README, fix doc drift (#279, #281)

### DIFF
--- a/.changeset/docs-license.md
+++ b/.changeset/docs-license.md
@@ -1,0 +1,9 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Add a `LICENSE` file (MIT) and a consumer-facing README. The README now
+documents installation, a minimal usage example with the required
+`@jbpark/live-editor/style.css` import, and the subpath entry points; the
+structure diagrams and `AGENTS.md` paths were also corrected to match the
+current source layout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,12 @@ Canvas의 DnD 편집 결과를 Babel AST 변환으로 소스 코드에 역으로
 ```text
 live-editor/
 ├─ .github/
-│  ├─ skills/               # AI 스킬 파일 (component, ast, review, refactor, doc, pr-summary)
-│  └─ copilot-instructions.md  # GitHub Copilot 프로젝트 지침
+│  ├─ skills/ast/           # Babel AST 변환 스킬 (SKILL.md)
+│  ├─ scripts/              # changeset/릴리즈 노트 자동화 스크립트 (*.mjs)
+│  └─ workflows/            # CI, changeset-draft, version, publish, release
+├─ .claude/
+│  ├─ skills/               # 코딩 컨벤션/설계 스킬 (아래 "관련 스킬 파일" 참고)
+│  └─ commands/             # publish-check.md
 ├─ src/
 │  ├─ components/
 │  │  ├─ context/           # 전역 상태 (PreviewContext, ErrorContext)
@@ -21,31 +25,40 @@ live-editor/
 │  │  │  ├─ draggable.tsx   # 드래그 가능한 섹션 아이템
 │  │  │  ├─ droppable.tsx   # 드롭 영역
 │  │  │  ├─ sortable.tsx    # 정렬 가능한 리스트
-│  │  │  └─ overlay.tsx     # 드래그 인디케이터
-│  │  ├─ editor/            # CodeMirror 코드 에디터 (core.tsx)
+│  │  │  ├─ overlay.tsx     # 드래그 인디케이터
+│  │  │  └─ use-section-document.ts  # 섹션 문서 상태 훅
+│  │  ├─ editor/            # CodeMirror 코드 에디터 (core.tsx, use-format-code.ts)
 │  │  ├─ error/             # 에러 처리 (boundary.tsx, guard.tsx, runtime.tsx)
-│  │  ├─ frame/             # 미리보기 컨테이너 (iframe.tsx, shadow.tsx)
-│  │  └─ preview/           # 컴파일 + 렌더링 (client.tsx)
+│  │  ├─ frame/             # 미리보기 컨테이너 (iframe.tsx, shadow.tsx, measure.ts, viewport-units.ts)
+│  │  └─ preview/           # 컴파일 + 렌더링 (client.tsx, use-compiled-module.ts, use-dynamic-tailwind.ts)
 │  ├─ pages/
-│  │  ├─ playground/        # 메인 에디터 페이지
-│  │  └─ preview/           # 풀스크린 미리보기 페이지
+│  │  └─ editor/            # 로컬 개발용 에디터 페이지 (index.tsx = 앱 레이아웃, Editor/DnD 토글)
 │  ├─ utils/
 │  │  ├─ index.ts           # compile(), cn(), baseModules 등 핵심 유틸
+│  │  ├─ cache.ts           # 바운디드 LRU 캐시
+│  │  ├─ selection.ts       # 다중 선택 헬퍼
 │  │  ├─ ast/               # Babel AST 조작 유틸 (파이프라인 단계별 분리, index.ts는 재수출 배럴)
 │  │  │  ├─ types.ts        # DataAttrNode, BindingItem 등 타입 정의
 │  │  │  ├─ helpers.ts      # wrap/unwrap/attrValue/generateCode (여러 단계 공용)
 │  │  │  ├─ binding.ts      # parseBinding(), getCurrentValue(), findEditableChildren()
 │  │  │  ├─ value.ts        # JS 값 ↔ AST 리터럴 변환 (extractNodeValue 등)
 │  │  │  ├─ extract.ts      # raw JSX 문자열 → DataAttrNode 트리 (extract())
+│  │  │  ├─ document.ts     # 문서 파싱/섹션 분리/미리보기 생성 (traverse)
+│  │  │  ├─ items.ts        # 배열 아이템 편집 (추가/이동/삭제)
+│  │  │  ├─ patch.ts        # 소스 스팬 기반 부분 편집 적용 (applyEdits)
 │  │  │  ├─ update.ts       # 값 → AST 반영 (update(), bulkUpdate())
+│  │  │  ├─ validate.ts     # 바인딩 값 검증
 │  │  │  └─ tree.ts         # replaceIds()/fillIds()/clone()
 │  │  └─ tailwind/          # Tailwind 관련 유틸
 │  ├─ constants/index.ts    # 상수, 정규식, 기본 템플릿
 │  ├─ types/index.ts        # TypeScript 타입 정의
-│  ├─ App.tsx               # 앱 레이아웃 (Editor/DnD 모드 토글)
 │  └─ main.tsx              # 진입점
+├─ demos/                   # 문서용 독립 iframe 데모
+├─ website/                 # Docusaurus 문서 사이트
+├─ .changeset/              # changesets (버전/체인지로그)
 ├─ package.json
 ├─ vite.config.ts
+├─ vitest.config.ts         # 테스트 설정
 ├─ tsdown.config.ts         # 라이브러리 빌드 설정
 └─ tsconfig.app.json
 ```
@@ -124,8 +137,12 @@ live-editor/
 ```bash
 pnpm dev           # Vite 개발 서버 (HMR)
 pnpm build         # 타입 체크 + 라이브러리 빌드 (tsdown)
+pnpm build:demos   # 문서용 iframe 데모 빌드
 pnpm check-types   # tsc -b 타입 체크만
 pnpm lint          # ESLint
+pnpm test          # Vitest 1회 실행
+pnpm test:watch    # Vitest watch 모드
+pnpm bench         # Vitest 벤치마크
 pnpm preview       # 빌드 결과 미리보기
 ```
 
@@ -157,12 +174,14 @@ pnpm preview       # 빌드 결과 미리보기
 
 ## 🔗 관련 스킬 파일
 
-| 스킬       | 경로                                 | 설명                     |
-| ---------- | ------------------------------------ | ------------------------ |
-| commit     | `.github/skills/commit/SKILL.md`     | 커밋 메시지 생성         |
-| component  | `.github/skills/component/SKILL.md`  | React 컴포넌트 추가      |
-| ast        | `.github/skills/ast/SKILL.md`        | Babel AST 변환 코드 작성 |
-| review     | `.github/skills/review/SKILL.md`     | 코드 리뷰                |
-| refactor   | `.github/skills/refactor/SKILL.md`   | 코드 리팩토링            |
-| doc        | `.github/skills/doc/SKILL.md`        | JSDoc/문서 생성          |
-| pr-summary | `.github/skills/pr-summary/SKILL.md` | PR Summary/Changes 생성  |
+| 스킬                  | 경로                                            | 설명                        |
+| --------------------- | ----------------------------------------------- | --------------------------- |
+| ast                   | `.github/skills/ast/SKILL.md`                   | Babel AST 변환 코드 작성    |
+| coding-style          | `.claude/skills/coding-style/SKILL.md`          | 코딩 스타일/컨벤션          |
+| component-naming      | `.claude/skills/component-naming/SKILL.md`      | 컴포넌트/파일 네이밍        |
+| composition-patterns  | `.claude/skills/composition-patterns/SKILL.md`  | 컴포넌트 합성 패턴          |
+| react-best-practices  | `.claude/skills/react-best-practices/SKILL.md`  | React 베스트 프랙티스       |
+| version-management    | `.claude/skills/version-management/SKILL.md`    | 버전/changeset 관리         |
+| web-design-guidelines | `.claude/skills/web-design-guidelines/SKILL.md` | 웹 디자인 가이드라인        |
+| writing-guidelines    | `.claude/skills/writing-guidelines/SKILL.md`    | 문서/텍스트 작성 가이드라인 |
+| publish-check         | `.claude/commands/publish-check.md`             | 배포 전 점검 커맨드         |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 jbpark
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ko.md
+++ b/README.ko.md
@@ -12,20 +12,25 @@
 live-editor/
 ├─ src/
 │  ├─ components/
-│  │  ├─ Context/           # 전역 상태 관리
-│  │  ├─ Dnd/               # 드래그 앤 드롭 시스템 및 편집 패널
-│  │  ├─ Editor/             # 코드 에디터
-│  │  ├─ Error/              # 에러 바운더리
-│  │  ├─ Frame/              # iframe/shadow DOM 프리뷰 격리
-│  │  └─ Preview/            # 격리된 프리뷰 런타임
+│  │  ├─ context/            # 전역 상태 관리
+│  │  ├─ dnd/                # 드래그 앤 드롭 시스템 및 편집 패널
+│  │  │  └─ panel/           # 속성 패널 필드 에디터
+│  │  ├─ editor/             # CodeMirror 코드 에디터
+│  │  ├─ error/             # 에러 바운더리
+│  │  ├─ frame/             # iframe/shadow DOM 프리뷰 격리
+│  │  └─ preview/           # 격리된 프리뷰 런타임
 │  ├─ pages/
-│  │  └─ Editor/              # 로컬 개발용 에디터 (에디터 + DnD 전환)
-│  ├─ utils/ast/             # AST 조작 및 코드 생성
-│  ├─ constants/             # 상수 및 설정
-│  ├─ types/                 # TypeScript 타입 정의
-│  └─ main.tsx                # 로컬 개발 앱 엔트리
-├─ demos/                     # 문서용 독립 iframe 데모
-├─ website/                   # Docusaurus 문서 사이트
+│  │  └─ editor/            # 로컬 개발용 에디터 (에디터 + DnD 전환)
+│  ├─ utils/
+│  │  ├─ ast/               # AST 조작 및 코드 생성
+│  │  ├─ tailwind/          # Tailwind 테마 헬퍼
+│  │  ├─ cache.ts           # 바운디드 LRU 캐시
+│  │  └─ selection.ts       # 다중 선택 헬퍼
+│  ├─ constants/            # 상수 및 설정
+│  ├─ types/                # TypeScript 타입 정의
+│  └─ main.tsx              # 로컬 개발 앱 엔트리
+├─ demos/                   # 문서용 독립 iframe 데모
+├─ website/                 # Docusaurus 문서 사이트
 └─ package.json
 ```
 
@@ -37,6 +42,76 @@ live-editor/
 - **스마트 Items 에디터**: 배열 아이템을 추가/이동/삭제하고, 일반 속성과 중첩된 JSX 컴포넌트를 편집합니다. 순서 변경 시에도 안정적인 컴포넌트 ID를 유지합니다.
 - **프리뷰 런타임**: 컴파일된 결과를 DOM/CSS 격리를 위해 iframe 안에서 렌더링합니다 (보안 샌드박스는 아닙니다 — [보안 참고사항](#-보안-참고사항) 참고).
 - **강력한 드래그 앤 드롭**: `@dnd-kit` 기반으로 부드러운 정렬과 배치를 지원합니다.
+
+## 📦 설치
+
+```bash
+pnpm add @jbpark/live-editor react react-dom
+```
+
+`react`와 `react-dom`(>= 19)은 peer dependency입니다. `prettier`(>= 3)는 선택적
+peer로, 에디터의 저장 시 포맷(format-on-save)을 쓰려면 함께 설치하세요. 없어도
+에디터는 정상 동작하며 포맷만 건너뜁니다.
+
+## 🧑‍💻 사용법
+
+스타일시트를 앱 루트 근처에서 한 번 import하세요 — **필수**이며 JS 엔트리가
+자동으로 불러오지 않습니다:
+
+```tsx
+import { useState } from 'react';
+
+import Live from '@jbpark/live-editor';
+import '@jbpark/live-editor/style.css';
+
+// 필수 — JS 엔트리가 import하지 않음
+
+const SAMPLE = `
+import * as ui from 'ui-kit';
+
+const App = () => (
+  <div className="p-6 space-y-2">
+    <ui.Typography.Title level={3}>Hello</ui.Typography.Title>
+    <ui.Button type="primary">Edit me</ui.Button>
+  </div>
+);
+
+export default App;
+`;
+
+export default function Example() {
+  const [code, setCode] = useState(SAMPLE);
+
+  return (
+    <Live>
+      <Live.Editor value={code} onChange={setCode} />
+      <Live.Preview showError frame={{ mode: 'iframe', syncStyle: true }} />
+    </Live>
+  );
+}
+```
+
+전체 가이드(Tailwind가 프리뷰에 반영되는 방식, 커스텀 패널 등)는
+[문서 사이트](https://live-editor-lab.vercel.app)를 참고하세요.
+
+## 🧩 엔트리 포인트
+
+패키지는 서브패스 export를 제공해, 한 기능 영역만 필요한 소비자가 나머지를
+번들에 포함하지 않도록 합니다(예: 프리뷰 전용 빌드에는 CodeMirror 미포함) —
+[#194](https://github.com/pjb0811/live-editor/issues/194) 참고:
+
+| Import                               | 내용                                   |
+| ------------------------------------ | -------------------------------------- |
+| `@jbpark/live-editor`                | 전체 (`Live` 프로바이더 + 모든 서피스) |
+| `@jbpark/live-editor/provider`       | 공유 편집 컨텍스트 프로바이더만        |
+| `@jbpark/live-editor/dnd`            | 드래그 앤 드롭 캔버스 + 속성 패널      |
+| `@jbpark/live-editor/editor`         | CodeMirror 코드 에디터                 |
+| `@jbpark/live-editor/preview`        | 격리된 프리뷰 런타임                   |
+| `@jbpark/live-editor/error`          | 에러 바운더리                          |
+| `@jbpark/live-editor/utils`          | 컴파일/섹션 헬퍼                       |
+| `@jbpark/live-editor/utils/ast`      | AST 조작 및 코드 생성                  |
+| `@jbpark/live-editor/utils/tailwind` | Tailwind 테마 헬퍼                     |
+| `@jbpark/live-editor/style.css`      | 컴파일된 스타일시트 (필수)             |
 
 ## 🔒 보안 참고사항
 
@@ -58,7 +133,10 @@ live-editor/
 - Node.js: 20.x 이상
 - **pnpm**: 10.x 이상 ([Corepack](https://nodejs.org/api/corepack.html)으로 관리)
 
-## 🚀 시작하기
+## 🚀 개발 (이 저장소)
+
+> Live Editor 자체를 개발할 때 참고하세요. 패키지를 앱에서 _사용_ 하려면
+> 위의 [설치](#-설치)를 보세요.
 
 ### pnpm 설정 (권장)
 
@@ -95,6 +173,12 @@ pnpm run dev
 pnpm run build
 ```
 
+### 테스트
+
+```bash
+pnpm test
+```
+
 ### 린트 & 타입 체크
 
 ```bash
@@ -114,16 +198,16 @@ pnpm run preview
 
 - `main`으로 향하는 PR마다 AI가 변경 내용을 요약한 changeset 파일을 초안으로 작성합니다.
 - `main`에 changeset들이 쌓이면 "Version Packages" PR이 `package.json`의 버전을 승격시키고 `CHANGELOG.md`를 정리합니다.
-- 이 PR을 머지하면 빌드, 태그 생성, (이 패키지가 공개로 전환되면) npm 배포가 실행됩니다.
+- 이 PR을 머지하면 빌드, 태그 생성, npm 배포가 실행됩니다.
 
 CI 워크플로우:
 
 - `changeset-draft.yml`: `main` 대상 PR이 열리거나 갱신될 때 AI가 changeset 초안을 작성
 - `version.yml`: changeset이 쌓이면 "Version Packages" PR을 열거나 갱신
-- `publish.yml`: `main` 머지 시 버전이 미태그 상태면 빌드/(공개 패키지면 배포)/태그/GitHub Release 생성
+- `publish.yml`: `main` 머지 시 버전이 미태그 상태면 빌드/배포/태그/GitHub Release 생성
 - `release.yml`: 기존 태그에 대한 GitHub Release를 수동(`workflow_dispatch`)으로 재생성하는 백업 유틸리티
 - Docusaurus 문서 사이트는 `website/`에서 빌드되며 Vercel로 배포됩니다(`vercel.json` 참고).
 
 ## 📄 라이선스
 
-MIT License
+[MIT License](./LICENSE) — Copyright (c) 2026 jbpark

--- a/README.md
+++ b/README.md
@@ -12,20 +12,25 @@ An interactive editor for building UIs with real-time preview and drag‑and‑d
 live-editor/
 ├─ src/
 │  ├─ components/
-│  │  ├─ Context/           # Global state management
-│  │  ├─ Dnd/               # Drag-and-drop system with editing panels
-│  │  ├─ Editor/             # Code editor
-│  │  ├─ Error/              # Error boundary
-│  │  ├─ Frame/              # iframe/shadow-DOM preview isolation
-│  │  └─ Preview/            # Isolated preview runtime
+│  │  ├─ context/            # Global state management
+│  │  ├─ dnd/                # Drag-and-drop system with editing panels
+│  │  │  └─ panel/           # Property panel field editors
+│  │  ├─ editor/             # CodeMirror code editor
+│  │  ├─ error/             # Error boundary
+│  │  ├─ frame/             # iframe/shadow-DOM preview isolation
+│  │  └─ preview/           # Isolated preview runtime
 │  ├─ pages/
-│  │  └─ Editor/              # Local development editor (editor + DnD toggle)
-│  ├─ utils/ast/             # AST manipulation & code generation
-│  ├─ constants/             # Constants and configurations
-│  ├─ types/                 # TypeScript type definitions
-│  └─ main.tsx                # Local development app entry
-├─ demos/                     # Standalone iframe demos for the documentation
-├─ website/                   # Docusaurus documentation site
+│  │  └─ editor/            # Local development editor (editor + DnD toggle)
+│  ├─ utils/
+│  │  ├─ ast/               # AST manipulation & code generation
+│  │  ├─ tailwind/          # Tailwind theme helpers
+│  │  ├─ cache.ts           # Bounded LRU cache
+│  │  └─ selection.ts       # Multi-select helpers
+│  ├─ constants/            # Constants and configurations
+│  ├─ types/                # TypeScript type definitions
+│  └─ main.tsx              # Local development app entry
+├─ demos/                   # Standalone iframe demos for the documentation
+├─ website/                 # Docusaurus documentation site
 └─ package.json
 ```
 
@@ -37,6 +42,76 @@ live-editor/
 - **Smart Items editor**: Manage array items with add/move/delete operations, edit properties and nested JSX components with stable component identity across reorders.
 - **Preview runtime**: Renders compiled output inside an iframe for DOM/CSS isolation (not a security sandbox — see [Security Notes](#-security-notes)).
 - **Robust drag-and-drop**: Powered by `@dnd-kit` for smooth sorting and positioning.
+
+## 📦 Installation
+
+```bash
+pnpm add @jbpark/live-editor react react-dom
+```
+
+`react` and `react-dom` (>= 19) are peer dependencies. `prettier` (>= 3) is an
+optional peer — install it too if you want the editor's format-on-save; without
+it the editor still works and simply skips formatting.
+
+## 🧑‍💻 Usage
+
+Import the stylesheet once near your app root — it is **required** and is not
+imported by the JS entry:
+
+```tsx
+import { useState } from 'react';
+
+import Live from '@jbpark/live-editor';
+import '@jbpark/live-editor/style.css';
+
+// required — not imported by the JS entry
+
+const SAMPLE = `
+import * as ui from 'ui-kit';
+
+const App = () => (
+  <div className="p-6 space-y-2">
+    <ui.Typography.Title level={3}>Hello</ui.Typography.Title>
+    <ui.Button type="primary">Edit me</ui.Button>
+  </div>
+);
+
+export default App;
+`;
+
+export default function Example() {
+  const [code, setCode] = useState(SAMPLE);
+
+  return (
+    <Live>
+      <Live.Editor value={code} onChange={setCode} />
+      <Live.Preview showError frame={{ mode: 'iframe', syncStyle: true }} />
+    </Live>
+  );
+}
+```
+
+See the [documentation site](https://live-editor-lab.vercel.app) for the full
+guide (how Tailwind reaches the preview, custom panels, and more).
+
+## 🧩 Entry points
+
+The package ships subpath exports so a consumer who needs only one feature area
+can avoid pulling in the rest (e.g. no CodeMirror in a preview-only build) — see
+[#194](https://github.com/pjb0811/live-editor/issues/194):
+
+| Import                               | Contains                                    |
+| ------------------------------------ | ------------------------------------------- |
+| `@jbpark/live-editor`                | Everything (`Live` provider + all surfaces) |
+| `@jbpark/live-editor/provider`       | The shared editing context provider only    |
+| `@jbpark/live-editor/dnd`            | Drag-and-drop canvas + property panel       |
+| `@jbpark/live-editor/editor`         | CodeMirror code editor                      |
+| `@jbpark/live-editor/preview`        | Isolated preview runtime                    |
+| `@jbpark/live-editor/error`          | Error boundary                              |
+| `@jbpark/live-editor/utils`          | Compile/section helpers                     |
+| `@jbpark/live-editor/utils/ast`      | AST manipulation & code generation          |
+| `@jbpark/live-editor/utils/tailwind` | Tailwind theme helpers                      |
+| `@jbpark/live-editor/style.css`      | Compiled stylesheet (required)              |
 
 ## 🔒 Security Notes
 
@@ -58,7 +133,10 @@ live-editor/
 - Node.js: 20.x or higher
 - **pnpm**: 10.x or higher (managed via [Corepack](https://nodejs.org/api/corepack.html))
 
-## 🚀 Getting Started
+## 🚀 Development (this repo)
+
+> Working on Live Editor itself. To _use_ the package in your app, see
+> [Installation](#-installation) above.
 
 ### pnpm Setup (Recommended)
 
@@ -96,6 +174,12 @@ feature demos live in `website/`.
 pnpm run build
 ```
 
+### Test
+
+```bash
+pnpm test
+```
+
 ### Lint & Type Check
 
 ```bash
@@ -115,17 +199,17 @@ Releases are fully automated via [changesets](https://github.com/changesets/chan
 
 - Each PR against `main` gets an AI-drafted changeset file describing its change.
 - Once changesets accumulate on `main`, a "Version Packages" PR bumps `package.json`'s version and consolidates `CHANGELOG.md`.
-- Merging that PR builds, tags the release, and (once this package is made public) publishes to npm.
+- Merging that PR builds, tags the release, and publishes to npm.
 
 CI workflows:
 
 - `changeset-draft.yml`: Drafts an AI-generated changeset on PR open/sync against `main`.
 - `version.yml`: Opens/updates the "Version Packages" PR once changesets accumulate.
-- `publish.yml`: Builds/(publishes if public)/tags/creates the GitHub Release on merge to `main` when the version is untagged.
+- `publish.yml`: Builds/publishes/tags/creates the GitHub Release on merge to `main` when the version is untagged.
 - `release.yml`: Manual `workflow_dispatch` fallback to (re)create a GitHub Release for an existing tag.
 - The Docusaurus documentation site is built from `website/` and deployed via
   Vercel (see `vercel.json`).
 
 ## 📄 License
 
-MIT License
+[MIT License](./LICENSE) — Copyright (c) 2026 jbpark


### PR DESCRIPTION
Closes #279. Closes #281.

## Summary

Documentation-only, grouped into one editing pass (no behaviour change).

### #279 — LICENSE
- Add a root `LICENSE` file with the verbatim MIT text (`Copyright (c) 2026 jbpark`). npm always includes `LICENSE*` in the tarball regardless of `files`, so no `files` change is needed. Linked from both READMEs' License section.

### #281 — doc drift
- **README.md / README.ko.md — consumer section (was repo-dev only):** new **Installation**, **Usage**, and **Entry points** sections. The mandatory `import '@jbpark/live-editor/style.css'` is made impossible to miss (the JS entry does not import it), and the nine subpath exports are tabulated with a note on why they exist (#194). The old "Getting Started" is relabelled **Development (this repo)** and gains a `pnpm test` entry.
- **Structure diagrams:** corrected from stale PascalCase (`Context/`, `Dnd/`, …) to the real kebab-case `src/` layout, adding the previously-missing `utils/tailwind`, `utils/cache.ts`, `utils/selection.ts`, and `dnd/panel/`.
- **Release section:** dropped the stale "once this package is made public" / "publishes if public" hedges (the package has shipped since 2.0.x).
- **AGENTS.md:** removed the nonexistent `.github/copilot-instructions.md` and the wrong seven-row skills table (now the real `.github/skills/ast` + `.claude/skills/*` + `.claude/commands/publish-check.md`); fixed `src/pages/{playground,preview}` → `src/pages/editor`; dropped `src/App.tsx`; added missing files (ast pipeline stages, hooks, `demos/`/`website/`/`.changeset/`/`vitest.config.ts`); added `test`/`test:watch`/`bench`/`build:demos` to the commands block.

## Test plan

Ran the issues' own verification checks:
- `LICENSE` is tracked; both READMEs contain `@jbpark/live-editor/style.css`; no PascalCase dir names remain in the READMEs; no stale public/private hedge; every full-path reference in `AGENTS.md` resolves.
- `pnpm lint` passes (markdown/LICENSE don't affect eslint/build/tests).