### PR TITLE
feat(dnd): export the built-in single-binding control as Field

### DIFF
--- a/.changeset/expose-panel-field.md
+++ b/.changeset/expose-panel-field.md
@@ -1,0 +1,9 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Export the built-in single-binding control as `Live.Dnd.Field`. A custom `renderPanel` can now mix its own controls with the built-in one per binding, instead of choosing all-or-nothing between hand-rolling every field and wrapping `DefaultPanel`.
+
+It's driven entirely by public render data — a `PanelBinding` out of `bindings` plus `onNodeChange` — and renders the control only, leaving the label to the caller. Most useful for `items`/`children`/`array` bindings, whose editors reach nested data-bound elements that `bindings` alone can't address.
+
+Also exports the `FieldProps` and `PanelNodeChange` types. `PanelNodeChange` names the node-level commit callback's shape, which was previously spelled out inline everywhere it appeared.

--- a/demos/custom-palette-panel/custom-palette-panel-demo.tsx
+++ b/demos/custom-palette-panel/custom-palette-panel-demo.tsx
@@ -4,7 +4,7 @@ import { Button } from '@jbpark/ui-kit';
 import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 
 import Context from '~/components/context';
-import Dnd, { type PanelBinding } from '~/components/dnd';
+import Dnd, { Field, type PanelBinding } from '~/components/dnd';
 import { DEFAULT_TEMPLATE } from '~/constants';
 import { cn } from '~/utils';
 import {
@@ -269,6 +269,7 @@ const CustomPalettePanelDemo = () => {
               canMoveUp,
               canMoveDown,
               bindings,
+              onNodeChange,
             } = data;
 
             return (
@@ -306,6 +307,20 @@ const CustomPalettePanelDemo = () => {
                       // to render whatever control you want. onChange commits
                       // through the same AST pipeline as the built-in panel.
                       bindings.map((binding, index) => {
+                        // An `items`/`children`/array binding holds nested
+                        // data-bound JSX that `bindings` alone can't reach
+                        // (see #308). Flattening it gives a wall of tiny
+                        // inputs at best, a raw source textarea at worst —
+                        // so hand these back to the built-in control and
+                        // keep the hand-rolled ones for the simple types.
+                        // This is the point of `Live.Dnd.Field`: the choice
+                        // is per binding, not all-or-nothing.
+                        const isStructural =
+                          binding.type === 'array' ||
+                          binding.property === 'items' ||
+                          binding.property === 'data' ||
+                          binding.property === 'children';
+
                         const isMultiline =
                           binding.type === 'jsx' || binding.type === 'richtext';
                         // Some `children` bindings hold a serialized document
@@ -318,9 +333,10 @@ const CustomPalettePanelDemo = () => {
                         // one of these (or just a long plain string) falls
                         // back to a textarea rather than the single-line
                         // ValidatedField either way.
-                        const flattened = isMultiline
-                          ? null
-                          : flattenEditableValue(binding.rawValue);
+                        const flattened =
+                          isMultiline || isStructural
+                            ? null
+                            : flattenEditableValue(binding.rawValue);
                         const entries =
                           flattened && flattened.length <= MAX_EDITABLE_ENTRIES
                             ? flattened
@@ -339,7 +355,14 @@ const CustomPalettePanelDemo = () => {
                             >
                               {binding.label}
                             </span>
-                            {entries ? (
+                            {isStructural ? (
+                              // Renders the control only — the label above is
+                              // ours, which is why `Field` doesn't draw one.
+                              <Field
+                                binding={binding}
+                                onNodeChange={onNodeChange}
+                              />
+                            ) : entries ? (
                               <ParsedValueEditor
                                 binding={binding}
                                 entries={entries}

--- a/src/components/dnd/dnd.test.tsx
+++ b/src/components/dnd/dnd.test.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_TEMPLATE, DRAGGABLE_ITEMS } from '~/constants';
 
 import { PreviewContext } from '../context/states';
 import Dnd, { type PanelRenderData } from './dnd';
+import Field from './panel/field';
 
 // The canvas isn't what's under test here, and each section renders a
 // compiled component inside an iframe — none of which jsdom needs to do for
@@ -123,5 +124,41 @@ describe('renderPanel data', () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0]![0]).toContain('CHANGED');
+  });
+});
+
+describe('Field, exported for per-binding reuse', () => {
+  // The point of exporting it: everything it needs is public render data, so
+  // a custom panel can delegate one binding without adopting the whole
+  // built-in panel. If this ever needs something internal, the export is a
+  // lie and this fails.
+  it('drives the nested item editors from `bindings` + `onNodeChange` alone', () => {
+    const { getData } = renderWithPanel();
+    const data = getData()!;
+    const onNodeChange = vi.fn();
+
+    const { container } = render(
+      <Field binding={data.bindings[0]!} onNodeChange={onNodeChange} />,
+    );
+
+    const values = [...container.querySelectorAll('textarea')].map(
+      el => el.value,
+    );
+
+    // The nested Title/Description leaves Stats' `bindings` can't reach.
+    expect(values).toContain('Open');
+    expect(values).toContain('Source Project');
+    expect(values).toContain('By Doing');
+  });
+
+  it('renders the control only, leaving the label to the caller', () => {
+    const { getData } = renderWithPanel();
+    const data = getData()!;
+
+    const { container } = render(<Field binding={data.bindings[0]!} />);
+
+    // `FieldGroup` draws "Stats Items (items)" in the built-in panel; a
+    // consumer supplying their own heading must not get a second one.
+    expect(container.textContent).not.toContain('Stats Items');
   });
 });

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -124,6 +124,18 @@ export interface PaletteRenderData {
   isMobile: boolean;
 }
 
+// The node-level commit callback's shape, named because it's now part of
+// the public surface in three places (`PanelRenderData`, `DefaultPanel`,
+// `Field`) and was previously spelled out inline in each — see #308.
+export interface PanelNodeChange {
+  (params: {
+    id: string;
+    label: string;
+    property: string;
+    value: unknown;
+  }): void;
+}
+
 export interface PanelRenderData {
   item?: Section;
   onChange: (next: Partial<Section>) => void;
@@ -152,12 +164,7 @@ export interface PanelRenderData {
   // fixed `id` — hence this `(id, label, property, value)` channel. Pass it
   // straight through when re-embedding `DefaultPanel`, otherwise nested
   // array/children edits inside it silently don't commit (#308).
-  onNodeChange: (params: {
-    id: string;
-    label: string;
-    property: string;
-    value: unknown;
-  }) => void;
+  onNodeChange: PanelNodeChange;
 }
 
 // One editable data-binding, flattened out of the selected section for a

--- a/src/components/dnd/index.ts
+++ b/src/components/dnd/index.ts
@@ -1,6 +1,7 @@
 import DndImpl, {
   type PaletteRenderData,
   type PanelBinding,
+  type PanelNodeChange,
   type PanelRenderData,
   type Props,
 } from './dnd';
@@ -8,6 +9,7 @@ import DraggableItem, {
   type DraggableItemDragState,
   type DraggableItemProps,
 } from './draggable';
+import Field, { type FieldProps } from './panel/field';
 import { ICON_MAP, ICON_OPTIONS } from './panel/icon-map';
 import DefaultPanel, { type PanelProps } from './panel/panel';
 
@@ -20,14 +22,24 @@ type DndComponent = typeof DndImpl & {
   // `renderPanel` is lossless. See panel.tsx's own doc comment for why
   // `onNodeChange` is optional there but required in `PanelRenderData`.
   DefaultPanel: typeof DefaultPanel;
+  // The built-in control for one binding, exported so a custom panel can
+  // mix its own controls with the built-in one per binding instead of
+  // choosing all-or-nothing between `renderPanel` and `DefaultPanel`. Takes
+  // a `PanelBinding` straight out of `bindings` plus `onNodeChange` — both
+  // public `PanelRenderData` fields, so nothing internal is needed to drive
+  // it. Most useful for `items`/`children` bindings, whose editors find
+  // nested data-bound elements a consumer can't reach through `bindings`.
+  // Renders the control only — supply your own label.
+  Field: typeof Field;
 };
 
 const Dnd = DndImpl as DndComponent;
 
 Dnd.DraggableItem = DraggableItem;
 Dnd.DefaultPanel = DefaultPanel;
+Dnd.Field = Field;
 
-export { DraggableItem, DefaultPanel };
+export { DraggableItem, DefaultPanel, Field };
 // The built-in panel's own `widget: 'icon-picker'` icon set/options —
 // exported so a custom renderPanel can reach icon-picker parity (name ->
 // lucide-react component, and the same label/value pairs fed to Select)
@@ -38,7 +50,9 @@ export type {
   PaletteRenderData,
   PanelRenderData,
   PanelBinding,
+  PanelNodeChange,
   PanelProps,
+  FieldProps,
   DraggableItemProps,
   DraggableItemDragState,
 };

--- a/src/components/dnd/panel/children.tsx
+++ b/src/components/dnd/panel/children.tsx
@@ -8,18 +8,14 @@ import { nanoid } from 'nanoid';
 import { type DataAttrNode, findEditableChildren } from '~/utils/ast';
 import { moveSelectedIndices, removeIndices } from '~/utils/selection';
 
+import type { PanelNodeChange } from '../dnd';
 import { BulkActionsBar } from './items';
 import Node from './node';
 
 interface Props {
   value: DataAttrNode[];
   onChange?: (value: string) => void;
-  onNodeChange?: (params: {
-    id: string;
-    label: string;
-    property: string;
-    value: unknown;
-  }) => void;
+  onNodeChange?: PanelNodeChange;
 }
 
 const Children = ({ value, onChange, onNodeChange }: Props) => {

--- a/src/components/dnd/panel/field-group.tsx
+++ b/src/components/dnd/panel/field-group.tsx
@@ -1,14 +1,9 @@
-import type { PanelBinding } from '../dnd';
+import type { PanelBinding, PanelNodeChange } from '../dnd';
 import Field from './field';
 
 interface Props {
   bindings: PanelBinding[];
-  onNodeChange?: (params: {
-    id: string;
-    label: string;
-    property: string;
-    value: unknown;
-  }) => void;
+  onNodeChange?: PanelNodeChange;
 }
 
 // One bordered group per element `id` — the same visual grouping `Node`

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -16,12 +16,19 @@ import CoreEditor from '~/components/editor/core';
 import { BINDING_PROP } from '~/constants';
 import { parseValue, validateBindingValue } from '~/utils/ast';
 
-import type { PanelBinding } from '../dnd';
+import type { PanelBinding, PanelNodeChange } from '../dnd';
 import Children from './children';
 import { ICON_MAP, ICON_OPTIONS } from './icon-map';
 import Items from './items';
 
-interface Props {
+// Exported as `Live.Dnd.Field` (see index.ts) so a custom `renderPanel` can
+// hand any single binding back to the built-in control instead of
+// reimplementing it — most usefully for `items`/`children` bindings, whose
+// editors discover nested data-bound elements by re-extracting the value's
+// own JSX (~100 lines of Babel walking a consumer would otherwise have to
+// reproduce). Renders the *control* only; the built-in panel's label comes
+// from `FieldGroup`, so a consumer supplies their own heading and layout.
+export interface FieldProps {
   binding: PanelBinding;
   // `Items`/`Children` edit a *different* element than `binding` itself —
   // an array item or a sibling child, each with its own id/label/property —
@@ -29,13 +36,8 @@ interface Props {
   // the node-level escape hatch those two need (see #237's documented
   // items/children boundary). Not part of `PanelBinding`, which is
   // per-binding; it reaches a custom panel through `PanelRenderData`
-  // instead (#308).
-  onNodeChange?: (params: {
-    id: string;
-    label: string;
-    property: string;
-    value: unknown;
-  }) => void;
+  // instead (#308). Omit it and nested array/children edits won't commit.
+  onNodeChange?: PanelNodeChange;
 }
 
 const isColorProperty = (propertyName: string): boolean => {
@@ -161,7 +163,7 @@ const ColorPickerField = ({ value, onChange }: ColorPickerFieldProps) => {
   );
 };
 
-const Field = ({ binding, onNodeChange }: Props) => {
+const Field = ({ binding, onNodeChange }: FieldProps) => {
   // `value` is already structured (its real JS type); `rawValue` is the exact
   // source text used for the raw editors (Items/code/textarea) and as the
   // <input> defaultValue. See #238.

--- a/src/components/dnd/panel/items.tsx
+++ b/src/components/dnd/panel/items.tsx
@@ -28,6 +28,7 @@ import {
   updateArrayItemValue,
 } from '~/utils/ast';
 
+import type { PanelNodeChange } from '../dnd';
 import Field from './field';
 import Node from './node';
 
@@ -63,12 +64,7 @@ interface Props {
   value: string;
   render?: BindingRenderMap;
   onChange?: (value: string) => void;
-  onChildChange?: (params: {
-    id: string;
-    label: string;
-    property: string;
-    value: unknown;
-  }) => void;
+  onChildChange?: PanelNodeChange;
 }
 
 interface BulkActionsBarProps {

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -6,7 +6,7 @@ import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 import type { Section } from '~/types';
 import { cn } from '~/utils';
 
-import type { PanelBinding } from '../dnd';
+import type { PanelBinding, PanelNodeChange } from '../dnd';
 import FieldGroup from './field-group';
 
 // Exported as `Live.Dnd.DefaultPanel` (see index.ts) so a consumer can
@@ -37,12 +37,7 @@ export interface PanelProps {
   // `bindings` useMemo — the same data a custom renderPanel receives, so
   // this panel doesn't re-derive it from DataAttrNode a second time (#237).
   bindings: PanelBinding[];
-  onNodeChange?: (params: {
-    id: string;
-    label: string;
-    property: string;
-    value: unknown;
-  }) => void;
+  onNodeChange?: PanelNodeChange;
 }
 
 // `bindings` is flat (one entry per bound property, across every editable

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,10 @@ import './index.css';
 
 import Context from './components/context';
 import LiveDnd, {
+  type FieldProps,
   type PaletteRenderData,
   type PanelBinding,
+  type PanelNodeChange,
   type PanelRenderData,
 } from './components/dnd';
 import LiveEditor, { type EditorRenderData } from './components/editor';
@@ -31,7 +33,9 @@ export {
 export type {
   PaletteRenderData,
   PanelBinding,
+  PanelNodeChange,
   PanelRenderData,
+  FieldProps,
   EditorRenderData,
   FrameProps,
   Section,

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -178,6 +178,46 @@ editable elements are only reachable this way. Drop `onNodeChange` and those
 edits are silent no-ops — the fields still render and accept typing, but
 nothing commits.
 
+### Reusing the built-in control for one binding
+
+Wrapping `DefaultPanel` is all-or-nothing: you get the built-in panel for
+every field. When you want your own controls for most bindings but not all
+of them, `Live.Dnd.Field` renders the built-in control for a single
+binding:
+
+```tsx
+renderPanel={({ bindings, onNodeChange }) => (
+  <div>
+    {bindings.map(binding => (
+      <label key={`${binding.id}-${binding.property}`}>
+        <span>{binding.label}</span>
+        {binding.type === 'array' || binding.property === 'children' ? (
+          <Live.Dnd.Field binding={binding} onNodeChange={onNodeChange} />
+        ) : (
+          <MyOwnControl binding={binding} />
+        )}
+      </label>
+    ))}
+  </div>
+)}
+```
+
+`Field` takes nothing but a `PanelBinding` out of `bindings` and the same
+`onNodeChange` — both already part of `PanelRenderData`, so no internal
+wiring is involved.
+
+It renders the **control only**. The built-in panel's `Label (property)`
+heading comes from the row around it, not from `Field`, so supply your own
+as above.
+
+This is worth the most on `items`/`children`/`array` bindings. Those hold
+nested data-bound JSX that `bindings` can't reach, and reproducing the
+editor means re-parsing the value's JSX, walking it for `data-id` /
+`data-binding` pairs, and translating item positions back to array element
+positions before every edit. `Field` already does that. For a plain string,
+number or option binding there's little reason to reach for it — a bare
+`<input>` wired to `binding.onChange` is the simpler answer.
+
 ### `PanelBinding`
 
 | Field | Type | Description |


### PR DESCRIPTION
## Summary

Follow-up to #310. `renderPanel` was all-or-nothing: hand-roll every control from `bindings`, or wrap `DefaultPanel` and get the built-in panel for everything. This exports the built-in control for a *single* binding as `Live.Dnd.Field`, so a custom panel can mix the two per binding.

This is step 1 of the two-step plan discussed for making custom panels easier to build. Step 2 (a headless `useItemsEditor` hook, for consumers who want different *markup* rather than the built-in control) is deliberately not in this PR — see *Follow-up* below.

## Why `Field` and not a refactor first

`items.tsx` is 672 lines, so the obvious assumption is that reuse needs restructuring first. It doesn't, for this use case:

- `Field`'s props are `binding: PanelBinding` + `onNodeChange` — **both already public** as of #310.
- The four panel components (`field` / `items` / `children` / `node`) have **zero context dependencies**; they're pure props-in.

So `Field` is usable as-is. Verified before writing any of this, and pinned as a test here.

## What it buys

Reproducing the `items`/`children` editor by hand means re-parsing the value's JSX, walking it for `data-id` / `data-binding` pairs, and translating item positions to array element positions before each edit (the object/primitive index split, plus the selection reconciliation from #285). `Field` already does all of it.

For a plain string or option binding there's little reason to use it — a bare `<input>` on `binding.onChange` is simpler, and the docs say so.

## Changes

- Export `Field` as both `Live.Dnd.Field` and a named export; export `FieldProps`.
- Add `PanelNodeChange`, naming the node-level callback shape that was spelled out inline in **six** places (`PanelRenderData`, `PanelProps`, `FieldProps`, `FieldGroup`, `Children`, `Items`). It became public API in #310, so it should have a name rather than drift.
- Demo: render `Field` for `items`/`children`/array bindings in "Custom fields" mode. It previously fell back to a raw source textarea there — showing **1** of Stats' 10 editable fields.
- Docs: new "Reusing the built-in control for one binding" section, including the label caveat.
- Changeset (minor).

### Note on the label

`Field` renders the **control only** — the built-in `Label (property)` heading comes from `FieldGroup`, one level up. That's the right split for a consumer (they bring their own heading and layout), but it's easy to trip over, so it's documented and pinned by a test asserting `Field` alone doesn't emit the label.

## Type of Change

- [x] feat — new feature
- [x] docs — documentation update

## Scope

- [x] DnD / Canvas
- [x] Documentation

## Validation

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`
- [x] Manual verification completed

```
pnpm test        19 files, 391 passed (was 389 — +2)
pnpm build       ok; Field, FieldProps, PanelNodeChange all present in dist/dnd/index.d.ts
pnpm build:demos ok
```

Manual, in the custom palette/panel demo on "Custom fields":

| | before | after |
| --- | --- | --- |
| Stats fields shown | 1 (raw textarea of source) | 9 (nested Title/Description editors) |
| nested edit commits | no | yes — verified on canvas |

The demo's own "Stats Items" label renders above the built-in control, with no duplicate heading.

## Follow-up (not in this PR)

Step 2 — extract `useItemsEditor` from `items.tsx`. The file already separates cleanly into derivation (~95 lines: `parseArrayExpression` → `jsxBindings`/`jsxFallbacks`), mutation + selection (~185 lines), and presentation (~250 lines); the first two are what a headless hook would expose. That's what's needed to replace the *markup*, which `Field` deliberately doesn't address. Sequencing it after this PR is intentional: exporting `Field` fixes the boundary of what stays internal, so the hook's API can be designed against a settled surface.

## Checklist

- [x] Commit messages follow conventional-commit style (no gitmoji)
- [x] Updated docs when behavior/API changed
- [x] Added or updated tests when needed
- [x] No unrelated changes included

Note: `website/docs/custom-palette-panel.mdx` fails `prettier --check` before and after — pre-existing on `main`, untouched here.
