### PR TITLE
fix(dnd): forward the node-level commit callback to renderPanel

### DIFF
--- a/.changeset/fix-308-panel-render-data-node-change.md
+++ b/.changeset/fix-308-panel-render-data-node-change.md
@@ -1,0 +1,7 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Forward the node-level commit callback to `renderPanel`. `PanelRenderData` now carries `onNodeChange`, so a custom panel that re-embeds `Live.Dnd.DefaultPanel` can spread the render data straight in (`<Live.Dnd.DefaultPanel {...data} />`) and keep nested array/children edits working — previously those edits were silent no-ops, affecting 5 of the 8 shipped sections (9 of Stats' 10 editable elements).
+
+`onNodeChange` is a required field on `PanelRenderData`. Reading it off the argument in a `renderPanel` is unaffected; only code that constructs a `PanelRenderData` object by hand (a test helper or a re-shaping wrapper) needs to add the field.

--- a/demos/custom-palette-panel/custom-palette-panel-demo.tsx
+++ b/demos/custom-palette-panel/custom-palette-panel-demo.tsx
@@ -175,17 +175,47 @@ const ValidatedField = ({ binding }: { binding: PanelBinding }) => {
 // Drag-and-drop keeps working through the exported `DraggableItem`, and
 // `renderPanel` hands over `bindings` (one per editable field) so custom
 // controls still commit through the same AST-update pipeline.
+//
+// The "Wrap built-in" mode shows the other way to use `renderPanel`: keep
+// `DefaultPanel` and only add around it. Spreading the whole render data in
+// is what makes that lossless — `onNodeChange` rides along with it, and
+// without it nested array/children edits (drop in Stats and edit a card's
+// title) wouldn't commit (#308).
 const CustomPalettePanelDemo = () => {
   const [value, setValue] = useState(DEFAULT_TEMPLATE);
+  const [wrapDefaultPanel, setWrapDefaultPanel] = useState(false);
 
   return (
     <Context>
-      <div className="h-screen overflow-y-auto">
+      <div className="flex h-screen flex-col">
+        <div
+          className={cn(
+            'flex items-center justify-end gap-2',
+            'border-b border-gray-200 px-4 py-2',
+          )}
+        >
+          <span className="text-xs text-gray-600">Panel</span>
+          <Button
+            size="small"
+            type={wrapDefaultPanel ? 'default' : 'primary'}
+            onClick={() => setWrapDefaultPanel(false)}
+          >
+            Custom fields
+          </Button>
+          <Button
+            size="small"
+            type={wrapDefaultPanel ? 'primary' : 'default'}
+            onClick={() => setWrapDefaultPanel(true)}
+          >
+            Wrap built-in
+          </Button>
+        </div>
         <Dnd
           value={value}
           onChange={setValue}
           frame={{ mode: 'shadow', syncStyle: true }}
           dynamicTailwind
+          className="min-h-0 flex-1 overflow-y-auto"
           renderPalette={({ items, onAdd, DraggableItem, isMobile }) => (
             <div className="space-y-2 p-2">
               {items.map(item => (
@@ -211,127 +241,155 @@ const CustomPalettePanelDemo = () => {
               ))}
             </div>
           )}
-          renderPanel={({
-            item,
-            onDelete,
-            onMoveUp,
-            onMoveDown,
-            canMoveUp,
-            canMoveDown,
-            bindings,
-          }) => (
-            <div className="space-y-3 p-4">
-              {item ? (
-                <>
-                  <div className="flex items-center justify-between">
-                    <span className="font-semibold">{item.name}</span>
-                    <div className="flex items-center gap-1">
-                      <Button
-                        size="small"
-                        icon={<ChevronUp />}
-                        disabled={!canMoveUp}
-                        onClick={onMoveUp}
-                        aria-label="Move section up"
-                      />
-                      <Button
-                        size="small"
-                        icon={<ChevronDown />}
-                        disabled={!canMoveDown}
-                        onClick={onMoveDown}
-                        aria-label="Move section down"
-                      />
-                      <Button
-                        danger
-                        size="small"
-                        icon={<Trash />}
-                        onClick={() => onDelete(item.id)}
-                        aria-label="Delete section"
-                      />
-                    </div>
-                  </div>
-                  {bindings.length ? (
-                    // `bindings` is plain data — switch on each entry's `type`
-                    // to render whatever control you want. onChange commits
-                    // through the same AST pipeline as the built-in panel.
-                    bindings.map((binding, index) => {
-                      const isMultiline =
-                        binding.type === 'jsx' || binding.type === 'richtext';
-                      // Some `children` bindings hold a serialized document
-                      // tree rather than a few simple fields — Features'
-                      // "Feature Cards" flattens to 240 leaves (tag names,
-                      // ids, individual attributes...), which is technically
-                      // correct but useless as a form. Capping the entry
-                      // count treats those as opaque instead of rendering a
-                      // wall of tiny inputs; a value long enough to likely be
-                      // one of these (or just a long plain string) falls
-                      // back to a textarea rather than the single-line
-                      // ValidatedField either way.
-                      const flattened = isMultiline
-                        ? null
-                        : flattenEditableValue(binding.rawValue);
-                      const entries =
-                        flattened && flattened.length <= MAX_EDITABLE_ENTRIES
-                          ? flattened
-                          : null;
-                      const useTextarea =
-                        isMultiline ||
-                        (!entries && binding.rawValue.length > 120);
+          renderPanel={data => {
+            if (wrapDefaultPanel) {
+              // Spreading the whole render data keeps the built-in panel
+              // fully functional — including `onNodeChange`, which nested
+              // array/children editors need to commit.
+              return (
+                <div className="h-full overflow-y-auto">
+                  <p
+                    className={cn(
+                      'border-b border-gray-200 bg-gray-50',
+                      'px-4 py-2 text-xs text-gray-600',
+                    )}
+                  >
+                    Custom header — the built-in panel below is unchanged.
+                  </p>
+                  <Dnd.DefaultPanel {...data} />
+                </div>
+              );
+            }
 
-                      return (
-                        <label
-                          key={`${binding.id}-${binding.property}-${index}`}
-                          className="block space-y-1"
-                        >
-                          <span className="text-xs font-semibold text-gray-700">
-                            {binding.label}
-                          </span>
-                          {entries ? (
-                            <ParsedValueEditor
-                              binding={binding}
-                              entries={entries}
-                            />
-                          ) : binding.widget === 'slider' ? (
-                            <SliderField binding={binding} />
-                          ) : binding.options ? (
-                            <select
-                              className="w-full rounded border border-gray-300
-                                px-2 py-1 text-sm"
-                              value={binding.rawValue}
-                              onChange={e => binding.onChange(e.target.value)}
+            const {
+              item,
+              onDelete,
+              onMoveUp,
+              onMoveDown,
+              canMoveUp,
+              canMoveDown,
+              bindings,
+            } = data;
+
+            return (
+              <div className="space-y-3 p-4">
+                {item ? (
+                  <>
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold">{item.name}</span>
+                      <div className="flex items-center gap-1">
+                        <Button
+                          size="small"
+                          icon={<ChevronUp />}
+                          disabled={!canMoveUp}
+                          onClick={onMoveUp}
+                          aria-label="Move section up"
+                        />
+                        <Button
+                          size="small"
+                          icon={<ChevronDown />}
+                          disabled={!canMoveDown}
+                          onClick={onMoveDown}
+                          aria-label="Move section down"
+                        />
+                        <Button
+                          danger
+                          size="small"
+                          icon={<Trash />}
+                          onClick={() => onDelete(item.id)}
+                          aria-label="Delete section"
+                        />
+                      </div>
+                    </div>
+                    {bindings.length ? (
+                      // `bindings` is plain data — switch on each entry's `type`
+                      // to render whatever control you want. onChange commits
+                      // through the same AST pipeline as the built-in panel.
+                      bindings.map((binding, index) => {
+                        const isMultiline =
+                          binding.type === 'jsx' || binding.type === 'richtext';
+                        // Some `children` bindings hold a serialized document
+                        // tree rather than a few simple fields — Features'
+                        // "Feature Cards" flattens to 240 leaves (tag names,
+                        // ids, individual attributes...), which is technically
+                        // correct but useless as a form. Capping the entry
+                        // count treats those as opaque instead of rendering a
+                        // wall of tiny inputs; a value long enough to likely be
+                        // one of these (or just a long plain string) falls
+                        // back to a textarea rather than the single-line
+                        // ValidatedField either way.
+                        const flattened = isMultiline
+                          ? null
+                          : flattenEditableValue(binding.rawValue);
+                        const entries =
+                          flattened && flattened.length <= MAX_EDITABLE_ENTRIES
+                            ? flattened
+                            : null;
+                        const useTextarea =
+                          isMultiline ||
+                          (!entries && binding.rawValue.length > 120);
+
+                        return (
+                          <label
+                            key={`${binding.id}-${binding.property}-${index}`}
+                            className="block space-y-1"
+                          >
+                            <span
+                              className="text-xs font-semibold text-gray-700"
                             >
-                              {binding.options.map(option => (
-                                <option key={option.value} value={option.value}>
-                                  {option.label}
-                                </option>
-                              ))}
-                            </select>
-                          ) : useTextarea ? (
-                            <textarea
-                              className="w-full rounded border border-gray-300
-                                px-2 py-1 text-sm"
-                              rows={3}
-                              defaultValue={binding.rawValue}
-                              onBlur={e => binding.onChange(e.target.value)}
-                            />
-                          ) : (
-                            <ValidatedField binding={binding} />
-                          )}
-                        </label>
-                      );
-                    })
-                  ) : (
-                    <p className="text-xs text-gray-400">
-                      No editable elements.
-                    </p>
-                  )}
-                </>
-              ) : (
-                <p className="text-sm text-gray-500">
-                  Select a section on the canvas.
-                </p>
-              )}
-            </div>
-          )}
+                              {binding.label}
+                            </span>
+                            {entries ? (
+                              <ParsedValueEditor
+                                binding={binding}
+                                entries={entries}
+                              />
+                            ) : binding.widget === 'slider' ? (
+                              <SliderField binding={binding} />
+                            ) : binding.options ? (
+                              <select
+                                className="w-full rounded border border-gray-300
+                                  px-2 py-1 text-sm"
+                                value={binding.rawValue}
+                                onChange={e => binding.onChange(e.target.value)}
+                              >
+                                {binding.options.map(option => (
+                                  <option
+                                    key={option.value}
+                                    value={option.value}
+                                  >
+                                    {option.label}
+                                  </option>
+                                ))}
+                              </select>
+                            ) : useTextarea ? (
+                              <textarea
+                                className="w-full rounded border border-gray-300
+                                  px-2 py-1 text-sm"
+                                rows={3}
+                                defaultValue={binding.rawValue}
+                                onBlur={e => binding.onChange(e.target.value)}
+                              />
+                            ) : (
+                              <ValidatedField binding={binding} />
+                            )}
+                          </label>
+                        );
+                      })
+                    ) : (
+                      <p className="text-xs text-gray-400">
+                        No editable elements.
+                      </p>
+                    )}
+                  </>
+                ) : (
+                  <p className="text-sm text-gray-500">
+                    Select a section on the canvas.
+                  </p>
+                )}
+              </div>
+            );
+          }}
         />
       </div>
     </Context>

--- a/src/components/dnd/dnd.test.tsx
+++ b/src/components/dnd/dnd.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_TEMPLATE, DRAGGABLE_ITEMS } from '~/constants';
+
+import { PreviewContext } from '../context/states';
+import Dnd, { type PanelRenderData } from './dnd';
+
+// The canvas isn't what's under test here, and each section renders a
+// compiled component inside an iframe — none of which jsdom needs to do for
+// us to inspect the data `renderPanel` is handed.
+vi.mock('./renderer', () => ({
+  default: () => <div data-testid="renderer" />,
+}));
+
+// jsdom has no ResizeObserver, which `useResponsiveSize` (via ui-kit's
+// breakpoint hook) constructs on mount. Never observes anything here — the
+// default breakpoint is enough to land on the desktop layout, where the
+// panel renders unconditionally.
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+const stats = DRAGGABLE_ITEMS.find(item => item.id === 'stats')!;
+
+const documentWith = (sectionCode: string) =>
+  DEFAULT_TEMPLATE.replace(
+    '<main id="app-container"></main>',
+    `<main id="app-container">${sectionCode}</main>`,
+  );
+
+// Renders Dnd with a custom `renderPanel`, selects the only section by
+// clicking it on the canvas, and hands back the data the panel last
+// received plus the Dnd-level onChange spy.
+const renderWithPanel = () => {
+  const onChange = vi.fn();
+  const setCode = vi.fn();
+  let data: PanelRenderData | undefined;
+
+  const { container } = render(
+    <PreviewContext.Provider value={{ code: '', setCode }}>
+      <Dnd
+        value={documentWith(stats.code)}
+        onChange={onChange}
+        renderPanel={next => {
+          data = next;
+          return <div data-testid="panel" />;
+        }}
+      />
+    </PreviewContext.Provider>,
+  );
+
+  const sortable = container.querySelector<HTMLElement>(
+    '[aria-roledescription="sortable"]',
+  );
+
+  expect(sortable).not.toBeNull();
+
+  act(() => sortable!.click());
+
+  return { onChange, getData: () => data };
+};
+
+describe('renderPanel data', () => {
+  it('forwards the node-level commit callback', () => {
+    const { getData } = renderWithPanel();
+
+    expect(getData()?.item).toBeDefined();
+    expect(typeof getData()?.onNodeChange).toBe('function');
+  });
+
+  it('commits an edit to a data-id that `bindings` cannot reach', () => {
+    const { onChange, getData } = renderWithPanel();
+
+    const data = getData()!;
+    // Stats' only top-level binding. Everything else in the section lives
+    // inside this one's `items` value, so `extract()` never reaches it and
+    // no `PanelBinding.onChange` can address it — that's the whole reason
+    // `onNodeChange` has to be forwarded (#308).
+    expect(data.bindings.map(binding => binding.label)).toEqual([
+      'Stats Items',
+    ]);
+
+    // Where the built-in Items editor finds these: the binding's own raw
+    // source, which carries the filled `data-id`s of the nested elements.
+    // `item.code` is no use here — element ids are only filled on the copy
+    // Dnd derives internally, so there they're still `data-id=""`.
+    const items = data.bindings[0]!.rawValue;
+    const reachable = new Set(data.bindings.map(binding => binding.id));
+    const nestedOnly = [...items.matchAll(/data-id="([^"]+)"/g)]
+      .map(match => match[1]!)
+      .filter(id => !reachable.has(id));
+
+    expect(nestedOnly.length).toBeGreaterThan(0);
+
+    // The nested Title/Description bindings declare `innerText`, not
+    // `children` — `children` belongs to the outer "Stats Cards" wrapper.
+    // Committing with the wrong property fails as `binding-not-declared`,
+    // which looks identical to this bug from the outside but isn't it, so
+    // pin the property the fixture actually declares.
+    const titleId = nestedOnly.find(id => {
+      const at = items.indexOf(`data-id="${id}"`);
+      const after = items.slice(at, at + 400);
+      return (
+        /label: '([^']+)'/.exec(after)?.[1] === 'Title' &&
+        /property: '([^']+)'/.exec(after)?.[1] === 'innerText'
+      );
+    });
+
+    expect(titleId).toBeDefined();
+
+    data.onNodeChange({
+      id: titleId!,
+      label: 'Title',
+      property: 'innerText',
+      value: 'CHANGED',
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]![0]).toContain('CHANGED');
+  });
+});

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -143,6 +143,21 @@ export interface PanelRenderData {
   // on a bad edit. Switch on `type` to render your own control (an
   // `<input>`, `<textarea>`, `<select>`, ...) instead of the built-in one.
   bindings: PanelBinding[];
+  // Node-level commit for elements that aren't in `bindings` — the nested
+  // data-bound JSX held inside an `items`/`children` value, which the
+  // built-in Items/Children editors discover by re-extracting that value's
+  // own JSX. Those `data-id`s never reach `bindings` (the top-level
+  // `extract()` doesn't walk into an attribute expression), and no single
+  // `PanelBinding.onChange` can address them since each one closes over a
+  // fixed `id` — hence this `(id, label, property, value)` channel. Pass it
+  // straight through when re-embedding `DefaultPanel`, otherwise nested
+  // array/children edits inside it silently don't commit (#308).
+  onNodeChange: (params: {
+    id: string;
+    label: string;
+    property: string;
+    value: unknown;
+  }) => void;
 }
 
 // One editable data-binding, flattened out of the selected section for a
