### PR TITLE
chore: drop emoji labels from PR template type-of-change

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,14 +12,14 @@
 
 <!-- Check all that apply. -->
 
-- [ ] ✨ feat — new feature
-- [ ] 🐛 fix — bug fix
-- [ ] ♻️ refactor — code structure improvement
-- [ ] 💄 style — UI/style-only change
-- [ ] 📝 docs — documentation update
-- [ ] ⚡️ perf — performance improvement
-- [ ] 👷 ci — CI/CD workflow change
-- [ ] 🔧 chore/build — tooling or build/config change
+- [ ] feat — new feature
+- [ ] fix — bug fix
+- [ ] refactor — code structure improvement
+- [ ] style — UI/style-only change
+- [ ] docs — documentation update
+- [ ] perf — performance improvement
+- [ ] ci — CI/CD workflow change
+- [ ] chore/build — tooling or build/config change
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Remove the gitmoji/emoji prefixes from the "Type of Change" checklist in the PR template, so the template no longer implies emoji usage. This aligns with the commit convention change to drop gitmoji from commit titles.

## Changes

- Strip emoji prefixes (✨/🐛/♻️/… ) from the "Type of Change" options in `.github/pull_request_template.md`

## Type of Change

- [x] chore — build/config/maintenance changes