### PR TITLE
refactor(dnd): extract the array-editing engine into useItemsEditor

### DIFF
--- a/.changeset/items-headless-hook.md
+++ b/.changeset/items-headless-hook.md
@@ -1,0 +1,11 @@
+---
+'@jbpark/live-editor': minor
+---
+
+Export `useItemsEditor`, the array-editing engine behind the built-in Items panel, so a custom panel can keep its own markup instead of adopting the built-in control. It returns `PanelBinding`s and position-translated actions, so it composes with `Live.Dnd.Field`: render your own layout and hand individual bindings to the built-in control where that's enough.
+
+It saves reimplementing the parts that are easy to get wrong — re-parsing each item's JSX to find nested data-bound elements, resolving the binding `render` map, translating visible item positions to array element positions before every edit, and reconciling the selection after a move or delete.
+
+Also exports the `ItemsEditor`, `ItemsEditorItem`, `ItemsEditorNestedGroup`, `ItemsEditorNestedElement`, `ItemsEditorActions` and `ItemsEditorOptions` types.
+
+Internally `panel/items.tsx` is now presentation over that hook (668 → 291 lines). The built-in panel's rendered markup is unchanged.

--- a/demos/custom-palette-panel/custom-palette-panel-demo.tsx
+++ b/demos/custom-palette-panel/custom-palette-panel-demo.tsx
@@ -4,7 +4,12 @@ import { Button } from '@jbpark/ui-kit';
 import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 
 import Context from '~/components/context';
-import Dnd, { Field, type PanelBinding } from '~/components/dnd';
+import Dnd, {
+  Field,
+  type PanelBinding,
+  type PanelNodeChange,
+  useItemsEditor,
+} from '~/components/dnd';
 import { DEFAULT_TEMPLATE } from '~/constants';
 import { cn } from '~/utils';
 import {
@@ -170,6 +175,163 @@ const ValidatedField = ({ binding }: { binding: PanelBinding }) => {
   );
 };
 
+// A deliberately different layout for an `items` binding, built on the
+// exported `useItemsEditor`. Nothing here parses JSX or touches Babel: the
+// hook hands back `PanelBinding`s and position-translated actions, so this
+// only has to decide what it looks like. Compare with the built-in Items
+// panel ("Wrap built-in") — same engine, different markup.
+const HeadlessItems = ({
+  binding,
+  onNodeChange,
+}: {
+  binding: PanelBinding;
+  onNodeChange: PanelNodeChange;
+}) => {
+  const { items, selection, actions } = useItemsEditor(binding.rawValue, {
+    render: binding.render,
+    onChange: binding.onChange,
+    onNodeChange,
+  });
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-gray-500">{items.length} item(s)</span>
+        <div className="flex gap-1">
+          {selection.selected.size > 0 && (
+            <>
+              <button
+                type="button"
+                className="rounded bg-gray-100 px-2 py-0.5 text-xs"
+                onClick={() => actions.moveSelected('up')}
+              >
+                ↑
+              </button>
+              <button
+                type="button"
+                className="rounded bg-gray-100 px-2 py-0.5 text-xs"
+                onClick={() => actions.moveSelected('down')}
+              >
+                ↓
+              </button>
+              <button
+                type="button"
+                className="rounded bg-red-50 px-2 py-0.5 text-xs text-red-600"
+                onClick={actions.removeSelected}
+              >
+                Delete {selection.selected.size}
+              </button>
+            </>
+          )}
+          <button
+            type="button"
+            className="rounded bg-green-50 px-2 py-0.5 text-xs text-green-700"
+            onClick={actions.add}
+          >
+            + Add
+          </button>
+        </div>
+      </div>
+
+      {items.map(item => (
+        <details
+          key={item.id}
+          open
+          className="rounded border border-gray-200 px-2 py-1"
+        >
+          <summary className="flex cursor-pointer items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              checked={selection.isSelected(item.index)}
+              onChange={() => selection.toggle(item.index, false)}
+              onClick={e => e.stopPropagation()}
+            />
+            <span className="font-medium">#{item.index + 1}</span>
+            <button
+              type="button"
+              className="ml-auto text-red-500"
+              onClick={e => {
+                e.preventDefault();
+                actions.remove(item.elementIndex);
+              }}
+            >
+              remove
+            </button>
+          </summary>
+
+          <div className="space-y-1 py-1">
+            {/* A primitive array item has a single value binding. */}
+            {item.value && (
+              <input
+                className="w-full rounded border border-gray-300 px-2 py-1
+                  text-sm"
+                defaultValue={item.value.rawValue}
+                onBlur={e => item.value!.onChange(e.target.value)}
+              />
+            )}
+
+            {item.properties.map(prop => (
+              <label key={prop.label} className="flex items-center gap-2">
+                <span className="w-16 shrink-0 text-xs text-gray-500">
+                  {prop.label}
+                </span>
+                <input
+                  className="w-full rounded border border-gray-300 px-2 py-1
+                    text-sm"
+                  defaultValue={prop.rawValue}
+                  onBlur={e => prop.onChange(e.target.value)}
+                />
+              </label>
+            ))}
+
+            {/* The nested elements `bindings` alone can't reach. Each one
+                already carries its own `onChange`, wired to `onNodeChange`
+                by the hook. */}
+            {item.nested.map(group =>
+              group.fallback ? (
+                <Field
+                  key={group.property}
+                  binding={group.fallback}
+                  onNodeChange={onNodeChange}
+                />
+              ) : (
+                group.elements.map(element => (
+                  <div
+                    key={`${group.property}-${element.id}`}
+                    className="space-y-1 rounded bg-gray-50 p-1"
+                  >
+                    <div className="text-[10px] text-gray-400">
+                      {group.property} › &lt;{element.tagName}&gt;
+                    </div>
+                    {element.bindings.map(nestedBinding => (
+                      <label
+                        key={nestedBinding.label}
+                        className="flex items-center gap-2"
+                      >
+                        <span className="w-16 shrink-0 text-xs text-gray-500">
+                          {nestedBinding.label}
+                        </span>
+                        {/* Structural bindings still get the built-in
+                            control — the hook and `Field` compose. */}
+                        <Field
+                          binding={nestedBinding}
+                          onNodeChange={onNodeChange}
+                        />
+                      </label>
+                    ))}
+                  </div>
+                ))
+              ),
+            )}
+          </div>
+        </details>
+      ))}
+    </div>
+  );
+};
+
+type PanelMode = 'custom' | 'wrap' | 'headless';
+
 // Custom Palette & Panel demo. Mirrors the app's `pages/docs/dnd-custom-render`:
 // `Dnd`'s `renderPalette`/`renderPanel` fully replace the built-in layouts.
 // Drag-and-drop keeps working through the exported `DraggableItem`, and
