### PR TITLE
docs: drop gitmoji from PR template checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,7 +47,7 @@
 
 ## Checklist
 
-- [ ] Commit messages follow gitmoji + conventional-commit style
+- [ ] Commit messages follow conventional-commit style (no gitmoji)
 - [ ] Updated docs when behavior/API changed
 - [ ] Added or updated tests when needed
 - [ ] No unrelated changes included


### PR DESCRIPTION
Align the commit-message checklist item with the global convention change made on 2026-09-07: commit titles are plain `type: summary` with no gitmoji.

- `.github/pull_request_template.md`: "gitmoji + conventional-commit style" → "conventional-commit style (no gitmoji)".