@@ -500,6 +515,7 @@ const Dnd = ({
         canMoveUp,
         canMoveDown,
         bindings,
+        onNodeChange: onFieldChange,
       });
     }
 

--- a/src/components/dnd/index.ts
+++ b/src/components/dnd/index.ts
@@ -15,9 +15,10 @@ type DndComponent = typeof DndImpl & {
   DraggableItem: typeof DraggableItem;
   // The built-in property panel, exported so a `renderPanel` can wrap or
   // partially override it instead of starting from zero — see #237. Its
-  // props line up with `PanelRenderData` (drop `onChange`; `bindings`
-  // is the same array). See panel.tsx's own doc comment for the one
-  // exception (`onNodeChange`, optional, internal-only).
+  // props line up with `PanelRenderData` (drop `onChange`; `bindings` and
+  // `onNodeChange` are the same), so `<DefaultPanel {...data} />` inside a
+  // `renderPanel` is lossless. See panel.tsx's own doc comment for why
+  // `onNodeChange` is optional there but required in `PanelRenderData`.
   DefaultPanel: typeof DefaultPanel;
 };
 

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -26,9 +26,10 @@ interface Props {
   // `Items`/`Children` edit a *different* element than `binding` itself —
   // an array item or a sibling child, each with its own id/label/property —
   // which `binding.onChange`'s single-value shape can't express. This is
-  // the internal, node-level escape hatch those two still need (see #237's
-  // documented items/children boundary); it isn't part of the public
-  // `PanelBinding` surface a custom `renderPanel` sees.
+  // the node-level escape hatch those two need (see #237's documented
+  // items/children boundary). Not part of `PanelBinding`, which is
+  // per-binding; it reaches a custom panel through `PanelRenderData`
+  // instead (#308).
   onNodeChange?: (params: {
     id: string;
     label: string;

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -12,14 +12,16 @@ import FieldGroup from './field-group';
 // Exported as `Live.Dnd.DefaultPanel` (see index.ts) so a consumer can
 // wrap or partially override the built-in panel instead of starting a
 // `renderPanel` from zero — see #237. Every field here lines up 1:1 with
-// `PanelRenderData` (drop `onChange`, which this panel never needed) with
-// one exception: `onNodeChange` isn't part of the public data a
-// `renderPanel` receives, because it's the internal, node-level escape
-// hatch `Items`/`Children` use to commit a *different* element's edit
-// than any single `PanelBinding.onChange` can express (see field.tsx's
-// items/children boundary note from step 1). It's optional here — a
-// consumer re-embedding `DefaultPanel` outside of `Dnd` itself can omit
-// it, at the cost of nested array/children edits not committing.
+// `PanelRenderData` (drop `onChange`, which this panel never needed), so
+// spreading that data straight in works: `<DefaultPanel {...data} />`.
+// `onNodeChange` is the node-level escape hatch `Items`/`Children` use to
+// commit a *different* element's edit than any single
+// `PanelBinding.onChange` can express (see field.tsx's items/children
+// boundary note from step 1). It's optional here only so a consumer can
+// deliberately render this panel read-only for nested edits; when wrapping
+// it inside a `renderPanel`, forward the `onNodeChange` that
+// `PanelRenderData` hands you or nested array/children edits won't commit
+// (#308).
 export interface PanelProps {
   item?: Section;
   onDelete?: (id: string) => void;

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -79,6 +79,7 @@ one opaque blob for the whole array.
 | `onMoveDown` | `() => void` | Move the selected section down, same rationale as `onMoveUp`. |
 | `canMoveUp` | `boolean` | Whether `onMoveUp` would do anything right now — disable your move-up control when `false`. |
 | `canMoveDown` | `boolean` | Whether `onMoveDown` would do anything right now — disable your move-down control when `false`. |
+| `onNodeChange` | `(params: { id: string; label: string; property: string; value: unknown }) => void` | Commit an edit to an element addressed by its own `data-id`, rather than through a binding you were handed. Only needed when you re-embed `DefaultPanel` — pass it straight through. See [Wrapping the built-in panel](#wrapping-the-built-in-panel-instead-of-starting-from-zero). |
 
 `bindings` carries each field's `type`, current `value`, `options` (when
 present), and an `onChange` wired straight into the same AST-update pipeline
@@ -153,30 +154,29 @@ own chrome around it (or swap it in for only some sections):
   renderPanel={data => (
     <div>
       <MyCustomHeader item={data.item} />
-      <Live.Dnd.DefaultPanel
-        item={data.item}
-        bindings={data.bindings}
-        onDelete={data.onDelete}
-        onMoveUp={data.onMoveUp}
-        onMoveDown={data.onMoveDown}
-        canMoveUp={data.canMoveUp}
-        canMoveDown={data.canMoveDown}
-      />
+      <Live.Dnd.DefaultPanel {...data} />
     </div>
   )}
 />
 ```
 
-`DefaultPanel`'s props line up 1:1 with `PanelRenderData` (drop `onChange`,
-which it never needed). One thing it takes that `PanelRenderData` doesn't
-have: an internal, optional `onNodeChange` prop that array/children fields
-use to commit an edit to a *different*, dynamically-discovered element than
-the one being rendered — not expressible through a single binding's own
-`onChange`. It's not part of the public data because of that, so a
-`DefaultPanel` re-embedded this way (without `Dnd` wiring it in for you)
-renders everything correctly but nested array/children edits inside it
-won't commit. Rendering `DefaultPanel` un-wrapped, or letting `Dnd` render
-it by not passing `renderPanel` at all, doesn't have this limitation.
+Spread the whole object rather than picking fields off it. `DefaultPanel`'s
+props line up 1:1 with `PanelRenderData` (it just ignores `onChange`, which
+it never needed), so the spread is lossless — and it's the only form that
+carries `onNodeChange` through.
+
+That last one matters more than it looks. `bindings` covers the elements
+`extract()` finds by walking the section's markup, which does not include
+JSX nested *inside* an attribute value — the elements held in an `items` or
+`children` binding. The built-in array/children editors discover those by
+re-extracting that value themselves, and commit them through `onNodeChange`,
+addressing each by its own `data-id`. No single `PanelBinding.onChange` can
+stand in for it, because each one is bound to a fixed element.
+
+Most shipped sections are affected: in `stats`, 9 of the section's 10
+editable elements are only reachable this way. Drop `onNodeChange` and those
+edits are silent no-ops — the fields still render and accept typing, but
+nothing commits.
 
 ### `PanelBinding`
 


### PR DESCRIPTION
## Summary

Fixes #308. `PanelRenderData` didn't carry the node-level commit callback, so a custom `renderPanel` that re-embeds `Live.Dnd.DefaultPanel` rendered every field correctly but silently dropped edits to nested array/children elements — no AST write, no toast, no console warning.

The gap was not marginal: 5 of the 8 shipped sections carry `data-id`s a `renderPanel` couldn't reach (9 of Stats' 10 editable elements). Forwarding the callback that already exists closes it — no AST-layer change was needed.

## Changes

- Add `onNodeChange` to `PanelRenderData` and forward `onFieldChange` at the `renderPanel` call site (`src/components/dnd/dnd.tsx`).
- Update the "internal-only" rationale comments in `panel/panel.tsx`, `panel/field.tsx` and `index.ts` — the capability is now public, so the reasoning they documented no longer holds.
- Add `src/components/dnd/dnd.test.tsx`, the first test covering `renderPanel`'s data shape: asserts the callback arrives, and that committing a nested-only `data-id` produces changed code.
- Add a "Wrap built-in" toggle to the custom palette/panel demo, which previously never exercised this path (it destructured `bindings` and rendered its own controls, showing 1 of Stats' 10 fields).
- Replace the documented limitation in `website/docs/custom-palette-panel.mdx` with the `{...data}` spread example, and document `onNodeChange` in the `PanelRenderData` table.
- Add a changeset (minor), calling out the required-field typing note.

### Why the callback rather than a new binding

`extract()` doesn't descend into JSX held inside an attribute expression, so nested data-bound elements never reach `bindings`. The built-in `Items`/`Children` editors recover them by re-extracting that value themselves and commit through an `(id, label, property, value)` triple — strictly more expressive than `PanelBinding.onChange`, which closes over a fixed `id`. `update()` already resolves any `data-id` in the section source regardless of nesting depth, so the callback just needed to arrive.

### API note

`onNodeChange` is **required** on `PanelRenderData`. Reading it off the argument inside a `renderPanel` is unaffected — only code that constructs a `PanelRenderData` object by hand (a test helper or a re-shaping wrapper) needs to add the field. There is no such construction in this repo.

## Type of Change

- [x] fix — bug fix
- [x] docs — documentation update

## Scope

- [x] DnD / Canvas
- [x] Documentation

## Validation

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`
- [x] Manual verification completed

```
pnpm test       19 files, 389 passed (was 387 — +2 new)
pnpm build      ok, `onNodeChange` present in dist/index.d.ts
pnpm build:demos ok
```

The new test fails without the fix, as it should:

```
× forwards the node-level commit callback
  AssertionError: expected 'undefined' to be 'function'
× commits an edit to a data-id that `bindings` cannot reach
  TypeError: data.onNodeChange is not a function
```

Manual: ran the custom palette/panel demo, dropped in **Stats**, switched to "Wrap built-in", edited a nested card's Title — the canvas updated. Before the fix that edit was a no-op.

### Note for whoever reads the issue's repro

The issue suggests finding nested ids in `PanelRenderData.item.code`. That doesn't work — element `data-id`s are only filled on the copy `Dnd` derives internally, so `item.code` still holds `data-id=""`. The filled ids live in `bindings[].rawValue`, which is the same source the built-in `Items` editor re-extracts. The test uses that path.

The `property: 'innerText'` caveat from the issue is real and is pinned by an assertion — passing `'children'` fails as `binding-not-declared`, which looks identical to this bug from the outside.

## Checklist

- [x] Commit messages follow conventional-commit style (no gitmoji)
- [x] Updated docs when behavior/API changed
- [x] Added or updated tests when needed
- [x] No unrelated changes included

Note: `website/docs/custom-palette-panel.mdx` fails `prettier --check` both before and after this PR — a pre-existing condition on `main`, left untouched here.
