### PR TITLE
refactor(dnd)!: redesign the customization API from render props to hooks and region components

### DIFF
--- a/.changeset/dnd-customization-redesign.md
+++ b/.changeset/dnd-customization-redesign.md
@@ -1,0 +1,45 @@
+---
+'@jbpark/live-editor': major
+---
+
+Redesign `Live.Dnd`'s customization surface around components and hooks instead of render props. Not customizing behaves exactly as before; customizing now reaches the layout, the palette and the panel through the same mechanism.
+
+`renderPalette` and `renderPanel` are **removed**. What they handed over is now published as data through three hooks, and a replacement is an ordinary component rendered inside `Live.Dnd`:
+
+```tsx
+import { useDndPanel } from '@jbpark/live-editor/dnd';
+
+const MyPanel = () => {
+  const { item, bindings, onNodeChange } = useDndPanel();
+  // ...
+};
+
+<Live.Dnd value={value} onChange={setValue}>
+  <Live.Dnd.Layout panel={<MyPanel />} />
+</Live.Dnd>;
+```
+
+Why: a render prop can't hold state. Every non-trivial custom panel ended up extracting a component anyway and re-passing data it had already been handed — the shipped demo's validated field, slider and headless items editor are all this shape. A component reads what it needs where it needs it.
+
+**Migration**
+
+| Before                                | After                                                                                                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `renderPalette={data => ...}`         | a component calling `useDndPalette()`, passed as `Live.Dnd.Layout`'s `palette` slot or placed in `children`                                             |
+| `renderPanel={data => ...}`           | a component calling `useDndPanel()`, passed as the `panel` slot or placed in `children`                                                                 |
+| `PaletteRenderData`                   | `DndPalette` — `{ items, onAdd }`. `DraggableItem` is now the export `Live.Dnd.DraggableItem`; `isMobile` moved to `useDndLayout()`                     |
+| `PanelRenderData`                     | `DndPanel` — same fields                                                                                                                                |
+| `<Live.Dnd.DefaultPanel {...data} />` | `<Live.Dnd.Panel />` — it reads `useDndPanel()` itself, so there's nothing left to spread and `onNodeChange` can't be dropped on the way through (#308) |
+| `Live.Dnd.DefaultLayout`              | `Live.Dnd.Layout`                                                                                                                                       |
+| `PanelProps`                          | no longer public — the built-in panel takes no data props                                                                                               |
+
+New in this release:
+
+- **`children` replaces the arrangement**, not just the content. `Live.Dnd.Palette`, `Live.Dnd.Canvas` and `Live.Dnd.Panel` are the three regions, each in the container it needs; put them wherever you want (a vertical stack, tabs, CSS grid areas) as long as they're inside `Live.Dnd`, which keeps owning the drag context they share. `Canvas` is the one that can't be replaced — it carries the droppable, the sortable list, and the scroll container each section's iframe measures itself against.
+- **`Live.Dnd.Layout` takes `palette`/`panel` slots**, so swapping one region out doesn't mean rebuilding the 3-pane Splitter and the mobile Drawers around it. A slot is placed in both the desktop pane and the mobile Drawer.
+- **`useDndLayout()`** returns the state the built-in mobile chrome runs on (`isMobile`, `selectedId`, `clearSelection`, `paletteOpen`, `setPaletteOpen`) — needed because supplying `children` replaces the floating palette button and both Drawers along with the Splitter.
+- `Palette`, `Canvas`, `Panel`, `Layout`, `useDndPalette`, `useDndPanel`, `useDndLayout`, `DndPalette`, `DndPanel`, `DndLayout`, `DndLayoutProps` and `DndRegionProps` are exported from the `dnd` subpath; the `Dnd*` types also from the package root.
+
+One behaviour change beyond the API: `isMobile` now follows the breakpoint rather than "am I inside the mobile Drawer" — the same value in the built-in layout, and the right one for a custom layout that puts the palette elsewhere on touch, since tap-to-add is about the input device.
+
+Naming: dropping the render props is also what retires the `Default` prefix. `Live.Dnd.Panel` used to be the _slot_ a panel landed in, which is why the built-in panel component had to be `DefaultPanel`. With no slot to disambiguate against, each name refers to one thing.

--- a/demos/custom-palette-panel/custom-palette-panel-demo.tsx
+++ b/demos/custom-palette-panel/custom-palette-panel-demo.tsx
@@ -5,9 +5,13 @@ import { ChevronDown, ChevronUp, Trash } from 'lucide-react';
 
 import Context from '~/components/context';
 import Dnd, {
+  DraggableItem,
   Field,
   type PanelBinding,
   type PanelNodeChange,
+  useDndLayout,
+  useDndPalette,
+  useDndPanel,
   useItemsEditor,
 } from '~/components/dnd';
 import { DEFAULT_TEMPLATE } from '~/constants';
@@ -103,7 +107,7 @@ const ParsedValueEditor = ({
   </div>
 );
 
-// `binding.widget` is an open string (#236) — a custom renderPanel switches
+// `binding.widget` is an open string (#236) — a custom panel switches
 // on it to render whatever control it wants; the built-in panel only knows
 // `icon-picker`/`asset-picker`, so anything else (like `'slider'` here) is
 // exclusively this demo's own choice, not a value the library defines.
@@ -332,23 +336,267 @@ const HeadlessItems = ({
 
 type PanelMode = 'custom' | 'wrap' | 'headless';
 
-// Custom Palette & Panel demo. Mirrors the app's `pages/docs/dnd-custom-render`:
-// `Dnd`'s `renderPalette`/`renderPanel` fully replace the built-in layouts.
-// Drag-and-drop keeps working through the exported `DraggableItem`, and
-// `renderPanel` hands over `bindings` (one per editable field) so custom
-// controls still commit through the same AST-update pipeline.
+type LayoutMode = 'built-in' | 'stacked';
+
+// The palette, replaced end to end. `useDndPalette()` hands over the items
+// and the `onAdd` that drops one onto the canvas; `Live.Dnd.DraggableItem`
+// keeps the dnd-kit wiring, so this only decides what an item looks like.
+// `isMobile` comes from `useDndLayout()` — the same signal the built-in
+// palette uses to decide that a tap should add rather than start a drag.
+const MyPalette = () => {
+  const { items, onAdd } = useDndPalette();
+  const { isMobile } = useDndLayout();
+
+  return (
+    <div className="h-full space-y-2 overflow-y-auto p-2">
+      {items.map(item => (
+        <DraggableItem key={item.id} item={item}>
+          {({ ref, dragProps, isDragging }) => (
+            <div
+              ref={ref}
+              {...dragProps}
+              onClick={isMobile ? () => onAdd(item) : undefined}
+              onDoubleClick={() => onAdd(item)}
+              className={cn(
+                'cursor-grab rounded-lg',
+                'border border-dashed border-blue-300',
+                'bg-blue-50 px-3 py-2',
+                'text-sm font-medium text-blue-700',
+                isDragging && 'opacity-50',
+              )}
+            >
+              {item.name}
+            </div>
+          )}
+        </DraggableItem>
+      ))}
+    </div>
+  );
+};
+
+// The panel, replaced end to end. Being a component rather than a callback is
+// what lets the fields below hold their own state — `ValidatedField` keeps a
+// validation message, `useItemsEditor` keeps a selection — without this
+// having to hoist any of it.
+const MyPanel = ({ mode }: { mode: PanelMode }) => {
+  const {
+    item,
+    onDelete,
+    onMoveUp,
+    onMoveDown,
+    canMoveUp,
+    canMoveDown,
+    bindings,
+    onNodeChange,
+  } = useDndPanel();
+
+  if (!item) {
+    return (
+      <p className="p-4 text-sm text-gray-500">
+        Select a section on the canvas.
+      </p>
+    );
+  }
+
+  return (
+    <div className="h-full space-y-3 overflow-y-auto p-4">
+      <div className="flex items-center justify-between">
+        <span className="font-semibold">{item.name}</span>
+        <div className="flex items-center gap-1">
+          <Button
+            size="small"
+            icon={<ChevronUp />}
+            disabled={!canMoveUp}
+            onClick={onMoveUp}
+            aria-label="Move section up"
+          />
+          <Button
+            size="small"
+            icon={<ChevronDown />}
+            disabled={!canMoveDown}
+            onClick={onMoveDown}
+            aria-label="Move section down"
+          />
+          <Button
+            danger
+            size="small"
+            icon={<Trash />}
+            onClick={() => onDelete(item.id)}
+            aria-label="Delete section"
+          />
+        </div>
+      </div>
+      {!bindings.length && (
+        <p className="text-xs text-gray-400">No editable elements.</p>
+      )}
+      {/* `bindings` is plain data — switch on each entry's `type` to render
+          whatever control you want. onChange commits through the same AST
+          pipeline as the built-in panel. */}
+      {bindings.map((binding, index) => {
+        // An `items`/`children`/array binding holds nested data-bound JSX
+        // that `bindings` alone can't reach (see #308). Flattening it gives
+        // a wall of tiny inputs at best, a raw source textarea at worst — so
+        // hand these back to the built-in control and keep the hand-rolled
+        // ones for the simple types. This is the point of `Live.Dnd.Field`:
+        // the choice is per binding, not all-or-nothing.
+        const isStructural =
+          binding.type === 'array' ||
+          binding.property === 'items' ||
+          binding.property === 'data' ||
+          binding.property === 'children';
+
+        const isMultiline =
+          binding.type === 'jsx' || binding.type === 'richtext';
+        // Some `children` bindings hold a serialized document tree rather
+        // than a few simple fields — Features' "Feature Cards" flattens to
+        // 240 leaves (tag names, ids, individual attributes...), which is
+        // technically correct but useless as a form. Capping the entry count
+        // treats those as opaque instead of rendering a wall of tiny inputs;
+        // a value long enough to likely be one of these (or just a long
+        // plain string) falls back to a textarea rather than the single-line
+        // ValidatedField either way.
+        const flattened =
+          isMultiline || isStructural
+            ? null
+            : flattenEditableValue(binding.rawValue);
+        const entries =
+          flattened && flattened.length <= MAX_EDITABLE_ENTRIES
+            ? flattened
+            : null;
+        const useTextarea =
+          isMultiline || (!entries && binding.rawValue.length > 120);
+
+        return (
+          <label
+            key={`${binding.id}-${binding.property}-${index}`}
+            className="block space-y-1"
+          >
+            <span className="text-xs font-semibold text-gray-700">
+              {binding.label}
+            </span>
+            {isStructural ? (
+              // Same binding, two ways to render it: the built-in control,
+              // or your own markup over the same engine via
+              // `useItemsEditor`.
+              mode === 'headless' ? (
+                <HeadlessItems binding={binding} onNodeChange={onNodeChange} />
+              ) : (
+                // Renders the control only — the label above is ours, which
+                // is why `Field` doesn't draw one.
+                <Field binding={binding} onNodeChange={onNodeChange} />
+              )
+            ) : entries ? (
+              <ParsedValueEditor binding={binding} entries={entries} />
+            ) : binding.widget === 'slider' ? (
+              <SliderField binding={binding} />
+            ) : binding.options ? (
+              <select
+                className="w-full rounded border border-gray-300 px-2 py-1
+                  text-sm"
+                value={binding.rawValue}
+                onChange={e => binding.onChange(e.target.value)}
+              >
+                {binding.options.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            ) : useTextarea ? (
+              <textarea
+                className="w-full rounded border border-gray-300 px-2 py-1
+                  text-sm"
+                rows={3}
+                defaultValue={binding.rawValue}
+                onBlur={e => binding.onChange(e.target.value)}
+              />
+            ) : (
+              <ValidatedField binding={binding} />
+            )}
+          </label>
+        );
+      })}
+    </div>
+  );
+};
+
+// The other way to replace a region: keep the built-in panel and only add
+// around it. `Live.Dnd.Panel` reads `useDndPanel()` itself, so wrapping it
+// can't drop a callback on the way through — `onNodeChange` included, which
+// nested array/children edits need to commit (#308). `h-auto` overrides the
+// region's own `h-full` (className is tailwind-merged over the defaults), so
+// the header above it doesn't push it out of view.
+const WrappedPanel = () => (
+  <div className="h-full overflow-y-auto">
+    <p
+      className={cn(
+        'border-b border-gray-200 bg-gray-50',
+        'px-4 py-2 text-xs text-gray-600',
+      )}
+    >
+      Custom header — the built-in panel below is unchanged.
+    </p>
+    <Dnd.Panel className="h-auto" />
+  </div>
+);
+
+// A layout `Live.Dnd` doesn't ship: the palette as a strip across the top,
+// the canvas filling what's left, the panel as a fixed rail on the right.
+// `Canvas` is the one region that has to stay Dnd's (it owns the droppable,
+// the sortable list and the scroll container each section's iframe measures
+// itself against), so all this has to get right is where things go.
 //
-// The "Wrap built-in" mode shows the other way to use `renderPanel`: keep
-// `DefaultPanel` and only add around it. Spreading the whole render data in
-// is what makes that lossless — `onNodeChange` rides along with it, and
-// without it nested array/children edits (drop in Stats and edit a card's
-// title) wouldn't commit (#308).
+// Note this drops the built-in mobile chrome (the floating palette button and
+// the two Drawers) along with the built-in Splitter; a layout that needs them
+// either builds its own from `useDndLayout()` or goes back to
+// `Live.Dnd.Layout` and replaces one region through its slots.
+const StackedLayout = ({
+  palette,
+  panel,
+}: {
+  palette: React.ReactNode;
+  panel: React.ReactNode;
+}) => (
+  <div className="flex h-full min-h-0 w-full flex-col">
+    <div
+      className={cn(
+        'max-h-32 shrink-0 overflow-y-auto',
+        'border-b border-gray-200 p-2',
+      )}
+    >
+      {palette}
+    </div>
+    <div className="flex min-h-0 flex-1">
+      <Dnd.Canvas className="min-w-0 flex-1" />
+      <div className="w-72 shrink-0 border-l border-gray-200">{panel}</div>
+    </div>
+  </div>
+);
+
+// Custom Palette & Panel demo. Mirrors the app's `pages/docs/dnd-custom-render`:
+// `Live.Dnd` renders its built-in layout until you give it children, and every
+// region behind that layout is reachable as data — `useDndPalette()`,
+// `useDndPanel()`, `useDndLayout()` — so a replacement is an ordinary
+// component rather than a callback. Drag-and-drop keeps working through the
+// exported `DraggableItem`, and `useDndPanel()`'s `bindings` (one per editable
+// field) keep custom controls committing through the same AST-update pipeline.
+//
+// The "Wrap built-in" mode shows the other end of the range: keep
+// `Live.Dnd.Panel` and only add around it (see `WrappedPanel`).
 //
 // "Headless items" is the third option: keep your own markup but reuse the
 // array-editing engine through `useItemsEditor` (see `HeadlessItems`).
+//
+// The Layout toggle is the outer layer. "Built-in" keeps the shipped 3-pane
+// Splitter and mobile chrome and only fills its `palette`/`panel` slots;
+// "Stacked" replaces the arrangement itself (see `StackedLayout`).
 const CustomPalettePanelDemo = () => {
   const [value, setValue] = useState(DEFAULT_TEMPLATE);
   const [mode, setMode] = useState<PanelMode>('custom');
+  const [layout, setLayout] = useState<LayoutMode>('built-in');
+
+  const palette = <MyPalette />;
+  const panel = mode === 'wrap' ? <WrappedPanel /> : <MyPanel mode={mode} />;
 
   return (
     <Context>
@@ -381,6 +629,21 @@ const CustomPalettePanelDemo = () => {
           >
             Headless items
           </Button>
+          <span className="ml-4 text-xs text-gray-600">Layout</span>
+          <Button
+            size="small"
+            type={layout === 'built-in' ? 'primary' : 'default'}
+            onClick={() => setLayout('built-in')}
+          >
+            Built-in
+          </Button>
+          <Button
+            size="small"
+            type={layout === 'stacked' ? 'primary' : 'default'}
+            onClick={() => setLayout('stacked')}
+          >
+            Stacked
+          </Button>
         </div>
         <Dnd
           value={value}
@@ -388,215 +651,13 @@ const CustomPalettePanelDemo = () => {
           frame={{ mode: 'shadow', syncStyle: true }}
           dynamicTailwind
           className="min-h-0 flex-1 overflow-y-auto"
-          renderPalette={({ items, onAdd, DraggableItem, isMobile }) => (
-            <div className="space-y-2 p-2">
-              {items.map(item => (
-                <DraggableItem key={item.id} item={item}>
-                  {({ ref, dragProps, isDragging }) => (
-                    <div
-                      ref={ref}
-                      {...dragProps}
-                      onClick={isMobile ? () => onAdd(item) : undefined}
-                      onDoubleClick={() => onAdd(item)}
-                      className={cn(
-                        'cursor-grab rounded-lg',
-                        'border border-dashed border-blue-300',
-                        'bg-blue-50 px-3 py-2',
-                        'text-sm font-medium text-blue-700',
-                        isDragging && 'opacity-50',
-                      )}
-                    >
-                      {item.name}
-                    </div>
-                  )}
-                </DraggableItem>
-              ))}
-            </div>
+        >
+          {layout === 'stacked' ? (
+            <StackedLayout palette={palette} panel={panel} />
+          ) : (
+            <Dnd.Layout palette={palette} panel={panel} />
           )}
-          renderPanel={data => {
-            if (mode === 'wrap') {
-              // Spreading the whole render data keeps the built-in panel
-              // fully functional — including `onNodeChange`, which nested
-              // array/children editors need to commit.
-              return (
-                <div className="h-full overflow-y-auto">
-                  <p
-                    className={cn(
-                      'border-b border-gray-200 bg-gray-50',
-                      'px-4 py-2 text-xs text-gray-600',
-                    )}
-                  >
-                    Custom header — the built-in panel below is unchanged.
-                  </p>
-                  <Dnd.DefaultPanel {...data} />
-                </div>
-              );
-            }
-
-            const {
-              item,
-              onDelete,
-              onMoveUp,
-              onMoveDown,
-              canMoveUp,
-              canMoveDown,
-              bindings,
-              onNodeChange,
-            } = data;
-
-            return (
-              <div className="space-y-3 p-4">
-                {item ? (
-                  <>
-                    <div className="flex items-center justify-between">
-                      <span className="font-semibold">{item.name}</span>
-                      <div className="flex items-center gap-1">
-                        <Button
-                          size="small"
-                          icon={<ChevronUp />}
-                          disabled={!canMoveUp}
-                          onClick={onMoveUp}
-                          aria-label="Move section up"
-                        />
-                        <Button
-                          size="small"
-                          icon={<ChevronDown />}
-                          disabled={!canMoveDown}
-                          onClick={onMoveDown}
-                          aria-label="Move section down"
-                        />
-                        <Button
-                          danger
-                          size="small"
-                          icon={<Trash />}
-                          onClick={() => onDelete(item.id)}
-                          aria-label="Delete section"
-                        />
-                      </div>
-                    </div>
-                    {bindings.length ? (
-                      // `bindings` is plain data — switch on each entry's `type`
-                      // to render whatever control you want. onChange commits
-                      // through the same AST pipeline as the built-in panel.
-                      bindings.map((binding, index) => {
-                        // An `items`/`children`/array binding holds nested
-                        // data-bound JSX that `bindings` alone can't reach
-                        // (see #308). Flattening it gives a wall of tiny
-                        // inputs at best, a raw source textarea at worst —
-                        // so hand these back to the built-in control and
-                        // keep the hand-rolled ones for the simple types.
-                        // This is the point of `Live.Dnd.Field`: the choice
-                        // is per binding, not all-or-nothing.
-                        const isStructural =
-                          binding.type === 'array' ||
-                          binding.property === 'items' ||
-                          binding.property === 'data' ||
-                          binding.property === 'children';
-
-                        const isMultiline =
-                          binding.type === 'jsx' || binding.type === 'richtext';
-                        // Some `children` bindings hold a serialized document
-                        // tree rather than a few simple fields — Features'
-                        // "Feature Cards" flattens to 240 leaves (tag names,
-                        // ids, individual attributes...), which is technically
-                        // correct but useless as a form. Capping the entry
-                        // count treats those as opaque instead of rendering a
-                        // wall of tiny inputs; a value long enough to likely be
-                        // one of these (or just a long plain string) falls
-                        // back to a textarea rather than the single-line
-                        // ValidatedField either way.
-                        const flattened =
-                          isMultiline || isStructural
-                            ? null
-                            : flattenEditableValue(binding.rawValue);
-                        const entries =
-                          flattened && flattened.length <= MAX_EDITABLE_ENTRIES
-                            ? flattened
-                            : null;
-                        const useTextarea =
-                          isMultiline ||
-                          (!entries && binding.rawValue.length > 120);
-
-                        return (
-                          <label
-                            key={`${binding.id}-${binding.property}-${index}`}
-                            className="block space-y-1"
-                          >
-                            <span
-                              className="text-xs font-semibold text-gray-700"
-                            >
-                              {binding.label}
-                            </span>
-                            {isStructural ? (
-                              // Same binding, two ways to render it: the
-                              // built-in control, or your own markup over
-                              // the same engine via `useItemsEditor`.
-                              mode === 'headless' ? (
-                                <HeadlessItems
-                                  binding={binding}
-                                  onNodeChange={onNodeChange}
-                                />
-                              ) : (
-                                // Renders the control only — the label above
-                                // is ours, which is why `Field` doesn't draw
-                                // one.
-                                <Field
-                                  binding={binding}
-                                  onNodeChange={onNodeChange}
-                                />
-                              )
-                            ) : entries ? (
-                              <ParsedValueEditor
-                                binding={binding}
-                                entries={entries}
-                              />
-                            ) : binding.widget === 'slider' ? (
-                              <SliderField binding={binding} />
-                            ) : binding.options ? (
-                              <select
-                                className="w-full rounded border border-gray-300
-                                  px-2 py-1 text-sm"
-                                value={binding.rawValue}
-                                onChange={e => binding.onChange(e.target.value)}
-                              >
-                                {binding.options.map(option => (
-                                  <option
-                                    key={option.value}
-                                    value={option.value}
-                                  >
-                                    {option.label}
-                                  </option>
-                                ))}
-                              </select>
-                            ) : useTextarea ? (
-                              <textarea
-                                className="w-full rounded border border-gray-300
-                                  px-2 py-1 text-sm"
-                                rows={3}
-                                defaultValue={binding.rawValue}
-                                onBlur={e => binding.onChange(e.target.value)}
-                              />
-                            ) : (
-                              <ValidatedField binding={binding} />
-                            )}
-                          </label>
-                        );
-                      })
-                    ) : (
-                      <p className="text-xs text-gray-400">
-                        No editable elements.
-                      </p>
-                    )}
-                  </>
-                ) : (
-                  <p className="text-sm text-gray-500">
-                    Select a section on the canvas.
-                  </p>
-                )}
-              </div>
-            );
-          }}
-        />
+        </Dnd>
       </div>
     </Context>
   );

--- a/src/components/dnd/dnd.test.tsx
+++ b/src/components/dnd/dnd.test.tsx
@@ -5,20 +5,22 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_TEMPLATE, DRAGGABLE_ITEMS } from '~/constants';
 
 import { PreviewContext } from '../context/states';
-import Dnd, { type PanelRenderData } from './dnd';
+import Dnd, { type DndPanel } from './dnd';
+import { Canvas } from './layout';
+import { useDndPanel } from './layout-context';
 import Field from './panel/field';
 
 // The canvas isn't what's under test here, and each section renders a
 // compiled component inside an iframe — none of which jsdom needs to do for
-// us to inspect the data `renderPanel` is handed.
+// us to inspect the data `useDndPanel()` hands over.
 vi.mock('./renderer', () => ({
   default: () => <div data-testid="renderer" />,
 }));
 
-// jsdom has no ResizeObserver, which `useResponsiveSize` (via ui-kit's
-// breakpoint hook) constructs on mount. Never observes anything here — the
-// default breakpoint is enough to land on the desktop layout, where the
-// panel renders unconditionally.
+// jsdom has no ResizeObserver, which `useResponsiveSize` constructs on
+// mount. Never observes anything here, which is fine: the breakpoint only
+// decides how the *built-in* layout arranges itself, and these tests supply
+// their own children instead. See layout.test.tsx for the breakpoint paths.
 beforeAll(() => {
   globalThis.ResizeObserver = class {
     observe() {}
@@ -35,24 +37,26 @@ const documentWith = (sectionCode: string) =>
     `<main id="app-container">${sectionCode}</main>`,
   );
 
-// Renders Dnd with a custom `renderPanel`, selects the only section by
-// clicking it on the canvas, and hands back the data the panel last
-// received plus the Dnd-level onChange spy.
+// Renders Dnd with a custom layout whose panel is nothing but a probe on
+// `useDndPanel()`, selects the only section by clicking it on the canvas, and
+// hands back the data the panel last read plus the Dnd-level onChange spy.
 const renderWithPanel = () => {
   const onChange = vi.fn();
   const setCode = vi.fn();
-  let data: PanelRenderData | undefined;
+  let data: DndPanel | undefined;
+
+  const Probe = () => {
+    data = useDndPanel();
+
+    return <div data-testid="panel" />;
+  };
 
   const { container } = render(
     <PreviewContext.Provider value={{ code: '', setCode }}>
-      <Dnd
-        value={documentWith(stats.code)}
-        onChange={onChange}
-        renderPanel={next => {
-          data = next;
-          return <div data-testid="panel" />;
-        }}
-      />
+      <Dnd value={documentWith(stats.code)} onChange={onChange}>
+        <Canvas />
+        <Probe />
+      </Dnd>
     </PreviewContext.Provider>,
   );
 
@@ -67,7 +71,7 @@ const renderWithPanel = () => {
   return { onChange, getData: () => data };
 };
 
-describe('renderPanel data', () => {
+describe('useDndPanel() data', () => {
   it('forwards the node-level commit callback', () => {
     const { getData } = renderWithPanel();
 

--- a/src/components/dnd/dnd.tsx
+++ b/src/components/dnd/dnd.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { Children, useEffect, useMemo, useState } from 'react';
 
 import {
   DndContext,
@@ -17,16 +17,8 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import {
-  Button,
-  Drawer,
-  Space,
-  Splitter,
-  Toast,
-  Typography,
-} from '@jbpark/ui-kit';
+import { Space, Toast, Typography } from '@jbpark/ui-kit';
 import { useResponsiveSize } from '@jbpark/use-hooks';
-import { LayoutGrid } from 'lucide-react';
 
 import { DRAGGABLE_ITEMS } from '~/constants';
 import type { Section } from '~/types';
@@ -48,10 +40,10 @@ import { DEFAULT_TEMPLATE } from '../../constants';
 import { cn, preloadScripts } from '../../utils';
 import { usePreview } from '../context/states';
 import { type FrameProps } from '../frame';
-import DraggableItem, { DefaultDraggableItem } from './draggable';
 import Droppable from './droppable';
+import Layout from './layout';
+import { DndRegionContext } from './layout-context';
 import Overlay from './overlay';
-import Panel from './panel';
 import Renderer from './renderer';
 import Sortable from './sortable';
 import { useSectionDocument } from './use-section-document';
@@ -111,22 +103,20 @@ const describeUpdateFailure = (
   }
 };
 
-export interface PaletteRenderData {
+// What `useDndPalette()` returns. Deliberately just data: the drag wiring is
+// a component (`Live.Dnd.DraggableItem`) and the breakpoint belongs to
+// `useDndLayout()`, so a custom palette takes each from where it lives
+// rather than having all three funnelled through one object.
+export interface DndPalette {
   items: Section[];
+  // Appends the item to the canvas. Closes the mobile palette Drawer too,
+  // which is a no-op wherever it isn't open.
   onAdd: (item: Section) => void;
-  DraggableItem: typeof DraggableItem;
-  // True when the palette is rendering inside the mobile Drawer, where a
-  // tap can't be a failed drag attempt (there's nothing to drag onto —
-  // the canvas is stacked behind the Drawer) and native dblclick synthesis
-  // from double-tap is unreliable on touch. Custom renderPalette
-  // implementations should treat a single click/tap as "add" here instead
-  // of relying on onDoubleClick.
-  isMobile: boolean;
 }
 
-// The node-level commit callback's shape, named because it's now part of
-// the public surface in three places (`PanelRenderData`, `DefaultPanel`,
-// `Field`) and was previously spelled out inline in each — see #308.
+// The node-level commit callback's shape, named because it's part of the
+// public surface in two places (`DndPanel`, `Field`) and was previously
+// spelled out inline in each — see #308.
 export interface PanelNodeChange {
   (params: {
     id: string;
@@ -136,12 +126,15 @@ export interface PanelNodeChange {
   }): void;
 }
 
-export interface PanelRenderData {
+// What `useDndPanel()` returns — everything the built-in property panel runs
+// on, so a custom panel starts from the same place rather than re-deriving
+// any of it.
+export interface DndPanel {
   item?: Section;
   onChange: (next: Partial<Section>) => void;
   onDelete: (id: string) => void;
   // Alternative to dragging a section to reorder it — needed since the
-  // canvas sits behind the mobile Drawer this panel renders in, so
+  // canvas sits behind the mobile Drawer the panel renders in, so
   // there's nothing visible to drag onto there.
   onMoveUp: () => void;
   onMoveDown: () => void;
@@ -161,14 +154,14 @@ export interface PanelRenderData {
   // own JSX. Those `data-id`s never reach `bindings` (the top-level
   // `extract()` doesn't walk into an attribute expression), and no single
   // `PanelBinding.onChange` can address them since each one closes over a
-  // fixed `id` — hence this `(id, label, property, value)` channel. Pass it
-  // straight through when re-embedding `DefaultPanel`, otherwise nested
+  // fixed `id` — hence this `(id, label, property, value)` channel. Hand it
+  // to `Live.Dnd.Field` along with the binding, otherwise nested
   // array/children edits inside it silently don't commit (#308).
   onNodeChange: PanelNodeChange;
 }
 
 // One editable data-binding, flattened out of the selected section for a
-// custom renderPanel. Exposes just what a consumer needs to render its own
+// custom panel. Exposes just what a consumer needs to render its own
 // control — the declared `type`, the current `value`, and an `onChange`
 // that commits through Dnd's AST-update pipeline — so it never has to touch
 // DataAttrNode/parseBinding/getCurrentValue itself.
@@ -184,8 +177,8 @@ export interface PanelBinding {
   // -> checkbox, ...). `undefined` means a plain string binding.
   type?: BindingType;
   // Presentation, as opposed to `type`'s data kind — an open string, not a
-  // closed enum, since a custom renderPanel can declare any widget it
-  // wants (e.g. `'slider'`) and switch on it itself. The built-in panel
+  // closed enum, since a custom panel can declare any widget it wants
+  // (e.g. `'slider'`) and switch on it itself. The built-in panel
   // only recognizes `'icon-picker'`/`'asset-picker'`; anything else falls
   // back to the `type`-appropriate default control. See #236.
   widget?: string;
@@ -234,13 +227,21 @@ export interface Props extends Omit<
   dynamicTailwind?: boolean;
   provider?: (children: React.ReactNode) => React.ReactNode;
   onChange?: (value: string) => void;
-  // Full replacements for the built-in left palette / right panel — receive
-  // the same data/callbacks Dnd itself uses, so drag-and-drop and field
-  // editing keep working exactly as before, just with custom markup. Used
-  // for both the desktop layout and the mobile drawer, since those already
-  // render identical content today.
-  renderPalette?: (data: PaletteRenderData) => React.ReactNode;
-  renderPanel?: (data: PanelRenderData) => React.ReactNode;
+  // The single customization slot. Omit it for the built-in editor. Supply
+  // it and you own the arrangement: compose `Live.Dnd.Palette` /
+  // `Live.Dnd.Canvas` / `Live.Dnd.Panel` (each the built-in region, in the
+  // container it needs) and your own components in any structure you like.
+  // The drag context wraps all of it, so drag-and-drop and field editing
+  // keep working wherever a region lands. Your components read the same data
+  // the built-ins do through `useDndPalette()` / `useDndPanel()` /
+  // `useDndLayout()`.
+  //
+  // Note this replaces the mobile chrome too — the FAB and both Drawers live
+  // in `Live.Dnd.Layout`, which is what runs when children are omitted.
+  // Render it yourself (`<Live.Dnd.Layout panel={<MyPanel />} />`) to keep
+  // the built-in arrangement while swapping one region. Render `Canvas` at
+  // most once either way.
+  children?: React.ReactNode;
 }
 
 const conditionalModifiers: Modifier = args => {
@@ -263,8 +264,7 @@ const Dnd = ({
   frame,
   dynamicTailwind = false,
   provider,
-  renderPalette,
-  renderPanel,
+  children,
   ...restProps
 }: Props) => {
   const [mobilePaletteOpen, setMobilePaletteOpen] = useState(false);
@@ -354,8 +354,9 @@ const Dnd = ({
   // Reads only the extracted `code` local, not `selectedItem`, so the
   // compiler can verify this dependency array actually matches what the
   // body reads — matches Panel's own former version of this same logic,
-  // now shared here so both the built-in Panel and a custom renderPanel
-  // get the same extraction/update pipeline instead of each needing it.
+  // now shared here so both the built-in Panel and a custom one built on
+  // `useDndPanel()` get the same extraction/update pipeline instead of each
+  // needing it.
   const selectedCode = selectedItem?.code;
   const { fields, updatedCode, parseError } = useMemo(() => {
     if (!selectedCode) {
@@ -424,11 +425,11 @@ const Dnd = ({
   // Flattens the extracted `fields` (one DataAttrNode per element) down to
   // one PanelBinding per bound property — the same walk the built-in
   // FieldEditor/Node does internally (data-id + parsed data-binding +
-  // current value), but handed to a custom renderPanel as plain data so it
-  // can render its own controls. Kept in a useMemo keyed on `fields` alone;
-  // `onFieldChange` closes over `updatedCode`/`selectedItem` but is stable
-  // enough per render, and rebuilding on every render would defeat the memo
-  // guarding renderPanel's children.
+  // current value), but published through `useDndPanel()` as plain data so a
+  // custom panel can render its own controls. Kept in a useMemo keyed on
+  // `fields` alone; `onFieldChange` closes over `updatedCode`/`selectedItem`
+  // but is stable enough per render, and rebuilding this array on every
+  // render would re-render every panel consuming it.
   const bindings = useMemo<PanelBinding[]>(() => {
     return fields.flatMap(node => {
       const dataId = node.dataAttributes.find(a => a.name === 'data-id')?.value;
@@ -478,81 +479,35 @@ const Dnd = ({
     }
   }, [frame?.scripts]);
 
-  const renderPaletteItems = (
-    onAdd: (item: Section) => void,
-    forMobileDrawer = false,
-  ) => {
-    const paletteItems = items?.length ? items : DRAGGABLE_ITEMS;
-
-    if (renderPalette) {
-      return renderPalette({
-        items: paletteItems,
-        onAdd,
-        DraggableItem,
-        isMobile: forMobileDrawer,
-      });
-    }
-
-    return (
-      <Space orientation="vertical" align="start">
-        {paletteItems.map(item => (
-          <DefaultDraggableItem
-            key={item.id}
-            item={item}
-            onAdd={onAdd}
-            tapToAdd={forMobileDrawer}
-          />
-        ))}
-      </Space>
-    );
+  // Data, not nodes: the built-in palette and panel read these back through
+  // `useDndPalette()`/`useDndPanel()` exactly as a custom one does, so
+  // there's a single path and no way for the public surface to drift into a
+  // subset of what the built-ins use — the point of #237.
+  const palette: DndPalette = {
+    items: items?.length ? items : DRAGGABLE_ITEMS,
+    onAdd: (item: Section) => {
+      addItem(item);
+      setMobilePaletteOpen(false);
+    },
   };
 
-  const renderPanelContent = () => {
-    const canMoveUp = selectedIndex > 0;
-    const canMoveDown =
-      selectedIndex >= 0 && selectedIndex < sections.length - 1;
-
-    if (renderPanel) {
-      return renderPanel({
-        item: selectedItem,
-        onChange,
-        onDelete,
-        onMoveUp: () => moveSection(selectedId, 'up'),
-        onMoveDown: () => moveSection(selectedId, 'down'),
-        canMoveUp,
-        canMoveDown,
-        bindings,
-        onNodeChange: onFieldChange,
-      });
-    }
-
-    return (
-      <Panel
-        item={selectedItem}
-        onDelete={onDelete}
-        onMoveUp={() => moveSection(selectedId, 'up')}
-        onMoveDown={() => moveSection(selectedId, 'down')}
-        canMoveUp={canMoveUp}
-        canMoveDown={canMoveDown}
-        bindings={bindings}
-        onNodeChange={onFieldChange}
-      />
-    );
+  const panel: DndPanel = {
+    item: selectedItem,
+    onChange,
+    onDelete,
+    onMoveUp: () => moveSection(selectedId, 'up'),
+    onMoveDown: () => moveSection(selectedId, 'down'),
+    canMoveUp: selectedIndex > 0,
+    canMoveDown: selectedIndex >= 0 && selectedIndex < sections.length - 1,
+    bindings,
+    onNodeChange: onFieldChange,
   };
 
-  // Shared between the mobile (full-width) and desktop (Splitter middle
-  // panel) layouts below, so the drop target/sortable-list markup isn't
-  // duplicated per branch.
+  // Content only — the frame container that wraps this (`data-frame-container`
+  // plus the containment styles) belongs to `Live.Dnd.Canvas`, so a custom
+  // layout can't accidentally drop it while still placing the canvas.
   const canvas = (
-    <div
-      className="relative h-full w-full overflow-y-auto"
-      data-frame-container
-      style={{
-        isolation: 'isolate',
-        contain: 'layout style',
-        transform: 'translateZ(0)',
-      }}
-    >
+    <>
       <Droppable
         className={cn(
           !sections.length && 'h-full',
@@ -604,7 +559,7 @@ const Dnd = ({
           </SortableContext>
         )}
       </Droppable>
-    </div>
+    </>
   );
 
   return (
@@ -628,60 +583,29 @@ const Dnd = ({
           )}
           {...restProps}
         >
-          {isMobile ? (
-            canvas
-          ) : (
-            <Splitter withHandle orientation="horizontal">
-              <Splitter.Panel
-                defaultSize="20%"
-                minSize="15%"
-                maxSize="35%"
-                collapsible
-              >
-                <div className="h-full overflow-y-auto bg-gray-50 p-4">
-                  {renderPaletteItems(addItem)}
-                </div>
-              </Splitter.Panel>
-              <Splitter.Panel defaultSize="60%">{canvas}</Splitter.Panel>
-              <Splitter.Panel
-                defaultSize="20%"
-                minSize="15%"
-                maxSize="35%"
-                collapsible
-              >
-                {renderPanelContent()}
-              </Splitter.Panel>
-            </Splitter>
-          )}
-          <Button
-            type="primary"
-            shape="circle"
-            icon={<LayoutGrid />}
-            aria-label="Components"
-            className="fixed right-4 bottom-4 z-20 md:hidden"
-            onClick={() => setMobilePaletteOpen(true)}
-          />
-          <Drawer
-            open={isMobile && mobilePaletteOpen}
-            onClose={() => setMobilePaletteOpen(false)}
-            direction="bottom"
-            size="large"
-            title="Components"
+          {/* Not memoized: `palette`, `panel` and `canvas` are all rebuilt
+              each render anyway, so a memo would only add a dependency list
+              to keep in sync. */}
+          <DndRegionContext.Provider
+            value={{
+              palette,
+              panel,
+              canvas,
+              isMobile,
+              selectedId,
+              clearSelection,
+              paletteOpen: mobilePaletteOpen,
+              setPaletteOpen: setMobilePaletteOpen,
+            }}
           >
-            {renderPaletteItems(item => {
-              addItem(item);
-              setMobilePaletteOpen(false);
-            }, true)}
-          </Drawer>
-          <Drawer
-            open={isMobile && Boolean(selectedId)}
-            onClose={clearSelection}
-            direction="bottom"
-            size="large"
-            title="Properties"
-          >
-            {renderPanelContent()}
-          </Drawer>
+            {/* `Children.toArray` rather than a plain `children ??`: a JSX
+                comment, or a `{cond && <MyLayout />}` that fell through,
+                leaves `children` set but empty — and honouring that
+                literally renders an editor with no regions at all, which
+                looks like a broken build rather than a mistake in the
+                layout. Falling back keeps the failure legible. */}
+            {Children.toArray(children).length ? children : <Layout />}
+          </DndRegionContext.Provider>
         </div>
         <DragOverlay>
           <Overlay

--- a/src/components/dnd/draggable.tsx
+++ b/src/components/dnd/draggable.tsx
@@ -16,7 +16,7 @@ export interface DraggableItemProps {
 }
 
 // Owns the dnd-kit wiring (useDraggable + the `type: 'new-item'` data shape
-// Dnd's onDragEnd expects) so a custom renderPalette only has to decide how
+// Dnd's onDragEnd expects) so a custom palette only has to decide how
 // an item *looks*, not how dragging itself works. Exported as
 // Dnd.DraggableItem for that purpose; also used internally for the default
 // palette rendering, so both paths share the exact same drag wiring.

--- a/src/components/dnd/index.ts
+++ b/src/components/dnd/index.ts
@@ -1,17 +1,30 @@
 import DndImpl, {
-  type PaletteRenderData,
+  type DndPalette,
+  type DndPanel,
   type PanelBinding,
   type PanelNodeChange,
-  type PanelRenderData,
   type Props,
 } from './dnd';
 import DraggableItem, {
   type DraggableItemDragState,
   type DraggableItemProps,
 } from './draggable';
+import {
+  Canvas,
+  type DndLayoutProps,
+  type DndRegionProps,
+  Layout,
+  Palette,
+  Panel,
+} from './layout';
+import {
+  type DndLayout,
+  useDndLayout,
+  useDndPalette,
+  useDndPanel,
+} from './layout-context';
 import Field, { type FieldProps } from './panel/field';
 import { ICON_MAP, ICON_OPTIONS } from './panel/icon-map';
-import DefaultPanel, { type PanelProps } from './panel/panel';
 import {
   type ItemsEditor,
   type ItemsEditorActions,
@@ -23,32 +36,55 @@ import {
 } from './panel/use-items-editor';
 
 type DndComponent = typeof DndImpl & {
+  // Owns the dnd-kit wiring for a palette item and hands back `ref` /
+  // `dragProps` / `isDragging`, so a custom palette decides how an item
+  // *looks* without reimplementing how dragging works.
   DraggableItem: typeof DraggableItem;
-  // The built-in property panel, exported so a `renderPanel` can wrap or
-  // partially override it instead of starting from zero — see #237. Its
-  // props line up with `PanelRenderData` (drop `onChange`; `bindings` and
-  // `onNodeChange` are the same), so `<DefaultPanel {...data} />` inside a
-  // `renderPanel` is lossless. See panel.tsx's own doc comment for why
-  // `onNodeChange` is optional there but required in `PanelRenderData`.
-  DefaultPanel: typeof DefaultPanel;
-  // The built-in control for one binding, exported so a custom panel can
-  // mix its own controls with the built-in one per binding instead of
-  // choosing all-or-nothing between `renderPanel` and `DefaultPanel`. Takes
-  // a `PanelBinding` straight out of `bindings` plus `onNodeChange` — both
-  // public `PanelRenderData` fields, so nothing internal is needed to drive
-  // it. Most useful for `items`/`children` bindings, whose editors find
-  // nested data-bound elements a consumer can't reach through `bindings`.
-  // Renders the control only — supply your own label.
+  // The built-in control for one binding, exported so a custom panel can mix
+  // its own controls with the built-in one per binding rather than choosing
+  // all-or-nothing. Takes a `PanelBinding` straight out of `bindings` plus
+  // `onNodeChange` — both `useDndPanel()` fields, so nothing internal is
+  // needed to drive it. Most useful for `items`/`children` bindings, whose
+  // editors find nested data-bound elements a consumer can't reach through
+  // `bindings`. Renders the control only — supply your own label.
   Field: typeof Field;
+  // The three built-in regions, each in the container it needs. Pass them as
+  // `children` of `Live.Dnd` in any arrangement to own the layout, mixing in
+  // your own components where you want to replace one. `Canvas` is the one
+  // that can't be replaced — the droppable, the sortable list and each
+  // section's compiled iframe are Dnd's own machinery — so render it exactly
+  // once wherever the canvas belongs.
+  Palette: typeof Palette;
+  Canvas: typeof Canvas;
+  Panel: typeof Panel;
+  // The built-in arrangement: the 3-pane desktop Splitter, the stacked
+  // mobile canvas, and the mobile FAB/Drawers. What `Live.Dnd` renders when
+  // given no children, exported so children can wrap it (a toolbar above it,
+  // say) or replace one region through its `palette`/`panel` slots without
+  // rebuilding the rest. Also the only way to reach the built-in Splitter
+  // layout without importing `@jbpark/ui-kit` directly, which a consumer may
+  // not have as a direct dependency.
+  Layout: typeof Layout;
 };
 
 const Dnd = DndImpl as DndComponent;
 
 Dnd.DraggableItem = DraggableItem;
-Dnd.DefaultPanel = DefaultPanel;
 Dnd.Field = Field;
+Dnd.Palette = Palette;
+Dnd.Canvas = Canvas;
+Dnd.Panel = Panel;
+Dnd.Layout = Layout;
 
-export { DraggableItem, DefaultPanel, Field };
+export { DraggableItem, Field };
+export { Palette, Canvas, Panel, Layout };
+// The data behind each region, so a component placed in `Live.Dnd`'s children
+// can replace one without losing what drives it: the palette's items and
+// `onAdd`, the panel's selected section/bindings/commit callbacks, and the
+// layout state the built-in mobile chrome runs on (`isMobile`, `selectedId` /
+// `clearSelection`, the palette Drawer's open state) — needed because
+// supplying children replaces that chrome along with the Splitter.
+export { useDndPalette, useDndPanel, useDndLayout };
 // The array-editing engine behind the built-in Items panel, exposed for a
 // consumer who wants their own markup rather than the built-in control
 // (`Field` covers the latter). Everything it returns is `PanelBinding`s, so
@@ -56,17 +92,19 @@ export { DraggableItem, DefaultPanel, Field };
 // bindings to `Field` where the built-in control is good enough.
 export { useItemsEditor };
 // The built-in panel's own `widget: 'icon-picker'` icon set/options —
-// exported so a custom renderPanel can reach icon-picker parity (name ->
+// exported so a custom panel can reach icon-picker parity (name ->
 // lucide-react component, and the same label/value pairs fed to Select)
 // instead of reimplementing an icon library, per #236/#237.
 export { ICON_MAP, ICON_OPTIONS };
 export type {
   Props,
-  PaletteRenderData,
-  PanelRenderData,
+  DndPalette,
+  DndPanel,
+  DndLayout,
+  DndLayoutProps,
+  DndRegionProps,
   PanelBinding,
   PanelNodeChange,
-  PanelProps,
   FieldProps,
   ItemsEditor,
   ItemsEditorActions,

--- a/src/components/dnd/layout-context.ts
+++ b/src/components/dnd/layout-context.ts
@@ -1,0 +1,69 @@
+import { createContext, useContext } from 'react';
+
+import type { DndPalette, DndPanel } from './dnd';
+
+// The layout state a custom arrangement needs. Separate from the palette and
+// panel data because a layout decides *where* things go, not what they
+// contain — the built-in layout reads only this slice.
+export interface DndLayout {
+  // From `useResponsiveSize` — the same value that picks the stacked mobile
+  // arrangement, so a custom layout can branch on it without repeating the
+  // breakpoint check. Also what the built-in palette reads to decide
+  // tap-to-add: at a mobile breakpoint a tap can't be a failed drag attempt
+  // (there's nothing visible to drag onto behind the Drawer) and dblclick
+  // synthesis from double-tap is unreliable, so a single tap adds.
+  isMobile: boolean;
+  // `null` when nothing is selected. The built-in layout uses it to open the
+  // properties Drawer on mobile, where the panel has nowhere else to go.
+  selectedId: string | null;
+  clearSelection: () => void;
+  // The palette Drawer's open state. Dnd owns it because adding an item
+  // closes the Drawer; a layout only opens it.
+  paletteOpen: boolean;
+  setPaletteOpen: (open: boolean) => void;
+}
+
+// Everything `Live.Dnd` publishes to its children, read back through the
+// three hooks below rather than as one object — a custom panel has no
+// business seeing the palette's items, and narrow hooks say which part of
+// Dnd a component actually depends on.
+//
+// `canvas` is the one node here rather than data: the droppable, the
+// sortable list and each section's compiled iframe are Dnd's own machinery,
+// so `Live.Dnd.Canvas` places it but nobody reproduces it.
+interface DndRegions extends DndLayout {
+  palette: DndPalette;
+  panel: DndPanel;
+  canvas: React.ReactNode;
+}
+
+export const DndRegionContext = createContext<DndRegions | null>(null);
+
+// Internal, and takes a `subject` the public hooks don't: the caller as it
+// appears in source — a hook call, or the region element that wraps one — so
+// rendering `<Live.Dnd.Palette />` outside `Live.Dnd` reports the element the
+// reader actually wrote rather than the hook behind it.
+export const useDndRegions = (subject: string): DndRegions => {
+  const regions = useContext(DndRegionContext);
+
+  if (!regions) {
+    throw new Error(`${subject} must be used inside <Live.Dnd>.`);
+  }
+
+  return regions;
+};
+
+// The palette's items and the callback that adds one to the canvas. Pair it
+// with `Live.Dnd.DraggableItem` for the drag wiring and you have the whole
+// built-in palette's input.
+export const useDndPalette = (): DndPalette =>
+  useDndRegions('useDndPalette()').palette;
+
+// The selected section, its editable bindings, and the callbacks that commit
+// through Dnd's AST-update pipeline — everything the built-in property panel
+// runs on.
+export const useDndPanel = (): DndPanel => useDndRegions('useDndPanel()').panel;
+
+// Returns the context object itself, narrowed: identity is stable across
+// renders, so this is safe in a dependency array.
+export const useDndLayout = (): DndLayout => useDndRegions('useDndLayout()');

--- a/src/components/dnd/layout.test.tsx
+++ b/src/components/dnd/layout.test.tsx
@@ -1,0 +1,266 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_TEMPLATE, DRAGGABLE_ITEMS } from '~/constants';
+
+import { PreviewContext } from '../context/states';
+import Dnd from './dnd';
+import Layout, { Canvas, Palette, Panel } from './layout';
+import { useDndLayout, useDndPalette, useDndPanel } from './layout-context';
+
+// Same reason as dnd.test.tsx: each section compiles into an iframe, none of
+// which jsdom needs to do for us to see where the regions landed.
+vi.mock('./renderer', () => ({
+  default: () => <div data-testid="renderer" />,
+}));
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+// `useResponsiveSize` with no options measures `document.body.offsetWidth`,
+// which jsdom reports as 0 — so the default breakpoint is `xs` and Dnd takes
+// the mobile branch unless a test says otherwise. Stubbing the width is
+// enough to get the desktop Splitter, since the hook measures the body on
+// mount (useLayoutEffect) rather than only on resize.
+const withViewportWidth = (width: number) => {
+  Object.defineProperty(document.body, 'offsetWidth', {
+    value: width,
+    configurable: true,
+  });
+};
+
+afterEach(() => {
+  withViewportWidth(0);
+});
+
+const stats = DRAGGABLE_ITEMS.find(item => item.id === 'stats')!;
+
+const document_ = DEFAULT_TEMPLATE.replace(
+  '<main id="app-container"></main>',
+  `<main id="app-container">${stats.code}</main>`,
+);
+
+const renderDnd = (children?: React.ReactNode) =>
+  render(
+    <PreviewContext.Provider value={{ code: '', setCode: vi.fn() }}>
+      <Dnd value={document_}>{children}</Dnd>
+    </PreviewContext.Provider>,
+  );
+
+describe('the built-in layout', () => {
+  it('renders the 3-pane arrangement on desktop', () => {
+    withViewportWidth(1280);
+
+    const { container } = renderDnd();
+
+    // Palette (a draggable per DRAGGABLE_ITEMS entry), canvas, and the
+    // property panel's unselected state — one assertion per pane.
+    expect(container.textContent).toContain(stats.name);
+    expect(container.querySelector('[data-frame-container]')).not.toBeNull();
+    expect(container.textContent).toContain('Please select a section.');
+    expect(
+      container.querySelector('[aria-roledescription="sortable"]'),
+    ).not.toBeNull();
+  });
+
+  it('stacks the canvas and keeps the palette in a Drawer on mobile', () => {
+    const { container } = renderDnd();
+
+    expect(container.querySelector('[data-frame-container]')).not.toBeNull();
+    // The FAB that opens the palette Drawer, and nothing of the palette
+    // itself until it does.
+    expect(container.querySelector('[aria-label="Components"]')).not.toBeNull();
+    expect(container.textContent).not.toContain(stats.name);
+  });
+});
+
+describe("the built-in layout's slots", () => {
+  it('swaps one region out and keeps the rest of the arrangement', () => {
+    withViewportWidth(1280);
+
+    const MyPanel = () => {
+      const { item } = useDndPanel();
+
+      return <div data-testid="my-panel">{item?.name ?? 'nothing picked'}</div>;
+    };
+
+    const { container } = renderDnd(<Layout panel={<MyPanel />} />);
+
+    expect(container.querySelector('[data-testid="my-panel"]')).not.toBeNull();
+    // The built-in panel is gone, but the other two panes are untouched.
+    expect(container.textContent).not.toContain('Please select a section.');
+    expect(container.textContent).toContain(stats.name);
+    expect(container.querySelector('[data-frame-container]')).not.toBeNull();
+  });
+
+  it('reuses the same slot for the pane and the mobile Drawer', () => {
+    const MyPalette = () => {
+      const { items, onAdd } = useDndPalette();
+
+      return (
+        <button data-testid="my-palette" onClick={() => onAdd(items[0]!)}>
+          {items.length} items
+        </button>
+      );
+    };
+
+    const { container } = renderDnd(<Layout palette={<MyPalette />} />);
+
+    // Mobile: the palette lives in the Drawer the built-in layout still owns,
+    // so the slot has to reach it without the consumer rebuilding the chrome.
+    const fab = container.querySelector<HTMLElement>(
+      '[aria-label="Components"]',
+    )!;
+
+    act(() => fab.click());
+
+    // The Drawer portals out of Dnd's own subtree, so look for the slot in
+    // the whole document rather than the render container.
+    const slot = document.body.querySelector('[data-testid="my-palette"]')!;
+
+    expect(slot).not.toBeNull();
+    expect(slot.textContent).toBe(`${DRAGGABLE_ITEMS.length} items`);
+  });
+});
+
+describe('a layout supplied as children', () => {
+  it('places each region where the children put it', () => {
+    withViewportWidth(1280);
+
+    const { container } = renderDnd(
+      <div data-testid="custom">
+        <Panel />
+        <Canvas />
+        <Palette />
+      </div>,
+    );
+
+    const custom = container.querySelector('[data-testid="custom"]')!;
+
+    expect(custom.querySelector('[data-frame-container]')).not.toBeNull();
+    expect(custom.textContent).toContain(stats.name);
+    expect(custom.textContent).toContain('Please select a section.');
+  });
+
+  it('replaces the built-in chrome rather than rendering alongside it', () => {
+    withViewportWidth(1280);
+
+    const { container } = renderDnd(<Canvas />);
+
+    // Anything still rendering the default layout here would double up the
+    // palette — two draggables per item, sharing their drag ids.
+    expect(container.querySelector('[aria-label="Components"]')).toBeNull();
+    expect(container.textContent).not.toContain(stats.name);
+    expect(container.querySelectorAll('[data-frame-container]').length).toBe(1);
+  });
+
+  it('keeps selection flowing from the canvas to the panel', () => {
+    const { container } = renderDnd(
+      <>
+        <Canvas />
+        <Panel />
+      </>,
+    );
+
+    const sortable = container.querySelector<HTMLElement>(
+      '[aria-roledescription="sortable"]',
+    );
+
+    expect(sortable).not.toBeNull();
+
+    act(() => sortable!.click());
+
+    // Both regions read Dnd's state through the layout context, so selecting
+    // on the canvas has to reach the panel wherever the two sit in the tree.
+    expect(container.textContent).not.toContain('Please select a section.');
+    expect(container.textContent).toContain('Stats Items');
+  });
+
+  it('can wrap the built-in layout instead of rebuilding it', () => {
+    withViewportWidth(1280);
+
+    const { container } = renderDnd(
+      <div data-testid="wrapper" className="flex flex-col">
+        <div>toolbar</div>
+        <Layout />
+      </div>,
+    );
+
+    const wrapper = container.querySelector('[data-testid="wrapper"]')!;
+
+    expect(wrapper.textContent).toContain('toolbar');
+    expect(wrapper.querySelector('[data-frame-container]')).not.toBeNull();
+    expect(wrapper.textContent).toContain(stats.name);
+  });
+
+  it('falls back to the built-in layout when the children render nothing', () => {
+    withViewportWidth(1280);
+
+    // What `{condition && <MyLayout />}` collapses to. Honouring it literally
+    // would leave an editor with no regions at all, which reads as a broken
+    // build rather than a mistake in the layout.
+    const { container } = renderDnd(false);
+
+    expect(container.querySelector('[data-frame-container]')).not.toBeNull();
+    expect(container.textContent).toContain(stats.name);
+  });
+
+  it('reports the mobile state a custom layout has to branch on', () => {
+    const Probe = () => {
+      const { isMobile } = useDndLayout();
+
+      return <div data-testid="probe">{String(isMobile)}</div>;
+    };
+
+    const { container } = renderDnd(<Probe />);
+
+    // Supplying children drops the built-in mobile chrome, so a custom layout
+    // needs the same signal the built-in one branches on to replace it.
+    expect(container.querySelector('[data-testid="probe"]')!.textContent).toBe(
+      'true',
+    );
+  });
+});
+
+describe('rendering outside Dnd', () => {
+  it.each([
+    ['<Live.Dnd.Palette>', () => <Palette />],
+    ['<Live.Dnd.Canvas>', () => <Canvas />],
+    ['<Live.Dnd.Panel>', () => <Panel />],
+    ['<Live.Dnd.Layout>', () => <Layout />],
+  ])('names the offending region: %s', (subject, Region) => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<Region />)).toThrow(
+      `${subject} must be used inside <Live.Dnd>.`,
+    );
+
+    error.mockRestore();
+  });
+
+  it.each([
+    ['useDndPalette()', useDndPalette],
+    ['useDndPanel()', useDndPanel],
+    ['useDndLayout()', useDndLayout],
+  ])('names the offending hook: %s', (subject, hook) => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const Probe = () => {
+      hook();
+
+      return null;
+    };
+
+    expect(() => render(<Probe />)).toThrow(
+      `${subject} must be used inside <Live.Dnd>.`,
+    );
+
+    error.mockRestore();
+  });
+});

--- a/src/components/dnd/layout.tsx
+++ b/src/components/dnd/layout.tsx
@@ -1,0 +1,216 @@
+import { Button, Drawer, Space, Splitter } from '@jbpark/ui-kit';
+import { LayoutGrid } from 'lucide-react';
+
+import { cn } from '~/utils';
+
+import { DefaultDraggableItem } from './draggable';
+import { useDndRegions } from './layout-context';
+import PropertyPanel from './panel';
+
+// The regions take their content from context, so `children` is never a
+// consumer's to pass — everything else about the wrapper div is (className
+// is tailwind-merged over the defaults, so overriding one of them wins
+// rather than fighting).
+export type DndRegionProps = Omit<
+  React.ComponentPropsWithRef<'div'>,
+  'children'
+>;
+
+// The built-in palette and panel without their region wrapper. Both exist
+// because `Layout` renders them twice on mobile — once in a pane, once in a
+// Drawer that's already the scroll container and shouldn't inherit the
+// pane's background.
+const PaletteItems = ({ subject }: { subject: string }) => {
+  const {
+    palette: { items, onAdd },
+    isMobile,
+  } = useDndRegions(subject);
+
+  return (
+    <Space orientation="vertical" align="start">
+      {items.map(item => (
+        <DefaultDraggableItem
+          key={item.id}
+          item={item}
+          onAdd={onAdd}
+          tapToAdd={isMobile}
+        />
+      ))}
+    </Space>
+  );
+};
+
+const PanelFields = ({ subject }: { subject: string }) => {
+  const {
+    panel: {
+      item,
+      onDelete,
+      onMoveUp,
+      onMoveDown,
+      canMoveUp,
+      canMoveDown,
+      bindings,
+      onNodeChange,
+    },
+  } = useDndRegions(subject);
+
+  return (
+    <PropertyPanel
+      item={item}
+      onDelete={onDelete}
+      onMoveUp={onMoveUp}
+      onMoveDown={onMoveDown}
+      canMoveUp={canMoveUp}
+      canMoveDown={canMoveDown}
+      bindings={bindings}
+      onNodeChange={onNodeChange}
+    />
+  );
+};
+
+// The built-in palette, in the scroll container the desktop pane wants.
+// Replace it by putting your own component in `Layout`'s `palette` slot, or
+// anywhere in `Live.Dnd`'s children — `useDndPalette()` hands over the same
+// items and `onAdd` this reads.
+export const Palette = ({ className, ...restProps }: DndRegionProps) => (
+  <div
+    className={cn(
+      'h-full overflow-y-auto bg-gray-50 p-4',
+      className,
+      //
+    )}
+    {...restProps}
+  >
+    <PaletteItems subject="<Live.Dnd.Palette>" />
+  </div>
+);
+
+// Owns the scroll container each section's iframe resolves by
+// `closest('[data-frame-container]')` to size itself against (see
+// frame/iframe.tsx), plus the containment/isolation styles that keep a
+// section's compiled CSS out of the editor chrome — hence a region rather
+// than a plain slot: a custom layout can move it, not lose it. Needs a
+// height-constrained parent, since it fills one (`h-full`). Render it
+// exactly once — the droppable and the sortable list inside use fixed ids,
+// and a second instance would duplicate both.
+export const Canvas = ({ className, style, ...restProps }: DndRegionProps) => {
+  const { canvas } = useDndRegions('<Live.Dnd.Canvas>');
+
+  return (
+    <div
+      className={cn(
+        'relative h-full w-full overflow-y-auto',
+        className,
+        //
+      )}
+      data-frame-container
+      style={{
+        isolation: 'isolate',
+        contain: 'layout style',
+        transform: 'translateZ(0)',
+        ...style,
+      }}
+      {...restProps}
+    >
+      {canvas}
+    </div>
+  );
+};
+
+// The built-in property panel. Same deal as `Palette`: replace it via
+// `Layout`'s `panel` slot or by placing your own component in `Live.Dnd`'s
+// children, driving it from `useDndPanel()`.
+export const Panel = ({ className, ...restProps }: DndRegionProps) => (
+  <div
+    className={cn(
+      'h-full',
+      className,
+      //
+    )}
+    {...restProps}
+  >
+    <PanelFields subject="<Live.Dnd.Panel>" />
+  </div>
+);
+
+export interface DndLayoutProps {
+  // Replacements for the palette/panel regions, kept as slots so swapping
+  // one out doesn't mean rebuilding the 3-pane Splitter and the mobile
+  // Drawers around it. A slot is placed raw — it owns its own container,
+  // unlike the built-in regions, which bring theirs. Drive it from
+  // `useDndPalette()` / `useDndPanel()`.
+  palette?: React.ReactNode;
+  panel?: React.ReactNode;
+}
+
+// What `Live.Dnd` renders when given no children — the 3-pane desktop
+// Splitter, the stacked mobile canvas, and the mobile FAB/Drawers. Exported
+// so children can keep the built-in arrangement while wrapping it (a toolbar
+// above it, say) or while replacing just one region — and because
+// `@jbpark/ui-kit` is a dependency rather than a peer, so `Splitter` isn't
+// necessarily importable on the consumer's side.
+export const Layout = ({ palette, panel }: DndLayoutProps) => {
+  const { isMobile, selectedId, clearSelection, paletteOpen, setPaletteOpen } =
+    useDndRegions('<Live.Dnd.Layout>');
+
+  return (
+    <>
+      {isMobile ? (
+        <Canvas />
+      ) : (
+        <Splitter withHandle orientation="horizontal">
+          <Splitter.Panel
+            defaultSize="20%"
+            minSize="15%"
+            maxSize="35%"
+            collapsible
+          >
+            {palette ?? <Palette />}
+          </Splitter.Panel>
+          <Splitter.Panel defaultSize="60%">
+            <Canvas />
+          </Splitter.Panel>
+          <Splitter.Panel
+            defaultSize="20%"
+            minSize="15%"
+            maxSize="35%"
+            collapsible
+          >
+            {panel ?? <Panel />}
+          </Splitter.Panel>
+        </Splitter>
+      )}
+      <Button
+        type="primary"
+        shape="circle"
+        icon={<LayoutGrid />}
+        aria-label="Components"
+        className="fixed right-4 bottom-4 z-20 md:hidden"
+        onClick={() => setPaletteOpen(true)}
+      />
+      {/* A slot goes in as-is; the built-ins go in without their region
+          wrapper, since the Drawer is already the scroll container and the
+          palette's gray background belongs to the desktop pane. */}
+      <Drawer
+        open={isMobile && paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        direction="bottom"
+        size="large"
+        title="Components"
+      >
+        {palette ?? <PaletteItems subject="<Live.Dnd.Layout>" />}
+      </Drawer>
+      <Drawer
+        open={isMobile && Boolean(selectedId)}
+        onClose={clearSelection}
+        direction="bottom"
+        size="large"
+        title="Properties"
+      >
+        {panel ?? <PanelFields subject="<Live.Dnd.Layout>" />}
+      </Drawer>
+    </>
+  );
+};
+
+export default Layout;

--- a/src/components/dnd/panel/field.tsx
+++ b/src/components/dnd/panel/field.tsx
@@ -21,7 +21,7 @@ import Children from './children';
 import { ICON_MAP, ICON_OPTIONS } from './icon-map';
 import Items from './items';
 
-// Exported as `Live.Dnd.Field` (see index.ts) so a custom `renderPanel` can
+// Exported as `Live.Dnd.Field` (see index.ts) so a custom panel can
 // hand any single binding back to the built-in control instead of
 // reimplementing it — most usefully for `items`/`children` bindings, whose
 // editors discover nested data-bound elements by re-extracting the value's
@@ -35,7 +35,7 @@ export interface FieldProps {
   // which `binding.onChange`'s single-value shape can't express. This is
   // the node-level escape hatch those two need (see #237's documented
   // items/children boundary). Not part of `PanelBinding`, which is
-  // per-binding; it reaches a custom panel through `PanelRenderData`
+  // per-binding; it reaches a custom panel through `useDndPanel()`
   // instead (#308). Omit it and nested array/children edits won't commit.
   onNodeChange?: PanelNodeChange;
 }

--- a/src/components/dnd/panel/icon-map.tsx
+++ b/src/components/dnd/panel/icon-map.tsx
@@ -80,7 +80,7 @@ export const ICON_MAP: Record<string, LucideIcon> = {
 };
 
 // The label/value pairs Field's icon-picker feeds to Select, derived once
-// from ICON_MAP — exported (see index.ts) so a custom renderPanel can
+// from ICON_MAP — exported (see index.ts) so a custom panel can
 // reach icon-picker parity without rebuilding this itself, per #236/#237.
 export const ICON_OPTIONS = Object.entries(ICON_MAP).map(([name, Icon]) => ({
   label: (

--- a/src/components/dnd/panel/panel.tsx
+++ b/src/components/dnd/panel/panel.tsx
@@ -9,19 +9,19 @@ import { cn } from '~/utils';
 import type { PanelBinding, PanelNodeChange } from '../dnd';
 import FieldGroup from './field-group';
 
-// Exported as `Live.Dnd.DefaultPanel` (see index.ts) so a consumer can
-// wrap or partially override the built-in panel instead of starting a
-// `renderPanel` from zero — see #237. Every field here lines up 1:1 with
-// `PanelRenderData` (drop `onChange`, which this panel never needed), so
-// spreading that data straight in works: `<DefaultPanel {...data} />`.
+// The built-in property panel. Reached publicly as `Live.Dnd.Panel`, which
+// is this in the container the desktop pane wants, driven from
+// `useDndPanel()` — every field here lines up with what that hook returns
+// (drop `onChange`, which this panel never needed), so the built-in panel and
+// a custom one run on the same data and the public surface can't drift into a
+// subset of it (#237).
+//
 // `onNodeChange` is the node-level escape hatch `Items`/`Children` use to
 // commit a *different* element's edit than any single
 // `PanelBinding.onChange` can express (see field.tsx's items/children
-// boundary note from step 1). It's optional here only so a consumer can
-// deliberately render this panel read-only for nested edits; when wrapping
-// it inside a `renderPanel`, forward the `onNodeChange` that
-// `PanelRenderData` hands you or nested array/children edits won't commit
-// (#308).
+// boundary note from step 1). Optional here only so this can be rendered
+// read-only for nested edits; leave it out with real data and nested
+// array/children edits silently don't commit (#308).
 export interface PanelProps {
   item?: Section;
   onDelete?: (id: string) => void;
@@ -34,7 +34,7 @@ export interface PanelProps {
   canMoveUp?: boolean;
   canMoveDown?: boolean;
   // `item`'s editable fields, already resolved to PanelBindings by Dnd's
-  // `bindings` useMemo — the same data a custom renderPanel receives, so
+  // `bindings` useMemo — the same data a custom panel receives, so
   // this panel doesn't re-derive it from DataAttrNode a second time (#237).
   bindings: PanelBinding[];
   onNodeChange?: PanelNodeChange;

--- a/src/components/dnd/panel/use-items-editor.ts
+++ b/src/components/dnd/panel/use-items-editor.ts
@@ -253,7 +253,7 @@ const parseSource = (value: string) => {
 // data-bound elements, resolving the binding `render` map, translating
 // visible item positions to array element positions before every edit, and
 // reconciling the selection after a move or delete (#285). Everything comes
-// back as `PanelBinding`s, the same currency `renderPanel` and
+// back as `PanelBinding`s, the same currency `useDndPanel()` and
 // `Live.Dnd.Field` already speak, so nothing here requires touching Babel.
 export const useItemsEditor = (
   value: string,

--- a/src/components/frame/measure.ts
+++ b/src/components/frame/measure.ts
@@ -23,7 +23,7 @@ export const FALLBACK_PROBE_HEIGHT = 812;
 // `clientHeight` already excludes the scroll container's own border, but
 // not any padding/border on wrapper elements *between* the iframe and
 // that container (this codebase's own Sortable/Renderer/Frame don't add
-// any today, but a consumer's own `provider`/`renderPanel` wrapper
+// any today, but a consumer's own `provider` or custom-panel wrapper
 // could) — `wrapperInsets` is the sum of those, added up by the caller
 // while walking from the iframe to the scroll container.
 //

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -93,7 +93,7 @@ export const DRAGGABLE_ITEMS: Section[] = [
               max: 40,
               // step/unit aren't fields this library knows about — they
               // survive parsing under binding.meta instead of being
-              // stripped, so a custom renderPanel can read its own
+              // stripped, so a custom panel can read its own
               // per-field configuration back out. See #234.
               step: 4,
               unit: 'px',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,15 @@ import './index.css';
 
 import Context from './components/context';
 import LiveDnd, {
+  type DndLayout,
+  type DndPalette,
+  type DndPanel,
   type FieldProps,
   type ItemsEditor,
   type ItemsEditorItem,
   type ItemsEditorOptions,
-  type PaletteRenderData,
   type PanelBinding,
   type PanelNodeChange,
-  type PanelRenderData,
 } from './components/dnd';
 import LiveEditor, { type EditorRenderData } from './components/editor';
 import LiveError from './components/error';
@@ -34,10 +35,11 @@ export {
 };
 
 export type {
-  PaletteRenderData,
+  DndPalette,
+  DndPanel,
+  DndLayout,
   PanelBinding,
   PanelNodeChange,
-  PanelRenderData,
   FieldProps,
   ItemsEditor,
   ItemsEditorItem,

--- a/src/utils/ast/binding.ts
+++ b/src/utils/ast/binding.ts
@@ -28,7 +28,7 @@ const bindingRenderLeafSchema = z.object({
 });
 
 // `widget` is deliberately just `z.string()`, not an enum — see #236. An
-// unrecognized widget is expected (a renderPanel consumer's own value, not
+// unrecognized widget is expected (a custom panel author's own value, not
 // this library's), so unlike `type` there is no "drop it" failure mode to
 // design for.
 //
@@ -327,7 +327,7 @@ const STRING_VALUED_TYPES: ReadonlySet<BindingType> = new Set([
 
 // Structured counterpart to `getCurrentValue`: returns the value as its real
 // JS type (number/boolean/object/array/string) rather than always as a
-// string, so both the built-in panel and a custom `renderPanel` receive
+// string, so both the built-in panel and a custom panel receive
 // `PanelBinding.value` already typed. `getCurrentValue` still supplies the
 // exact source text (`PanelBinding.rawValue`). See #238.
 //

--- a/src/utils/ast/types.ts
+++ b/src/utils/ast/types.ts
@@ -72,10 +72,10 @@ export interface BindingItem {
   type?: BindingType;
   // Presentation — how to *render* it. Deliberately an open string, not a
   // closed enum: the library cannot enumerate controls it doesn't
-  // implement, and a renderPanel consumer owns presentation once they use
+  // implement, and a custom panel owns presentation once they use
   // it (see #234/#236). `'icon-picker'`/`'asset-picker'` are the built-in
   // panel's own two widgets; anything else (e.g. `'slider'`) is free for a
-  // custom renderPanel to switch on.
+  // custom panel to switch on.
   widget?: string;
   options?: BindingOption[];
   render?: BindingRenderMap;

--- a/src/utils/ast/value.ts
+++ b/src/utils/ast/value.ts
@@ -198,7 +198,7 @@ const isEditablePrimitive = (value: unknown): value is EditablePrimitive =>
 // existing content declares neither; it's just an object/array-shaped
 // string because that's what the bound prop actually is (e.g. `style`).
 // This recovers editable leaves from the *parsed value's own shape*
-// instead, so it works on content authored without a renderPanel in mind
+// instead, so it works on content authored without a custom panel in mind
 // — including an array of objects whose own members embed further JSX
 // (Live Editor's shipped Stats/FAQ sections both look like this: an
 // `items` array of `{ key, children }`, where `children` is itself a

--- a/website/docs/custom-palette-panel.mdx
+++ b/website/docs/custom-palette-panel.mdx
@@ -8,9 +8,21 @@ import DemoFrame from '@site/src/components/demo-frame';
 
 # Custom Palette & Panel
 
-`Live.Dnd` accepts `renderPalette` and `renderPanel` to fully replace the
-built-in left palette and right property panel with your own markup, while
-drag-and-drop and field editing keep working exactly as before.
+`Live.Dnd` ships a complete editor — a 3-pane Splitter on desktop, a stacked
+canvas with Drawers on mobile — and renders it whenever you don't say
+otherwise. Everything behind that layout is also reachable as plain data
+through three hooks (`useDndPalette()`, `useDndPanel()`, `useDndLayout()`), so
+replacing the palette, the property panel, or the arrangement of the whole
+thing is a matter of writing an ordinary component and rendering it inside
+`Live.Dnd`. Drag-and-drop and field editing keep working exactly as before.
+
+There are two ways in, and they compose:
+
+- **Keep the built-in layout, swap a region.** Render
+  `<Live.Dnd.Layout palette={...} panel={...} />` and fill only the slot you
+  care about. The Splitter, the mobile FAB, and both Drawers stay.
+- **Replace the layout.** Pass your own `children` and place
+  `Live.Dnd.Canvas` (plus whatever you want around it) wherever you like.
 
 <DemoFrame
   src="demos/custom-palette-panel/"
@@ -28,25 +40,115 @@ whose own `children`/`label` fields are further, separately data-bound
 JSX elements — each array entry gets its own group of fields instead of
 one opaque blob for the whole array.
 
+## Custom layout
+
+By default `Live.Dnd` renders a 3-pane Splitter (palette / canvas / panel)
+on desktop, and on mobile a full-width canvas with the palette and property
+panel in Drawers. Pass `children` to design that layout yourself, composing
+the three regions wherever you want them:
+
+```tsx
+import { Splitter } from '@jbpark/ui-kit';
+
+<Live.Dnd value={value} onChange={setValue}>
+  <Splitter withHandle orientation="horizontal">
+    <Splitter.Panel defaultSize="15%">
+      <Live.Dnd.Palette />
+    </Splitter.Panel>
+    <Splitter.Panel defaultSize="55%">
+      <Live.Dnd.Canvas />
+    </Splitter.Panel>
+    <Splitter.Panel defaultSize="30%">
+      <Live.Dnd.Panel />
+    </Splitter.Panel>
+  </Splitter>
+</Live.Dnd>;
+```
+
+Nothing about the layout is prescribed — a vertical stack, tabs, a
+collapsible sidebar of your own, panels in a modal, three CSS grid areas —
+as long as each region renders somewhere inside `Live.Dnd`, which owns the
+drag context they share.
+
+| Region | Renders |
+| --- | --- |
+| `Live.Dnd.Palette` | The built-in palette draggables, in a scroll container. |
+| `Live.Dnd.Canvas` | The drop target and the sortable list of sections. |
+| `Live.Dnd.Panel` | The built-in property panel, in a scroll container. |
+| `Live.Dnd.Layout` | The built-in arrangement, so you can wrap it (a toolbar above it, say) rather than rebuild it, and replace one region through its `palette`/`panel` slots. Also how to get the built-in Splitter layout without importing `@jbpark/ui-kit` yourself. |
+
+Each takes the props of a `div` (`className` is merged over the region's own
+defaults, so overriding one wins rather than fighting), and each should be
+rendered at most once — `Canvas` in particular carries the scroll container
+the section iframes size themselves against, plus fixed drag ids that a
+second copy would duplicate.
+
+Two things to know:
+
+- **`Canvas` needs a height-constrained parent.** It fills one (`h-full`),
+  so a parent with no height of its own collapses it.
+- **`children` replaces the mobile chrome too** — the floating palette
+  button and both Drawers are part of the default layout, not of `Live.Dnd`.
+  The `useDndLayout()` hook returns what drove them (`isMobile`,
+  `selectedId`, `clearSelection`, `paletteOpen`, `setPaletteOpen`) so a
+  custom layout can build its own:
+
+```tsx
+import { useDndLayout } from '@jbpark/live-editor/dnd';
+
+const MyLayout = () => {
+  const { isMobile, selectedId, clearSelection } = useDndLayout();
+
+  return isMobile ? <Live.Dnd.Canvas /> : /* ... */;
+};
+```
+
+### Keeping the built-in layout and swapping one region
+
+Replacing the palette or the panel usually doesn't mean you want a different
+*arrangement*. `Live.Dnd.Layout` is the built-in one, exported with two slots
+so you can hand it your own component and keep everything else:
+
+```tsx
+<Live.Dnd value={value} onChange={setValue}>
+  <Live.Dnd.Layout panel={<MyPanel />} />
+</Live.Dnd>
+```
+
+That keeps the desktop Splitter, the mobile FAB, and both Drawers — your
+`panel` is placed in the right-hand pane on desktop and in the properties
+Drawer on mobile. A slot goes in raw, so it owns its own container (the
+built-in regions bring theirs); `palette` works the same way.
+
 ## Custom palette
 
-`renderPalette` receives a `PaletteRenderData` object:
+`useDndPalette()` returns what drives the palette:
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `items` | `Section[]` | The palette's available sections. |
 | `onAdd` | `(item: Section) => void` | Add a section to the canvas. |
-| `DraggableItem` | component | Owns the drag wiring — wrap your own markup in it so items stay draggable. |
-| `isMobile` | `boolean` | `true` when the palette is rendering inside the mobile Drawer, where a tap can't be a failed drag attempt (there's nothing to drag onto — the canvas is stacked behind the Drawer) and native dblclick synthesis from double-tap is unreliable on touch. Treat a single click/tap as "add" here instead of relying on `onDoubleClick`, as the example below does.
+
+Wrap your own markup in the exported `Live.Dnd.DraggableItem` so items stay
+draggable — it owns the dnd-kit wiring and hands back `ref` / `dragProps` /
+`isDragging`. For "tap to add", take `isMobile` from `useDndLayout()`: at a
+mobile breakpoint a tap can't be read as a failed drag attempt (in the
+built-in layout the palette sits in a Drawer with the canvas stacked behind
+it, so there's nothing to drag onto) and native dblclick synthesis from
+double-tap is unreliable anyway. Treat a single click/tap as "add" there
+instead of relying on `onDoubleClick`, as below.
 
 ```tsx
-<Live.Dnd
-  value={value}
-  onChange={setValue}
-  renderPalette={({ items, onAdd, DraggableItem, isMobile }) => (
+import { useDndLayout, useDndPalette } from '@jbpark/live-editor/dnd';
+
+const MyPalette = () => {
+  const { items, onAdd } = useDndPalette();
+  const { isMobile } = useDndLayout();
+
+  return (
     <div>
       {items.map(item => (
-        <DraggableItem key={item.id} item={item}>
+        <Live.Dnd.DraggableItem key={item.id} item={item}>
           {({ ref, dragProps, isDragging }) => (
             <div
               ref={ref}
@@ -58,16 +160,20 @@ one opaque blob for the whole array.
               {item.name}
             </div>
           )}
-        </DraggableItem>
+        </Live.Dnd.DraggableItem>
       ))}
     </div>
-  )}
-/>
+  );
+};
+
+<Live.Dnd value={value} onChange={setValue}>
+  <Live.Dnd.Layout palette={<MyPalette />} />
+</Live.Dnd>;
 ```
 
 ## Custom panel
 
-`renderPanel` receives a `PanelRenderData` object:
+`useDndPanel()` returns what drives the property panel:
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -79,25 +185,20 @@ one opaque blob for the whole array.
 | `onMoveDown` | `() => void` | Move the selected section down, same rationale as `onMoveUp`. |
 | `canMoveUp` | `boolean` | Whether `onMoveUp` would do anything right now — disable your move-up control when `false`. |
 | `canMoveDown` | `boolean` | Whether `onMoveDown` would do anything right now — disable your move-down control when `false`. |
-| `onNodeChange` | `(params: { id: string; label: string; property: string; value: unknown }) => void` | Commit an edit to an element addressed by its own `data-id`, rather than through a binding you were handed. Only needed when you re-embed `DefaultPanel` — pass it straight through. See [Wrapping the built-in panel](#wrapping-the-built-in-panel-instead-of-starting-from-zero). |
+| `onNodeChange` | `(params: { id: string; label: string; property: string; value: unknown }) => void` | Commit an edit to an element addressed by its own `data-id`, rather than through a binding you were handed. Needed for the nested elements `bindings` can't reach — pass it to `Live.Dnd.Field` along with the binding. See [below](#reusing-the-built-in-control-for-one-binding). |
 
 `bindings` carries each field's `type`, current `value`, `options` (when
 present), and an `onChange` wired straight into the same AST-update pipeline
 the built-in panel uses. Switch on `binding.type` to render your own control:
 
 ```tsx
-<Live.Dnd
-  value={value}
-  onChange={setValue}
-  renderPanel={({
-    item,
-    bindings,
-    onDelete,
-    onMoveUp,
-    onMoveDown,
-    canMoveUp,
-    canMoveDown,
-  }) => (
+import { useDndPanel } from '@jbpark/live-editor/dnd';
+
+const MyPanel = () => {
+  const { item, bindings, onDelete, onMoveUp, onMoveDown, canMoveUp, canMoveDown } =
+    useDndPanel();
+
+  return (
     <div>
       <header>
         {item?.name}
@@ -137,35 +238,35 @@ the built-in panel uses. Switch on `binding.type` to render your own control:
         </label>
       ))}
     </div>
-  )}
-/>
+  );
+};
 ```
+
+Being an ordinary component rather than a callback is the point: a panel can
+hold its own state — a validation message, an open/closed group, a
+multi-select — without hoisting any of it into the component that renders
+`Live.Dnd`.
 
 ### Wrapping the built-in panel instead of starting from zero
 
-`renderPanel` doesn't have to replace the panel entirely — the built-in one
-is exported as `Live.Dnd.DefaultPanel`, so you can keep it and just add your
-own chrome around it (or swap it in for only some sections):
+You don't have to replace the panel to add to it. `Live.Dnd.Panel` *is* the
+built-in one, so keep it and put your own chrome around it:
 
 ```tsx
-<Live.Dnd
-  value={value}
-  onChange={setValue}
-  renderPanel={data => (
-    <div>
-      <MyCustomHeader item={data.item} />
-      <Live.Dnd.DefaultPanel {...data} />
-    </div>
-  )}
-/>
+const MyPanel = () => (
+  <div>
+    <MyCustomHeader />
+    <Live.Dnd.Panel className="h-auto" />
+  </div>
+);
 ```
 
-Spread the whole object rather than picking fields off it. `DefaultPanel`'s
-props line up 1:1 with `PanelRenderData` (it just ignores `onChange`, which
-it never needed), so the spread is lossless — and it's the only form that
-carries `onNodeChange` through.
+It reads `useDndPanel()` itself, so wrapping it can't drop a callback on the
+way through — `onNodeChange` included. (`className` is merged over the
+region's defaults, so `h-auto` overrides its own `h-full` and the header above
+it doesn't push it out of view.)
 
-That last one matters more than it looks. `bindings` covers the elements
+`onNodeChange` matters more than it looks. `bindings` covers the elements
 `extract()` finds by walking the section's markup, which does not include
 JSX nested *inside* an attribute value — the elements held in an `items` or
 `children` binding. The built-in array/children editors discover those by
@@ -180,31 +281,35 @@ nothing commits.
 
 ### Reusing the built-in control for one binding
 
-Wrapping `DefaultPanel` is all-or-nothing: you get the built-in panel for
+Keeping `Live.Dnd.Panel` is all-or-nothing: you get the built-in panel for
 every field. When you want your own controls for most bindings but not all
 of them, `Live.Dnd.Field` renders the built-in control for a single
 binding:
 
 ```tsx
-renderPanel={({ bindings, onNodeChange }) => (
-  <div>
-    {bindings.map(binding => (
-      <label key={`${binding.id}-${binding.property}`}>
-        <span>{binding.label}</span>
-        {binding.type === 'array' || binding.property === 'children' ? (
-          <Live.Dnd.Field binding={binding} onNodeChange={onNodeChange} />
-        ) : (
-          <MyOwnControl binding={binding} />
-        )}
-      </label>
-    ))}
-  </div>
-)}
+const MyPanel = () => {
+  const { bindings, onNodeChange } = useDndPanel();
+
+  return (
+    <div>
+      {bindings.map(binding => (
+        <label key={`${binding.id}-${binding.property}`}>
+          <span>{binding.label}</span>
+          {binding.type === 'array' || binding.property === 'children' ? (
+            <Live.Dnd.Field binding={binding} onNodeChange={onNodeChange} />
+          ) : (
+            <MyOwnControl binding={binding} />
+          )}
+        </label>
+      ))}
+    </div>
+  );
+};
 ```
 
 `Field` takes nothing but a `PanelBinding` out of `bindings` and the same
-`onNodeChange` — both already part of `PanelRenderData`, so no internal
-wiring is involved.
+`onNodeChange` — both already part of what `useDndPanel()` returns, so no
+internal wiring is involved.
 
 It renders the **control only**. The built-in panel's `Label (property)`
 heading comes from the row around it, not from `Field`, so supply your own
@@ -301,7 +406,7 @@ it can do is reachable here.
 | `label` | `string` | Human-readable label from the binding definition. |
 | `property` | `string` | The bound prop/attribute name. |
 | `type` | `BindingType?` | The declared data kind — what the value *is* (`string`, `number`, `boolean`, ...). `undefined` means a plain string binding. See the full list below. |
-| `widget` | `string?` | The declared presentation — how to *render* it. An open string, not `BindingType`: the library can't enumerate controls it doesn't implement, so a custom `renderPanel` is free to declare and switch on any value it wants (e.g. `'slider'`). The built-in panel only recognizes `'icon-picker'`/`'asset-picker'`. |
+| `widget` | `string?` | The declared presentation — how to *render* it. An open string, not `BindingType`: the library can't enumerate controls it doesn't implement, so a custom panel is free to declare and switch on any value it wants (e.g. `'slider'`). The built-in panel only recognizes `'icon-picker'`/`'asset-picker'`. |
 | `options` | `BindingOption[]?` | Present when the binding defines a fixed option set (render a `<select>`). |
 | `render` | `BindingRenderMap?` | Present on `object`/`array` bindings whose nested keys/items declare their own types — walk it to type each nested field instead of treating the value as an opaque string. |
 | `min` | `number?` | Minimum value for a `number` binding. Compared against the real number `value` delivers — pass it straight to `validateBindingValue`. |
@@ -365,7 +470,7 @@ existing authored content (`data-binding={[{ type: 'icon-picker', ... }]}`)
 keeps parsing — they describe a control, not a data kind, so `parseBinding`
 normalizes them into `{ type: 'string', widget: 'icon-picker' }` /
 `{ type: 'string', widget: 'asset-picker' }` rather than passing them
-through as-is. A custom `renderPanel` should switch on `binding.widget`
+through as-is. A custom panel should switch on `binding.widget`
 for these, not `binding.type`. The built-in panel's icon set is exported
 as `ICON_MAP` (`name -> lucide-react component`), and the same
 label/value pairs it feeds its own `<select>` as `ICON_OPTIONS`, if you
@@ -377,7 +482,7 @@ import { ICON_MAP, ICON_OPTIONS } from '@jbpark/live-editor';
 
 Author a brand-new field with any other widget the same way — `type`
 still describes the data kind (so validation/coercion keeps working),
-`widget` is free text your own `renderPanel` switches on:
+`widget` is free text your own panel switches on:
 
 ```tsx
 // data-binding={[{ label: 'Spacing', property: 'size', type: 'number', widget: 'slider', min: 0, max: 40 }]}
@@ -415,7 +520,7 @@ commit, neither enforced at parse time:
 
 `data-binding` covers declared, per-property edits. For anything else —
 restructuring markup, adding a whole new element, editing something with no
-binding declared at all — `PanelRenderData.item.code` is the section's full
+binding declared at all — `useDndPanel()`'s `item.code` is the section's full
 current source, and the exported `extract()` walks it into the same
 `DataAttrNode` tree the built-in panel reads (including custom, entirely
 undeclared `data-*` attributes, which `extract()` passes through intact).
@@ -424,16 +529,19 @@ Commit any string back with `onChange({ code })`:
 ```tsx
 import { extract } from '@jbpark/live-editor/utils/ast';
 
-renderPanel={({ item, onChange }) => {
+const RawEditor = () => {
+  const { item, onChange } = useDndPanel();
+
   if (!item) return null;
 
   const nodes = extract(item.code); // read whatever you need
+
   return (
     <button onClick={() => onChange({ code: item.code.replace(/foo/, 'bar') })}>
       Edit raw source
     </button>
   );
-}}
+};
 ```
 
 This is a full escape hatch, not a fallback of last resort — it's the same

--- a/website/docs/drag-and-drop.mdx
+++ b/website/docs/drag-and-drop.mdx
@@ -46,8 +46,10 @@ export default function DragAndDrop() {
 - `value` / `onChange` hold the generated source — drops and property edits are
   applied through the same AST pipeline, so the code stays canonical.
 - `frame` configures the preview surface (see [Preview Modes](./preview-modes.mdx)).
-- Use `items` to customize the palette, and `renderPalette` / `renderPanel` to
-  fully replace the built-in UI — see
+- Use `items` to customize the palette's available sections, and `children` to
+  replace the built-in UI — a region of it (`<Live.Dnd.Layout panel={...} />`)
+  or the whole arrangement, driven from the `useDndPalette()` /
+  `useDndPanel()` / `useDndLayout()` hooks — see
   [Custom Palette & Panel](./custom-palette-panel.mdx).
 
 The embedded demo above runs the real `Live.Dnd` component, isolated with

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -177,17 +177,17 @@ for what does and doesn't apply there.
 
 ### Other exports
 
-- **`Live.Error`** (`LiveError`) — the error display component `Live.Preview`'s `showError` renders compile/runtime errors through internally (`title`, `message`, `onReset` props). Exposed in case you want to render the same error UI yourself. (Unrelated to `renderPanel`'s own edit-validation errors, which surface through a `ui-kit` `Toast` instead.)
+- **`Live.Error`** (`LiveError`) — the error display component `Live.Preview`'s `showError` renders compile/runtime errors through internally (`title`, `message`, `onReset` props). Exposed in case you want to render the same error UI yourself. (Unrelated to the property panel's own edit-validation errors, which surface through a `ui-kit` `Toast` instead.)
 - **`LiveRenderer`** — an alias of `Live.Preview`/`LivePreview`, same component, same props.
 - **`LiveProvider`** — the named export for what `Live` itself is (the shared-context provider). `import Live from '@jbpark/live-editor'` and `import { LiveProvider } from '@jbpark/live-editor'` are the same component.
 
 ### Types
 
-`PaletteRenderData`, `PanelRenderData`, `PanelBinding`, `EditorRenderData`,
+`DndPalette`, `DndPanel`, `DndLayout`, `PanelBinding`, `EditorRenderData`,
 `FrameProps`, and `Section` are all importable from the package root:
 
 ```ts
-import type { PanelRenderData, Section } from '@jbpark/live-editor';
+import type { DndPanel, Section } from '@jbpark/live-editor';
 ```
 
 `BindingType`/`BindingOption` live under a subpath instead — see


### PR DESCRIPTION
## Summary

Redesigns `Live.Dnd`'s customization surface around **components and hooks** instead of render props, and makes the two usage modes explicit:

- **Don't customize** → identical behaviour to today (3-pane Splitter on desktop, stacked canvas + FAB + Drawers on mobile).
- **Do customize** → the layout, the palette and the panel are all reachable through one mechanism, at whatever granularity you need.

Breaking, so it ships as a `major` changeset (2.2.0 → 3.0.0).

## Why

`renderPalette` / `renderPanel` handed data to a function, and **a render prop can't hold state**. Every non-trivial custom panel therefore extracted a component anyway and re-passed data it had already been given — the shipped demo's `ValidatedField`, `SliderField` and `HeadlessItems` are all exactly this shape. A component that reads what it needs where it needs it removes the intermediate hop.

The render props were also the reason the `Default` prefix existed: `Live.Dnd.Panel` used to be the *slot* a panel landed in, so the built-in panel component had to be `DefaultPanel`. With no slot to disambiguate against, each name refers to one thing.

Finally, `children` previously only replaced the *content* while `Live.Dnd` kept owning the Splitter, so a consumer who wanted a different arrangement had no way in short of rebuilding the whole component (the #237 cliff).

## What changed

### Removed

| Before | After |
| --- | --- |
| `renderPalette={data => ...}` | a component calling `useDndPalette()` |
| `renderPanel={data => ...}` | a component calling `useDndPanel()` |
| `PaletteRenderData` | `DndPalette` — `{ items, onAdd }`; `DraggableItem` is now the export `Live.Dnd.DraggableItem`, `isMobile` moved to `useDndLayout()` |
| `PanelRenderData` | `DndPanel` — same fields |
| `<Live.Dnd.DefaultPanel {...data} />` | `<Live.Dnd.Panel />` |
| `Live.Dnd.DefaultLayout` | `Live.Dnd.Layout` |
| `PanelProps` | no longer public — the built-in panel takes no data props |

### Added

- **Three hooks** (`dnd` subpath): `useDndPalette()`, `useDndPanel()`, `useDndLayout()`. The first two publish what the render props used to pass; `useDndLayout()` exposes the state the built-in mobile chrome runs on (`isMobile`, `selectedId`, `clearSelection`, `paletteOpen`, `setPaletteOpen`), which a custom layout needs because supplying `children` replaces the FAB and both Drawers along with the Splitter. All three throw a named error when used outside `<Live.Dnd>`.
- **Three region components**: `Live.Dnd.Palette`, `Live.Dnd.Canvas`, `Live.Dnd.Panel`, each in the container it needs. Place them anywhere inside `Live.Dnd` — vertical stack, tabs, CSS grid areas. `className` is tailwind-merged over the region defaults, so an override wins rather than fights.
- **`Live.Dnd.Layout` takes `palette` / `panel` slots**, so replacing one region doesn't mean rebuilding the Splitter and the Drawers. A slot is placed in both the desktop pane and the mobile Drawer.

```tsx
import { useDndPanel } from '@jbpark/live-editor/dnd';

const MyPanel = () => {
  const { item, bindings, onNodeChange } = useDndPanel();
  // ...
};

<Live.Dnd value={value} onChange={setValue}>
  <Live.Dnd.Layout panel={<MyPanel />} />
</Live.Dnd>;
```

### Not replaceable, by design

`Canvas` is a *region*, not a slot: it carries the droppable, the sortable list, and the `[data-frame-container]` scroll parent that each section's iframe resolves via `closest()` to size itself against (`src/components/frame/iframe.tsx`), plus the containment/isolation styles that keep a section's compiled CSS out of the editor chrome. A custom layout can **move** it, not lose it. Render it exactly once — the droppable and the sortable list inside use fixed ids.

## Behaviour change beyond the API

`isMobile` now follows the responsive breakpoint rather than "am I inside the mobile Drawer". Same value inside the built-in layout, and the correct one for a custom layout that puts the palette somewhere else on touch, since tap-to-add is a property of the input device, not of the container.

## Test plan

- `pnpm check-types` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ — 21 files / 418 tests, including a new `src/components/dnd/layout.test.tsx` (17 tests) covering: the built-in arrangement on both breakpoints, each region rendered standalone, `className` merging over region defaults, a slot reused by both the desktop pane and the mobile Drawer, and the "outside `<Live.Dnd>`" error for all 4 regions and all 3 hooks
- `pnpm build` ✅ (only the pre-existing `IMPORT_IS_UNDEFINED` Babel warning)
- `website` Docusaurus build ✅
- `demos/custom-palette-panel` rewritten onto the new API and exercised manually: custom palette, three panel modes, the `wrap` mode wrapping `<Live.Dnd.Panel className="h-auto" />`, and a `StackedLayout` that drops the Splitter entirely

Docs updated: `website/docs/custom-palette-panel.mdx` (rebuilt around the hooks), `drag-and-drop.mdx`, `intro.md`.