@@ -181,9 +343,12 @@ const ValidatedField = ({ binding }: { binding: PanelBinding }) => {
 // is what makes that lossless — `onNodeChange` rides along with it, and
 // without it nested array/children edits (drop in Stats and edit a card's
 // title) wouldn't commit (#308).
+//
+// "Headless items" is the third option: keep your own markup but reuse the
+// array-editing engine through `useItemsEditor` (see `HeadlessItems`).
 const CustomPalettePanelDemo = () => {
   const [value, setValue] = useState(DEFAULT_TEMPLATE);
-  const [wrapDefaultPanel, setWrapDefaultPanel] = useState(false);
+  const [mode, setMode] = useState<PanelMode>('custom');
 
   return (
     <Context>
@@ -197,17 +362,24 @@ const CustomPalettePanelDemo = () => {
           <span className="text-xs text-gray-600">Panel</span>
           <Button
             size="small"
-            type={wrapDefaultPanel ? 'default' : 'primary'}
-            onClick={() => setWrapDefaultPanel(false)}
+            type={mode === 'custom' ? 'primary' : 'default'}
+            onClick={() => setMode('custom')}
           >
             Custom fields
           </Button>
           <Button
             size="small"
-            type={wrapDefaultPanel ? 'primary' : 'default'}
-            onClick={() => setWrapDefaultPanel(true)}
+            type={mode === 'wrap' ? 'primary' : 'default'}
+            onClick={() => setMode('wrap')}
           >
             Wrap built-in
+          </Button>
+          <Button
+            size="small"
+            type={mode === 'headless' ? 'primary' : 'default'}
+            onClick={() => setMode('headless')}
+          >
+            Headless items
           </Button>
         </div>
         <Dnd
@@ -242,7 +414,7 @@ const CustomPalettePanelDemo = () => {
             </div>
           )}
           renderPanel={data => {
-            if (wrapDefaultPanel) {
+            if (mode === 'wrap') {
               // Spreading the whole render data keeps the built-in panel
               // fully functional — including `onNodeChange`, which nested
               // array/children editors need to commit.
@@ -356,12 +528,23 @@ const CustomPalettePanelDemo = () => {
                               {binding.label}
                             </span>
                             {isStructural ? (
-                              // Renders the control only — the label above is
-                              // ours, which is why `Field` doesn't draw one.
-                              <Field
-                                binding={binding}
-                                onNodeChange={onNodeChange}
-                              />
+                              // Same binding, two ways to render it: the
+                              // built-in control, or your own markup over
+                              // the same engine via `useItemsEditor`.
+                              mode === 'headless' ? (
+                                <HeadlessItems
+                                  binding={binding}
+                                  onNodeChange={onNodeChange}
+                                />
+                              ) : (
+                                // Renders the control only — the label above
+                                // is ours, which is why `Field` doesn't draw
+                                // one.
+                                <Field
+                                  binding={binding}
+                                  onNodeChange={onNodeChange}
+                                />
+                              )
                             ) : entries ? (
                               <ParsedValueEditor
                                 binding={binding}

--- a/src/components/dnd/index.ts
+++ b/src/components/dnd/index.ts
@@ -12,6 +12,15 @@ import DraggableItem, {
 import Field, { type FieldProps } from './panel/field';
 import { ICON_MAP, ICON_OPTIONS } from './panel/icon-map';
 import DefaultPanel, { type PanelProps } from './panel/panel';
+import {
+  type ItemsEditor,
+  type ItemsEditorActions,
+  type ItemsEditorItem,
+  type ItemsEditorNestedElement,
+  type ItemsEditorNestedGroup,
+  type ItemsEditorOptions,
+  useItemsEditor,
+} from './panel/use-items-editor';
 
 type DndComponent = typeof DndImpl & {
   DraggableItem: typeof DraggableItem;
@@ -40,6 +49,12 @@ Dnd.DefaultPanel = DefaultPanel;
 Dnd.Field = Field;
 
 export { DraggableItem, DefaultPanel, Field };
+// The array-editing engine behind the built-in Items panel, exposed for a
+// consumer who wants their own markup rather than the built-in control
+// (`Field` covers the latter). Everything it returns is `PanelBinding`s, so
+// the two compose: render the hook's own layout and hand individual
+// bindings to `Field` where the built-in control is good enough.
+export { useItemsEditor };
 // The built-in panel's own `widget: 'icon-picker'` icon set/options —
 // exported so a custom renderPanel can reach icon-picker parity (name ->
 // lucide-react component, and the same label/value pairs fed to Select)
@@ -53,6 +68,12 @@ export type {
   PanelNodeChange,
   PanelProps,
   FieldProps,
+  ItemsEditor,
+  ItemsEditorActions,
+  ItemsEditorItem,
+  ItemsEditorNestedElement,
+  ItemsEditorNestedGroup,
+  ItemsEditorOptions,
   DraggableItemProps,
   DraggableItemDragState,
 };

--- a/src/components/dnd/panel/items.tsx
+++ b/src/components/dnd/panel/items.tsx
@@ -1,64 +1,14 @@
-import { useEffect, useMemo } from 'react';
-
-import * as t from '@babel/types';
-import { Button, Checkbox, Toast } from '@jbpark/ui-kit';
-import { useMultiSelect } from '@jbpark/use-hooks';
+import { Button, Checkbox } from '@jbpark/ui-kit';
 import { ArrowDown, ArrowUp, Copy, Plus, X } from 'lucide-react';
-import { nanoid } from 'nanoid';
 
-import {
-  type BindingRenderLeaf,
-  type BindingRenderMap,
-  type DataAttrNode,
-  type ExtractedNodeValue,
-  type NodeValueType,
-  appendArrayItem,
-  duplicateArrayItems,
-  extract,
-  extractNodeValue,
-  extractObjectProperties,
-  findEditableChildren,
-  generateCode,
-  moveArrayItem,
-  moveArrayItems,
-  parseArrayExpression,
-  parseValue,
-  removeArrayItems,
-  updateArrayItemProperty,
-  updateArrayItemValue,
-} from '~/utils/ast';
+import type { BindingRenderMap } from '~/utils/ast';
 
 import type { PanelNodeChange } from '../dnd';
 import Field from './field';
-import Node from './node';
-
-interface ItemProperty extends ExtractedNodeValue {
-  astNode: t.Node;
-}
-
-interface ItemData {
-  id: string;
-  index: number;
-  // Position in the array's elements, which is what `~/utils/ast`'s item
-  // functions address. Only differs from `index` when the array mixes
-  // objects and primitives.
-  elementIndex: number;
-  editableProperties: Record<string, ItemProperty>;
-  jsxBindings: Record<string, DataAttrNode[]>;
-  // JSX-valued properties (e.g. `label`) whose `jsxBindings` extraction came
-  // back empty — no editable binding found inside them at all. Rather than
-  // silently dropping them, the panel falls back to a raw CodeMirror editor
-  // for the property's source, keyed by property name here. See #298.
-  jsxFallbacks: Record<string, string>;
-}
-
-interface PrimitiveItem {
-  id: string;
-  index: number;
-  elementIndex: number;
-  value: string | number | boolean | null;
-  type: NodeValueType;
-}
+import {
+  type ItemsEditorNestedGroup,
+  useItemsEditor,
+} from './use-items-editor';
 
 interface Props {
   value: string;
@@ -128,308 +78,124 @@ const BulkActionsBar = ({
   );
 };
 
-const Items = ({ value, render, onChange, onChildChange }: Props) => {
-  const { objectItems, primitiveItems, parseError } = useMemo(() => {
-    const ast = parseArrayExpression(value);
-
-    if (!ast) {
-      return {
-        objectItems: [],
-        primitiveItems: [],
-        parseError: true,
-      };
-    }
-
-    const objectItems: ItemData[] = [];
-    const primitiveItems: PrimitiveItem[] = [];
-    const elements = ast.elements.filter((element): element is t.Expression =>
-      Boolean(element),
+// The data-bound elements found inside one JSX-valued property, or the
+// raw-source fallback when that property declared no binding at all (#298).
+const NestedGroup = ({
+  group,
+  onNodeChange,
+}: {
+  group: ItemsEditorNestedGroup;
+  onNodeChange?: PanelNodeChange;
+}) => {
+  if (group.fallback) {
+    return (
+      <div className="space-y-2">
+        <div className="text-xs font-medium text-blue-700">
+          {group.property}
+        </div>
+        <Field binding={group.fallback} onNodeChange={onNodeChange} />
+      </div>
     );
+  }
 
-    elements.forEach((element, elementIndex) => {
-      if (!t.isObjectExpression(element)) {
-        const extracted = extractNodeValue(element);
+  return (
+    <div className="space-y-2">
+      <div className="text-xs font-medium text-blue-700">
+        {group.property} Bindings ({group.elements.length}):
+      </div>
+      {group.elements.map(element => (
+        <div
+          key={`${group.property}-${element.id}`}
+          className="rounded border border-blue-100 bg-blue-50 p-2"
+        >
+          <div className="mb-1 text-xs text-blue-600">
+            &lt;{element.tagName}&gt;
+          </div>
+          <div className="space-y-2 rounded">
+            <div className="space-y-1">
+              {element.bindings.map(binding => (
+                <div key={binding.label} className="space-y-1">
+                  <label className="block text-xs font-semibold text-gray-700">
+                    {binding.label}
+                    <span className="ml-1 text-gray-400">
+                      ({binding.property})
+                    </span>
+                  </label>
+                  <Field binding={binding} onNodeChange={onNodeChange} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
 
-        primitiveItems.push({
-          id: nanoid(6),
-          index: primitiveItems.length,
-          elementIndex,
-          value: extracted.value,
-          type: extracted.type,
-        });
-        return;
-      }
+// Presentation for `useItemsEditor`. Everything that reads or writes the
+// array source lives in that hook, which is exported so a consumer can put
+// their own markup over the same engine — see its doc comment (#237/#308).
+const Items = ({ value, render, onChange, onChildChange }: Props) => {
+  const { kind, items, selection, actions } = useItemsEditor(value, {
+    render,
+    onChange,
+    onNodeChange: onChildChange,
+  });
 
-      const jsxBindings: Record<string, DataAttrNode[]> = {};
-      const jsxFallbacks: Record<string, string> = {};
-
-      element.properties.forEach(prop => {
-        if (
-          !t.isObjectProperty(prop) ||
-          !t.isIdentifier(prop.key) ||
-          !(t.isJSXElement(prop.value) || t.isJSXFragment(prop.value))
-        ) {
-          return;
-        }
-
-        const propertyName = prop.key.name;
-
-        try {
-          const jsxCode = generateCode(prop.value);
-          const nodes = extract(jsxCode);
-          const bindings: DataAttrNode[] = [];
-
-          const bindingContainer = nodes.find(node =>
-            node.bindings?.some(b => b.property === 'children'),
-          );
-
-          if (bindingContainer) {
-            bindings.push(bindingContainer);
-          } else {
-            nodes.forEach(node => {
-              if (
-                node.bindings &&
-                node.bindings.length > 0 &&
-                node.dataAttributes.some(a => a.name === 'data-id')
-              ) {
-                bindings.push(node);
-              }
-              const editableChildren = findEditableChildren(node);
-              bindings.push(...editableChildren);
-            });
-          }
-
-          if (bindings.length > 0) {
-            jsxBindings[propertyName] = bindings;
-          } else {
-            jsxFallbacks[propertyName] = jsxCode;
-          }
-        } catch (error) {
-          console.error(
-            `Failed to parse JSX in property '${propertyName}':`,
-            error,
-          );
-        }
-      });
-
-      objectItems.push({
-        id: nanoid(6),
-        index: objectItems.length,
-        elementIndex,
-        editableProperties: extractObjectProperties(element),
-        jsxBindings,
-        jsxFallbacks,
-      });
-    });
-
-    return { objectItems, primitiveItems, parseError: false };
-  }, [value]);
-
-  useEffect(() => {
-    if (parseError) {
-      Toast.error('Failed to parse items', {
-        description: 'Check the console for details.',
-      });
-    }
-  }, [parseError]);
-
-  const isPrimitive = primitiveItems.length > 0 && objectItems.length === 0;
-
-  const selection = useMultiSelect(
-    isPrimitive ? primitiveItems.length : objectItems.length,
+  const bulkBar = (
+    <BulkActionsBar
+      count={selection.selected.size}
+      onDuplicate={actions.duplicateSelected}
+      onMoveUp={() => actions.moveSelected('up')}
+      onMoveDown={() => actions.moveSelected('down')}
+      onDelete={actions.removeSelected}
+      onClear={selection.clear}
+    />
   );
 
-  // Every mutation goes through `~/utils/ast`'s item functions: the array
-  // source is re-parsed there and a new string comes back, so nothing here
-  // holds or edits AST nodes across renders. `null` means the edit could
-  // not be applied.
-  const commit = (next: string | null) => {
-    if (next === null) {
-      Toast.error('Failed to update this item', {
-        description: 'Check the console for details.',
-      });
-      return;
-    }
+  const itemControls = (item: { index: number; elementIndex: number }) => (
+    <div className="flex space-x-1">
+      <Button
+        size="small"
+        icon={<ArrowUp />}
+        disabled={item.index === 0}
+        onClick={() => actions.move(item.elementIndex, item.index - 1)}
+      />
+      <Button
+        size="small"
+        icon={<ArrowDown />}
+        disabled={item.index === items.length - 1}
+        onClick={() => actions.move(item.elementIndex, item.index + 1)}
+      />
+      <Button
+        danger
+        size="small"
+        icon={<X />}
+        disabled={items.length <= 1}
+        onClick={() => actions.remove(item.elementIndex)}
+      />
+    </div>
+  );
 
-    onChange?.(next);
-  };
-
-  // The panel shows one kind at a time, but the array can hold both, so
-  // selection indices (positions among the visible items) are translated to
-  // element positions before any edit. Keeping the two apart is what stops
-  // an edit from dropping the items that aren't on screen.
-  const elementIndicesOf = (
-    items: { index: number; elementIndex: number }[],
-    indices: Set<number>,
-  ) => {
-    return new Set(
-      items
-        .filter(item => indices.has(item.index))
-        .map(item => item.elementIndex),
-    );
-  };
-
-  const updatePrimitive = (elementIndex: number, next: unknown) => {
-    commit(updateArrayItemValue(value, elementIndex, next));
-  };
-
-  const movePrimitive = (from: number, to: number) => {
-    const target = primitiveItems.find(item => item.index === to);
-
-    if (!target) {
-      return;
-    }
-
-    commit(moveArrayItem(value, from, target.elementIndex));
-    // Positions shift after a move, but count is unchanged so useMultiSelect
-    // never reconciles the set — clear it so a later bulk action can't target
-    // the wrong elements. See #285.
-    selection.clear();
-  };
-
-  const deleteSelectedPrimitives = (indices: Set<number>) => {
-    commit(
-      removeArrayItems(
-        value,
-        elementIndicesOf(primitiveItems, indices),
-        'primitive',
-      ),
-    );
-  };
-
-  const deletePrimitive = (elementIndex: number) => {
-    commit(removeArrayItems(value, new Set([elementIndex]), 'primitive'));
-    // Removing an item shifts every position after it; clear the selection so
-    // a later bulk action can't target the wrong elements. See #285.
-    selection.clear();
-  };
-
-  const addPrimitive = () => {
-    commit(appendArrayItem(value, 'primitive'));
-  };
-
-  const duplicateSelectedPrimitives = (indices: Set<number>) => {
-    commit(
-      duplicateArrayItems(value, elementIndicesOf(primitiveItems, indices)),
-    );
-  };
-
-  const moveSelectedPrimitives = (
-    indices: Set<number>,
-    direction: 'up' | 'down',
-  ) => {
-    const result = moveArrayItems(
-      value,
-      elementIndicesOf(primitiveItems, indices),
-      direction,
-    );
-
-    if (!result) {
-      commit(null);
-      return;
-    }
-
-    // Element positions, which match selection indices for the all-one-kind
-    // arrays the panel is built for.
-    selection.replace(result.indices);
-    commit(result.code);
-  };
-
-  const moveItem = (from: number, to: number) => {
-    const target = objectItems.find(item => item.index === to);
-
-    if (!target) {
-      return;
-    }
-
-    commit(moveArrayItem(value, from, target.elementIndex));
-    // Positions shift after a move, but count is unchanged so useMultiSelect
-    // never reconciles the set — clear it so a later bulk action can't target
-    // the wrong elements. See #285.
-    selection.clear();
-  };
-
-  const updateProperty = (
-    elementIndex: number,
-    propertyKey: string,
-    next: unknown,
-  ) => {
-    commit(
-      updateArrayItemProperty(value, elementIndex, propertyKey, next, render),
-    );
-  };
-
-  const deleteSelectedItems = (indices: Set<number>) => {
-    commit(
-      removeArrayItems(value, elementIndicesOf(objectItems, indices), 'object'),
-    );
-  };
-
-  const deleteItem = (elementIndex: number) => {
-    commit(removeArrayItems(value, new Set([elementIndex]), 'object'));
-    // Removing an item shifts every position after it; clear the selection so
-    // a later bulk action can't target the wrong elements. See #285.
-    selection.clear();
-  };
-
-  const addItem = () => {
-    commit(appendArrayItem(value, 'object'));
-  };
-
-  const duplicateSelectedItems = (indices: Set<number>) => {
-    commit(duplicateArrayItems(value, elementIndicesOf(objectItems, indices)));
-  };
-
-  const moveSelectedItems = (
-    indices: Set<number>,
-    direction: 'up' | 'down',
-  ) => {
-    const result = moveArrayItems(
-      value,
-      elementIndicesOf(objectItems, indices),
-      direction,
-    );
-
-    if (!result) {
-      commit(null);
-      return;
-    }
-
-    selection.replace(result.indices);
-    commit(result.code);
-  };
-
-  if (isPrimitive) {
+  if (kind === 'primitive') {
     return (
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <div className="text-sm font-semibold">
-            Items ({primitiveItems.length})
-          </div>
+          <div className="text-sm font-semibold">Items ({items.length})</div>
           <Button
             size="small"
             icon={<Plus />}
             variant="solid"
             color="green"
-            onClick={addPrimitive}
+            onClick={actions.add}
           >
             Add Item
           </Button>
         </div>
 
-        <BulkActionsBar
-          count={selection.selected.size}
-          onDuplicate={() => duplicateSelectedPrimitives(selection.selected)}
-          onMoveUp={() => moveSelectedPrimitives(selection.selected, 'up')}
-          onMoveDown={() => moveSelectedPrimitives(selection.selected, 'down')}
-          onDelete={() => {
-            deleteSelectedPrimitives(selection.selected);
-            selection.clear();
-          }}
-          onClear={selection.clear}
-        />
+        {bulkBar}
 
-        {primitiveItems.map((item, i) => (
+        {items.map(item => (
           <div
             key={item.id}
             className="space-y-2 rounded border border-gray-100 bg-gray-50 p-2"
@@ -444,43 +210,9 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
                   onChange={() => {}}
                 />
               </div>
-              <div className="flex space-x-1">
-                <Button
-                  size="small"
-                  icon={<ArrowUp />}
-                  disabled={i === 0}
-                  onClick={() =>
-                    movePrimitive(item.elementIndex, item.index - 1)
-                  }
-                />
-                <Button
-                  size="small"
-                  icon={<ArrowDown />}
-                  disabled={i === primitiveItems.length - 1}
-                  onClick={() =>
-                    movePrimitive(item.elementIndex, item.index + 1)
-                  }
-                />
-                <Button
-                  danger
-                  size="small"
-                  icon={<X />}
-                  disabled={primitiveItems.length <= 1}
-                  onClick={() => deletePrimitive(item.elementIndex)}
-                />
-              </div>
+              {itemControls(item)}
             </div>
-            <Field
-              binding={{
-                id: `primitive-${item.id}`,
-                label: `item-${i}`,
-                property: item.type,
-                value: item.value ?? '',
-                rawValue: String(item.value ?? ''),
-                onChange: next => updatePrimitive(item.elementIndex, next),
-              }}
-              onNodeChange={onChildChange}
-            />
+            <Field binding={item.value!} onNodeChange={onChildChange} />
           </div>
         ))}
       </div>
@@ -490,34 +222,22 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <div className="text-sm font-semibold">
-          Items ({objectItems.length})
-        </div>
+        <div className="text-sm font-semibold">Items ({items.length})</div>
         <Button
           size="small"
           icon={<Plus />}
           variant="solid"
           color="green"
-          disabled={objectItems.length === 0}
-          onClick={addItem}
+          disabled={items.length === 0}
+          onClick={actions.add}
         >
           Add Item
         </Button>
       </div>
 
-      <BulkActionsBar
-        count={selection.selected.size}
-        onDuplicate={() => duplicateSelectedItems(selection.selected)}
-        onMoveUp={() => moveSelectedItems(selection.selected, 'up')}
-        onMoveDown={() => moveSelectedItems(selection.selected, 'down')}
-        onDelete={() => {
-          deleteSelectedItems(selection.selected);
-          selection.clear();
-        }}
-        onClear={selection.clear}
-      />
+      {bulkBar}
 
-      {objectItems.map(item => (
+      {items.map(item => (
         <div key={item.id} className="space-y-3 rounded border bg-gray-50 p-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-2">
@@ -532,126 +252,32 @@ const Items = ({ value, render, onChange, onChildChange }: Props) => {
               </div>
               <div className="text-xs font-medium">Item {item.index + 1}</div>
             </div>
-            <div className="flex space-x-1">
-              <Button
-                size="small"
-                icon={<ArrowUp />}
-                disabled={item.index === 0}
-                onClick={() => moveItem(item.elementIndex, item.index - 1)}
-              />
-              <Button
-                size="small"
-                icon={<ArrowDown />}
-                disabled={item.index === objectItems.length - 1}
-                onClick={() => moveItem(item.elementIndex, item.index + 1)}
-              />
-              <Button
-                danger
-                size="small"
-                icon={<X />}
-                disabled={objectItems.length <= 1}
-                onClick={() => deleteItem(item.elementIndex)}
-              />
-            </div>
+            {itemControls(item)}
           </div>
           <div className="space-y-2">
-            {Object.entries(item.editableProperties).map(([key, prop]) => (
-              <div key={`${item.id}-${key}`}>
+            {item.properties.map(binding => (
+              <div key={`${item.id}-${binding.label}`}>
                 <div className="flex flex-col space-y-2">
                   <label className="w-20 shrink-0 text-xs font-medium">
-                    {key}
+                    {binding.label}
                   </label>
-                  <Field
-                    binding={{
-                      id: `item-${item.id}-${key}`,
-                      label: key,
-                      property:
-                        render?.[key] && 'type' in render[key]
-                          ? ((render[key] as BindingRenderLeaf).property ??
-                            (render[key].type as string))
-                          : key,
-                      type:
-                        render?.[key] && 'type' in render[key]
-                          ? (render[key] as BindingRenderLeaf).type
-                          : undefined,
-                      render:
-                        render?.[key] && 'type' in render[key]
-                          ? (render[key] as BindingRenderLeaf).render
-                          : render?.[key] && !('type' in render[key])
-                            ? (render[key] as BindingRenderMap)
-                            : undefined,
-                      value: parseValue(String(prop.value)),
-                      rawValue: String(prop.value),
-                      onChange: next =>
-                        updateProperty(item.elementIndex, key, next),
-                    }}
-                    onNodeChange={onChildChange}
-                  />
+                  <Field binding={binding} onNodeChange={onChildChange} />
                 </div>
                 <span className="text-right text-xs text-gray-500">
-                  ({prop.type})
+                  ({String(binding.meta?.valueType)})
                 </span>
               </div>
             ))}
           </div>
           <div className="space-y-3 border-t pt-2">
-            {Object.entries(item.jsxBindings).length > 0 ||
-            Object.entries(item.jsxFallbacks).length > 0 ? (
-              <>
-                {Object.entries(item.jsxBindings).map(
-                  ([propertyName, bindings]) => (
-                    <div key={propertyName} className="space-y-2">
-                      <div className="text-xs font-medium text-blue-700">
-                        {propertyName} Bindings ({bindings.length}):
-                      </div>
-                      {bindings.map((bindingNode, idx) => {
-                        const nodeId = bindingNode.dataAttributes.find(
-                          a => a.name === 'data-id',
-                        )?.value;
-
-                        return (
-                          <div
-                            key={`binding-${item.id}-${propertyName}-${nodeId || idx}`}
-                            className="rounded border border-blue-100 bg-blue-50
-                              p-2"
-                          >
-                            <div className="mb-1 text-xs text-blue-600">
-                              &lt;{bindingNode.tagName || 'element'}&gt;
-                            </div>
-                            <Node data={bindingNode} onChange={onChildChange} />
-                          </div>
-                        );
-                      })}
-                    </div>
-                  ),
-                )}
-                {Object.entries(item.jsxFallbacks).map(
-                  ([propertyName, code]) => (
-                    <div key={propertyName} className="space-y-2">
-                      <div className="text-xs font-medium text-blue-700">
-                        {propertyName}
-                      </div>
-                      <Field
-                        binding={{
-                          id: `item-${item.id}-${propertyName}-jsx`,
-                          label: propertyName,
-                          property: propertyName,
-                          type: 'jsx',
-                          value: code,
-                          rawValue: code,
-                          onChange: next =>
-                            updateProperty(
-                              item.elementIndex,
-                              propertyName,
-                              next,
-                            ),
-                        }}
-                        onNodeChange={onChildChange}
-                      />
-                    </div>
-                  ),
-                )}
-              </>
+            {item.nested.length ? (
+              item.nested.map(group => (
+                <NestedGroup
+                  key={group.property}
+                  group={group}
+                  onNodeChange={onChildChange}
+                />
+              ))
             ) : (
               <div className="text-xs text-gray-500">
                 ✓ No JSX bindings found

--- a/src/components/dnd/panel/use-items-editor.test.tsx
+++ b/src/components/dnd/panel/use-items-editor.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useItemsEditor } from './use-items-editor';
+
+const objects = `[
+  { key: 'a', label: 'Alpha' },
+  { key: 'b', label: 'Beta' },
+  { key: 'c', label: 'Gamma' },
+]`;
+
+const primitives = `['one', 'two', 'three']`;
+
+// An item whose `children` holds JSX carrying its own data-binding — the
+// shape `bindings` can't reach, which is the whole reason this hook does
+// its own extraction (#308).
+const nested = `[
+  {
+    key: 'row',
+    children: (
+      <div data-id="wrap" data-binding={[{ label: 'Cards', property: 'children' }]}>
+        <p data-id="t1" data-binding={[{ label: 'Title', property: 'innerText' }]}>Open</p>
+        <p data-id="d1" data-binding={[{ label: 'Body', property: 'innerText' }]}>Source</p>
+      </div>
+    ),
+  },
+]`;
+
+describe('useItemsEditor derivation', () => {
+  it('resolves object items to PanelBindings, no AST types leaking out', () => {
+    const { result } = renderHook(() => useItemsEditor(objects));
+
+    expect(result.current.kind).toBe('object');
+    expect(result.current.items).toHaveLength(3);
+
+    const first = result.current.items[0]!;
+    expect(first.properties.map(p => p.label)).toEqual(['key', 'label']);
+    expect(first.properties[0]!.rawValue).toBe('a');
+    expect(typeof first.properties[0]!.onChange).toBe('function');
+  });
+
+  it('exposes a primitive array as one binding per item', () => {
+    const { result } = renderHook(() => useItemsEditor(primitives));
+
+    expect(result.current.kind).toBe('primitive');
+    expect(result.current.items.map(i => i.value!.rawValue)).toEqual([
+      'one',
+      'two',
+      'three',
+    ]);
+    expect(result.current.items[0]!.properties).toEqual([]);
+  });
+
+  it('finds data-bound elements nested inside a JSX-valued property', () => {
+    const { result } = renderHook(() => useItemsEditor(nested));
+
+    const groups = result.current.items[0]!.nested;
+    expect(groups.map(g => g.property)).toEqual(['children']);
+
+    // The wrapper declares `children`, so it wins outright — listing the
+    // <p>s separately would offer the same edit twice.
+    const elements = groups[0]!.elements;
+    expect(elements.map(e => e.id)).toEqual(['wrap']);
+    expect(elements[0]!.bindings.map(b => b.label)).toEqual(['Cards']);
+  });
+
+  it('commits a nested binding through onNodeChange, keyed by data-id', () => {
+    const onNodeChange = vi.fn();
+    const { result } = renderHook(() =>
+      useItemsEditor(nested, { onNodeChange }),
+    );
+
+    result.current.items[0]!.nested[0]!.elements[0]!.bindings[0]!.onChange(
+      'next',
+    );
+
+    expect(onNodeChange).toHaveBeenCalledWith({
+      id: 'wrap',
+      label: 'Cards',
+      property: 'children',
+      value: 'next',
+    });
+  });
+
+  it('reports a parse error instead of throwing on a non-array source', () => {
+    const { result } = renderHook(() => useItemsEditor('not an array'));
+
+    expect(result.current.parseError).toBe(true);
+    expect(result.current.items).toEqual([]);
+  });
+});
+
+describe('useItemsEditor mutations', () => {
+  it('adds, removes and moves through the array source', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useItemsEditor(objects, { onChange }));
+
+    act(() => result.current.actions.add());
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]![0]).toContain("key: 'a'");
+
+    act(() => result.current.actions.remove(0));
+    expect(onChange.mock.calls[1]![0]).not.toContain("key: 'a'");
+
+    act(() => result.current.actions.move(0, 1));
+    const moved = onChange.mock.calls[2]![0];
+    expect(moved.indexOf("key: 'b'")).toBeLessThan(moved.indexOf("key: 'a'"));
+  });
+
+  it('clears the selection after a move, so a later bulk action can not target stale positions', () => {
+    // Positions shift but the count doesn't, so useMultiSelect never
+    // reconciles the set on its own. See #285.
+    const { result } = renderHook(() => useItemsEditor(objects));
+
+    act(() => result.current.selection.toggle(0, false));
+    expect(result.current.selection.selected.size).toBe(1);
+
+    act(() => result.current.actions.move(0, 1));
+    expect(result.current.selection.selected.size).toBe(0);
+  });
+
+  it('clears the selection after a delete', () => {
+    const { result } = renderHook(() => useItemsEditor(objects));
+
+    act(() => result.current.selection.toggle(2, false));
+    act(() => result.current.actions.remove(0));
+
+    expect(result.current.selection.selected.size).toBe(0);
+  });
+
+  it('translates selection indices to element positions for bulk actions', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useItemsEditor(objects, { onChange }));
+
+    act(() => result.current.selection.toggle(1, false));
+    act(() => result.current.actions.removeSelected());
+
+    // Index 1 is Beta. Addressing by the visible index without translating
+    // would be right here only because the array is all one kind — the
+    // point is that Alpha and Gamma survive.
+    const next = onChange.mock.calls[0]![0];
+    expect(next).toContain("key: 'a'");
+    expect(next).not.toContain("key: 'b'");
+    expect(next).toContain("key: 'c'");
+  });
+
+  it('replaces the selection with the moved positions on a bulk move', () => {
+    const { result } = renderHook(() => useItemsEditor(objects));
+
+    act(() => result.current.selection.toggle(1, false));
+    act(() => result.current.actions.moveSelected('up'));
+
+    // Not cleared — the items are still selected, at their new positions.
+    expect([...result.current.selection.selected]).toEqual([0]);
+  });
+});

--- a/src/components/dnd/panel/use-items-editor.ts
+++ b/src/components/dnd/panel/use-items-editor.ts
@@ -1,0 +1,496 @@
+import { useEffect, useMemo } from 'react';
+
+import * as t from '@babel/types';
+import { Toast } from '@jbpark/ui-kit';
+import { useMultiSelect } from '@jbpark/use-hooks';
+import { nanoid } from 'nanoid';
+
+import {
+  type BindingRenderLeaf,
+  type BindingRenderMap,
+  type DataAttrNode,
+  appendArrayItem,
+  duplicateArrayItems,
+  extract,
+  extractNodeValue,
+  extractObjectProperties,
+  findEditableChildren,
+  generateCode,
+  getCurrentValue,
+  getStructuredValue,
+  moveArrayItem,
+  moveArrayItems,
+  parseArrayExpression,
+  parseBinding,
+  parseValue,
+  removeArrayItems,
+  updateArrayItemProperty,
+  updateArrayItemValue,
+} from '~/utils/ast';
+
+import type { PanelBinding, PanelNodeChange } from '../dnd';
+
+// One data-bound element discovered inside a JSX-valued item property.
+// These are the elements the top-level `bindings` array can't reach —
+// `extract()` doesn't walk into an attribute expression, so they're found
+// by re-extracting the property's own JSX here (#308).
+export interface ItemsEditorNestedElement {
+  // The element's `data-id`, which is what commits address it by.
+  id: string;
+  tagName: string;
+  bindings: PanelBinding[];
+}
+
+export interface ItemsEditorNestedGroup {
+  // The item property holding this JSX (e.g. `children`, `label`).
+  property: string;
+  elements: ItemsEditorNestedElement[];
+  // Set instead of `elements` when the JSX parsed but declared no binding
+  // at all. Editing the property's raw source is the only thing left to
+  // offer, so this is a `jsx`-typed binding over that source (#298).
+  fallback?: PanelBinding;
+}
+
+export interface ItemsEditorItem {
+  // Stable only for this parse of `value` — regenerated whenever the source
+  // string changes. Fine as a React key, not as an identity across edits;
+  // use `elementIndex` for that.
+  id: string;
+  // Position among the visible items of this kind, which is what selection
+  // indices refer to.
+  index: number;
+  // Position in the array's elements, which is what every `~/utils/ast`
+  // item function addresses. Differs from `index` when the array mixes
+  // objects and primitives.
+  elementIndex: number;
+  // An object item's plain (non-JSX) properties, already resolved through
+  // the binding `render` map.
+  properties: PanelBinding[];
+  // An object item's JSX-valued properties.
+  nested: ItemsEditorNestedGroup[];
+  // A primitive item's own value. Absent on object items.
+  value?: PanelBinding;
+}
+
+export interface ItemsEditorActions {
+  add: () => void;
+  move: (elementIndex: number, toIndex: number) => void;
+  remove: (elementIndex: number) => void;
+  duplicateSelected: () => void;
+  moveSelected: (direction: 'up' | 'down') => void;
+  removeSelected: () => void;
+}
+
+export interface ItemsEditor {
+  // Which kind the array is being edited as. The panel shows one kind at a
+  // time; an array holding both is treated as objects, and the primitives
+  // stay untouched rather than being dropped.
+  kind: 'object' | 'primitive';
+  items: ItemsEditorItem[];
+  // `@jbpark/use-hooks`' multi-select state, re-exposed as-is: `selected`,
+  // `toggle`, `isSelected`, `clear`, `replace`. Its indices are item
+  // `index` values, not `elementIndex` — the actions below translate.
+  selection: ReturnType<typeof useMultiSelect>;
+  actions: ItemsEditorActions;
+  // The source didn't parse as an array expression. `items` is empty; the
+  // built-in panel also raises a toast.
+  parseError: boolean;
+}
+
+export interface ItemsEditorOptions {
+  render?: BindingRenderMap;
+  // Commits a whole new array source. Every mutation here goes through
+  // `~/utils/ast`'s item functions, which re-parse the source and hand back
+  // a string, so no AST node is held or edited across renders.
+  onChange?: (value: string) => void;
+  // Commits an edit to one nested element, addressed by its own `data-id`.
+  // A single binding's `onChange` can't express this — see #308.
+  onNodeChange?: PanelNodeChange;
+}
+
+const resolveLeaf = (
+  render: BindingRenderMap | undefined,
+  key: string,
+): BindingRenderLeaf | null => {
+  const leaf = render?.[key];
+
+  return leaf && 'type' in leaf ? (leaf as BindingRenderLeaf) : null;
+};
+
+const resolveMap = (
+  render: BindingRenderMap | undefined,
+  key: string,
+): BindingRenderMap | undefined => {
+  const leaf = render?.[key];
+
+  return leaf && !('type' in leaf) ? (leaf as BindingRenderMap) : undefined;
+};
+
+interface RawObjectItem {
+  id: string;
+  index: number;
+  elementIndex: number;
+  editableProperties: ReturnType<typeof extractObjectProperties>;
+  jsxBindings: Record<string, DataAttrNode[]>;
+  jsxFallbacks: Record<string, string>;
+}
+
+interface RawPrimitiveItem {
+  id: string;
+  index: number;
+  elementIndex: number;
+  value: string | number | boolean | null;
+  type: ReturnType<typeof extractNodeValue>['type'];
+}
+
+// Pulls the data-bound elements out of one JSX-valued property. A container
+// declaring `children` wins outright: it owns the elements below it, so
+// listing them separately would offer the same edit twice.
+const bindingsInJSX = (node: t.Expression): DataAttrNode[] => {
+  const nodes = extract(generateCode(node));
+  const container = nodes.find(n =>
+    n.bindings?.some(b => b.property === 'children'),
+  );
+
+  if (container) {
+    return [container];
+  }
+
+  const bindings: DataAttrNode[] = [];
+
+  nodes.forEach(n => {
+    if (
+      n.bindings &&
+      n.bindings.length > 0 &&
+      n.dataAttributes.some(a => a.name === 'data-id')
+    ) {
+      bindings.push(n);
+    }
+
+    bindings.push(...findEditableChildren(n));
+  });
+
+  return bindings;
+};
+
+// The parse. Split from the binding construction below so the Babel work is
+// memoized on the source string alone, while the callbacks the bindings
+// close over stay current on every render.
+const parseSource = (value: string) => {
+  const ast = parseArrayExpression(value);
+
+  if (!ast) {
+    return { objectItems: [], primitiveItems: [], parseError: true };
+  }
+
+  const objectItems: RawObjectItem[] = [];
+  const primitiveItems: RawPrimitiveItem[] = [];
+  const elements = ast.elements.filter((element): element is t.Expression =>
+    Boolean(element),
+  );
+
+  elements.forEach((element, elementIndex) => {
+    if (!t.isObjectExpression(element)) {
+      const extracted = extractNodeValue(element);
+
+      primitiveItems.push({
+        id: nanoid(6),
+        index: primitiveItems.length,
+        elementIndex,
+        value: extracted.value,
+        type: extracted.type,
+      });
+      return;
+    }
+
+    const jsxBindings: Record<string, DataAttrNode[]> = {};
+    const jsxFallbacks: Record<string, string> = {};
+
+    element.properties.forEach(prop => {
+      if (
+        !t.isObjectProperty(prop) ||
+        !t.isIdentifier(prop.key) ||
+        !(t.isJSXElement(prop.value) || t.isJSXFragment(prop.value))
+      ) {
+        return;
+      }
+
+      const propertyName = prop.key.name;
+
+      try {
+        const found = bindingsInJSX(prop.value);
+
+        if (found.length > 0) {
+          jsxBindings[propertyName] = found;
+        } else {
+          jsxFallbacks[propertyName] = generateCode(prop.value);
+        }
+      } catch (error) {
+        console.error(
+          `Failed to parse JSX in property '${propertyName}':`,
+          error,
+        );
+      }
+    });
+
+    objectItems.push({
+      id: nanoid(6),
+      index: objectItems.length,
+      elementIndex,
+      editableProperties: extractObjectProperties(element),
+      jsxBindings,
+      jsxFallbacks,
+    });
+  });
+
+  return { objectItems, primitiveItems, parseError: false };
+};
+
+// The array-editing engine behind the built-in Items panel, exposed so a
+// consumer can render their own markup over it (#237/#308 follow-up).
+//
+// What it saves reimplementing: re-parsing each item's JSX to find nested
+// data-bound elements, resolving the binding `render` map, translating
+// visible item positions to array element positions before every edit, and
+// reconciling the selection after a move or delete (#285). Everything comes
+// back as `PanelBinding`s, the same currency `renderPanel` and
+// `Live.Dnd.Field` already speak, so nothing here requires touching Babel.
+export const useItemsEditor = (
+  value: string,
+  { render, onChange, onNodeChange }: ItemsEditorOptions = {},
+): ItemsEditor => {
+  const { objectItems, primitiveItems, parseError } = useMemo(
+    () => parseSource(value),
+    [value],
+  );
+
+  useEffect(() => {
+    if (parseError) {
+      Toast.error('Failed to parse items', {
+        description: 'Check the console for details.',
+      });
+    }
+  }, [parseError]);
+
+  const kind =
+    primitiveItems.length > 0 && objectItems.length === 0
+      ? 'primitive'
+      : 'object';
+  const isPrimitive = kind === 'primitive';
+
+  const selection = useMultiSelect(
+    isPrimitive ? primitiveItems.length : objectItems.length,
+  );
+
+  // `null` means the edit could not be applied.
+  const commit = (next: string | null) => {
+    if (next === null) {
+      Toast.error('Failed to update this item', {
+        description: 'Check the console for details.',
+      });
+      return;
+    }
+
+    onChange?.(next);
+  };
+
+  // Selection indices are positions among the visible items; every AST
+  // function addresses element positions. Keeping the two apart is what
+  // stops an edit from dropping the items that aren't on screen.
+  const elementIndicesOf = (indices: Set<number>) => {
+    const items = isPrimitive ? primitiveItems : objectItems;
+
+    return new Set(
+      items
+        .filter(item => indices.has(item.index))
+        .map(item => item.elementIndex),
+    );
+  };
+
+  const updateProperty = (
+    elementIndex: number,
+    propertyKey: string,
+    next: unknown,
+  ) => {
+    commit(
+      updateArrayItemProperty(value, elementIndex, propertyKey, next, render),
+    );
+  };
+
+  const actions: ItemsEditorActions = {
+    add: () => commit(appendArrayItem(value, kind)),
+
+    move: (elementIndex, toIndex) => {
+      const items = isPrimitive ? primitiveItems : objectItems;
+      const target = items.find(item => item.index === toIndex);
+
+      if (!target) {
+        return;
+      }
+
+      commit(moveArrayItem(value, elementIndex, target.elementIndex));
+      // Positions shift after a move, but the count doesn't, so
+      // `useMultiSelect` never reconciles the set on its own — clear it so a
+      // later bulk action can't target the wrong elements. See #285.
+      selection.clear();
+    },
+
+    remove: elementIndex => {
+      commit(removeArrayItems(value, new Set([elementIndex]), kind));
+      // Removing an item shifts every position after it; same reasoning.
+      selection.clear();
+    },
+
+    duplicateSelected: () =>
+      commit(duplicateArrayItems(value, elementIndicesOf(selection.selected))),
+
+    moveSelected: direction => {
+      const result = moveArrayItems(
+        value,
+        elementIndicesOf(selection.selected),
+        direction,
+      );
+
+      if (!result) {
+        commit(null);
+        return;
+      }
+
+      // Element positions, which match selection indices for the
+      // all-one-kind arrays this is built for.
+      selection.replace(result.indices);
+      commit(result.code);
+    },
+
+    removeSelected: () => {
+      commit(
+        removeArrayItems(value, elementIndicesOf(selection.selected), kind),
+      );
+      selection.clear();
+    },
+  };
+
+  // Built fresh each render rather than inside the memo above: these close
+  // over `onChange`/`onNodeChange`, and the work is a plain walk of the
+  // already-parsed result — no Babel.
+  const items: ItemsEditorItem[] = isPrimitive
+    ? primitiveItems.map(item => ({
+        id: item.id,
+        index: item.index,
+        elementIndex: item.elementIndex,
+        properties: [],
+        nested: [],
+        value: {
+          id: `primitive-${item.id}`,
+          label: `item-${item.index}`,
+          property: item.type,
+          value: item.value ?? '',
+          rawValue: String(item.value ?? ''),
+          onChange: next =>
+            commit(updateArrayItemValue(value, item.elementIndex, next)),
+        },
+      }))
+    : objectItems.map(item => {
+        const properties: PanelBinding[] = Object.entries(
+          item.editableProperties,
+        ).map(([key, prop]) => {
+          const leaf = resolveLeaf(render, key);
+
+          return {
+            id: `item-${item.id}-${key}`,
+            label: key,
+            property: leaf ? (leaf.property ?? (leaf.type as string)) : key,
+            type: leaf?.type,
+            render: leaf ? leaf.render : resolveMap(render, key),
+            value: parseValue(String(prop.value)),
+            rawValue: String(prop.value),
+            // Carried through so a consumer can label the control with the
+            // property's actual kind, as the built-in panel does.
+            meta: { valueType: prop.type },
+            onChange: next => updateProperty(item.elementIndex, key, next),
+          };
+        });
+
+        const nested: ItemsEditorNestedGroup[] = [
+          ...Object.entries(item.jsxBindings).map(([property, nodes]) => ({
+            property,
+            elements: nodes.flatMap(node => {
+              const id = node.dataAttributes.find(
+                a => a.name === 'data-id',
+              )?.value;
+              const attr = node.dataAttributes.find(
+                a => a.name === 'data-binding',
+              )?.value;
+
+              if (!id || !attr) {
+                return [];
+              }
+
+              const parsed = node.bindings ?? parseBinding(attr);
+
+              if (!parsed.length) {
+                return [];
+              }
+
+              return [
+                {
+                  id,
+                  tagName: node.tagName || 'element',
+                  bindings: parsed.map(binding => ({
+                    id,
+                    label: binding.label,
+                    property: binding.property,
+                    type: binding.type,
+                    widget: binding.widget,
+                    options: binding.options,
+                    render: binding.render,
+                    min: binding.min,
+                    max: binding.max,
+                    pattern: binding.pattern,
+                    required: binding.required,
+                    meta: binding.meta,
+                    value: getStructuredValue(
+                      node,
+                      binding.property,
+                      binding.type,
+                    ),
+                    rawValue: getCurrentValue(node, binding.property),
+                    onChange: (next: unknown) =>
+                      onNodeChange?.({
+                        id,
+                        label: binding.label,
+                        property: binding.property,
+                        value: next,
+                      }),
+                  })),
+                },
+              ];
+            }),
+          })),
+          ...Object.entries(item.jsxFallbacks).map(([property, code]) => ({
+            property,
+            elements: [],
+            fallback: {
+              id: `item-${item.id}-${property}-jsx`,
+              label: property,
+              property,
+              type: 'jsx' as const,
+              value: code,
+              rawValue: code,
+              onChange: (next: unknown) =>
+                updateProperty(item.elementIndex, property, next),
+            },
+          })),
+        ];
+
+        return {
+          id: item.id,
+          index: item.index,
+          elementIndex: item.elementIndex,
+          properties,
+          nested,
+        };
+      });
+
+  return { kind, items, selection, actions, parseError };
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,9 @@ import './index.css';
 import Context from './components/context';
 import LiveDnd, {
   type FieldProps,
+  type ItemsEditor,
+  type ItemsEditorItem,
+  type ItemsEditorOptions,
   type PaletteRenderData,
   type PanelBinding,
   type PanelNodeChange,
@@ -36,6 +39,9 @@ export type {
   PanelNodeChange,
   PanelRenderData,
   FieldProps,
+  ItemsEditor,
+  ItemsEditorItem,
+  ItemsEditorOptions,
   EditorRenderData,
   FrameProps,
   Section,

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -218,6 +218,81 @@ positions before every edit. `Field` already does that. For a plain string,
 number or option binding there's little reason to reach for it — a bare
 `<input>` wired to `binding.onChange` is the simpler answer.
 
+### Your own markup for an array binding: `useItemsEditor`
+
+`Field` gives you the built-in *control*. When you want the same engine but
+a different layout, `useItemsEditor` is that engine on its own:
+
+```tsx
+import { useItemsEditor } from '@jbpark/live-editor/dnd';
+
+const MyItems = ({ binding, onNodeChange }) => {
+  const { items, selection, actions } = useItemsEditor(binding.rawValue, {
+    render: binding.render,
+    onChange: binding.onChange,
+    onNodeChange,
+  });
+
+  return (
+    <div>
+      <button onClick={actions.add}>Add</button>
+      {items.map(item => (
+        <details key={item.id}>
+          <summary>
+            #{item.index + 1}
+            <button onClick={() => actions.remove(item.elementIndex)}>x</button>
+          </summary>
+
+          {/* plain properties of an object item */}
+          {item.properties.map(prop => (
+            <input
+              key={prop.label}
+              defaultValue={prop.rawValue}
+              onBlur={e => prop.onChange(e.target.value)}
+            />
+          ))}
+
+          {/* the nested elements `bindings` can't reach */}
+          {item.nested.map(group =>
+            group.elements.map(el =>
+              el.bindings.map(b => (
+                <Live.Dnd.Field key={b.label} binding={b} onNodeChange={onNodeChange} />
+              )),
+            ),
+          )}
+        </details>
+      ))}
+    </div>
+  );
+};
+```
+
+Everything it returns is a `PanelBinding`, so it composes with `Field` —
+render your own layout and still hand individual bindings to the built-in
+control where that's good enough, as above.
+
+What you don't have to reimplement:
+
+- Re-parsing each item's JSX to find nested data-bound elements, and
+  resolving the binding `render` map onto each property.
+- Translating a visible item position (`index`) to its position in the
+  array's elements (`elementIndex`), which is what every edit addresses.
+  They differ whenever the array mixes objects and primitives.
+- Reconciling the selection after a move or delete. Positions shift while
+  the count stays the same, so the selection has to be cleared or replaced
+  or a later bulk action hits the wrong elements.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `kind` | `'object' \| 'primitive'` | Which kind the array is being edited as. An array holding both is treated as objects; the primitives are left untouched rather than dropped. |
+| `items` | `ItemsEditorItem[]` | One entry per item. `properties` holds an object item's plain fields, `nested` its JSX-valued ones, `value` a primitive item's own binding. |
+| `selection` | multi-select state | `selected`, `toggle`, `isSelected`, `clear`, `replace`. Indices are item `index` values; the actions translate. |
+| `actions` | `ItemsEditorActions` | `add`, `move`, `remove`, plus `duplicateSelected` / `moveSelected` / `removeSelected`. |
+| `parseError` | `boolean` | The source didn't parse as an array. `items` is empty. |
+
+The built-in `Items` panel is written against exactly this hook, so anything
+it can do is reachable here.
+
 ### `PanelBinding`
 
 | Field | Type | Description |


### PR DESCRIPTION
## Summary

Step 2 of the two-step plan from #313. That PR exported the built-in *control* (`Live.Dnd.Field`); this one exports the *engine* — `useItemsEditor` — for consumers who want their own markup rather than the built-in control.

Stacked on #313 — review that one first.

## Why a hook and not more components

`Field` answers "I want the built-in editor here". It doesn't answer "I want the same behavior, my layout". Reproducing that behavior by hand means redoing:

- re-parsing each item's JSX to find the nested data-bound elements `bindings` can't reach (#308),
- resolving the binding `render` map onto each property,
- translating a visible item position (`index`) to its position in the array's elements (`elementIndex`) before every edit — these differ whenever the array mixes objects and primitives,
- reconciling the selection after a move or delete: positions shift while the count stays the same, so `useMultiSelect` never reconciles on its own and a stale set silently targets the wrong elements (#285).

The hook keeps all of it and returns `PanelBinding`s rather than AST nodes, so **nothing on the consumer's side touches Babel** and it composes with `Field`: render your own layout, hand individual bindings to the built-in control where that's good enough.

## Changes

- Add `src/components/dnd/panel/use-items-editor.ts`; export `useItemsEditor` plus `ItemsEditor`, `ItemsEditorItem`, `ItemsEditorNestedGroup`, `ItemsEditorNestedElement`, `ItemsEditorActions`, `ItemsEditorOptions`.
- `panel/items.tsx` becomes presentation over the hook: **668 → 291 lines**.
- Demo: third mode, "Headless items", rendering an array binding as `<details>` rows with its own inputs and bulk controls — visibly different markup, same engine.
- Docs: new section with the API table and what it saves reimplementing.
- Changeset (minor).

Exported from the `./dnd` subpath only, not the root barrel — a value export of a hook there trips `react-refresh/only-export-components`. Types are on both.

## Verifying the refactor is lossless

Behavior-preserving refactors deserve more than a green suite, so I diffed the **rendered markup** of the built-in panel before and after, for every section with array/children bindings:

| section | result |
| --- | --- |
| stats | identical |
| features | identical |
| getting-started | identical |
| faq | identical |
| cta | identical |

Byte-identical once whitespace *inside class attributes* is normalized. The raw diff showed only that: `class="… bg-blue-50\n   p-2"` became `class="… bg-blue-50 p-2"`, because extracting `NestedGroup` reduced the JSX nesting depth and prettier stopped wrapping that string. `class` is a whitespace-separated token list, so the token sets are equal.

```
stats            IDENTICAL  (len 31322 vs 31322)
features         IDENTICAL  (len 21640 vs 21640)
getting-started  IDENTICAL  (len 66733 vs 66733)
faq              IDENTICAL  (len 63504 vs 63504)
cta              IDENTICAL  (len 12537 vs 12537)
```

(The dump harness was temporary and is not part of this PR.)

## Validation

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`
- [x] Manual verification completed

```
pnpm test        20 files, 401 passed (was 391 — +10 hook tests)
pnpm build       ok; useItemsEditor + all six types in dist/dnd/index.d.ts
pnpm build:demos ok
```

The 10 new tests drive the hook directly, covering the parts most likely to rot: nested-JSX extraction, the `onNodeChange` wiring keyed by `data-id`, index translation on bulk actions, selection cleared after move/delete, selection *replaced* after a bulk move, and the parse-error path.

Manual, in the demo's "Headless items" mode with Stats: custom `<details>` markup renders 1 item property + 8 nested leaves; editing a nested Title commits to the canvas, and editing the item's own `key` through the demo's plain `<input>` commits too.

## Type of Change

- [x] refactor — code structure improvement
- [x] feat — new feature
- [x] docs — documentation update

## Scope

- [x] DnD / Canvas
- [x] Documentation

## Checklist

- [x] Commit messages follow conventional-commit style (no gitmoji)
- [x] Updated docs when behavior/API changed
- [x] Added or updated tests when needed
- [x] No unrelated changes included

Note: `website/docs/custom-palette-panel.mdx` fails `prettier --check` before and after — pre-existing on `main`.
