### PR TITLE
fix(ast): keep an untyped array attribute an expression on commit

### DIFF
--- a/.changeset/fix-untyped-array-attribute.md
+++ b/.changeset/fix-untyped-array-attribute.md
@@ -1,0 +1,11 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Fix array edits corrupting the document when the binding declares no `type`.
+
+Adding, removing or reordering an item in the panel's array editors rewrote `items={[...]}` into a quoted string attribute — `items="[{\n  key: '1', label: <p data-id=\"a\">…"` — leaving the section unparseable, so the panel emptied and the preview stopped updating. Both shipped sections hit this: `FAQ` and `Stats` declare `{ label: 'FAQ Items', property: 'items' }` with no `type`, and the serializer only recognized an array when `type: 'array'` was spelled out.
+
+`update()` now also reads what the attribute already holds, the same evidence `getStructuredValue()` uses on the way out. An attribute authored as an array or object literal keeps its expression form when the committed value is itself an array or object literal. Anything else is unchanged: `className={cn(...)}` and `items={rows}` are left alone, and a plain string committed against a text attribute is still written as a string literal.
+
+This affects every panel mode equally — the built-in `Items` control, a wrapped `Live.Dnd.Panel`, and custom markup over `useItemsEditor` all commit the array as source text through the same path.

--- a/src/utils/ast/binding.ts
+++ b/src/utils/ast/binding.ts
@@ -314,7 +314,7 @@ export const getCurrentValue = (
 // and `richtext` carry source that is an expression, not a literal, so they
 // stay as their exact source string too (the update pipeline re-inserts
 // them as expressions, not string literals).
-const STRING_VALUED_TYPES: ReadonlySet<BindingType> = new Set([
+export const STRING_VALUED_TYPES: ReadonlySet<BindingType> = new Set([
   'string',
   'url',
   'date',

--- a/src/utils/ast/update.test.ts
+++ b/src/utils/ast/update.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
+import { DRAGGABLE_ITEMS } from '~/constants';
+
+import { getCurrentValue } from './binding';
+import { extract } from './extract';
+import { appendArrayItem, parseItems } from './items';
+import type { DataAttrNode } from './types';
 import { bulkUpdate, update } from './update';
 
 const CODE = `
@@ -126,6 +132,61 @@ describe('update', () => {
 
     expect(result.success).toBe(true);
     expect(result.code).toContain('data={[1, 2, 3]}');
+  });
+
+  // Regression: the shipped `items` bindings declare no `type`
+  // (`{ label: 'FAQ Items', property: 'items' }`), so #238's declared-type
+  // gate sent their committed source text down the string-literal path and
+  // rewrote `items={[...]}` into `items="[{\n  key: ...\"...\" }]"`, which
+  // no longer parses as JSX. The panel's array editors always commit source
+  // text, so every add/remove/move on a shipped section broke the document.
+  describe('an array attribute whose binding declares no type', () => {
+    const arrayCode = `<Collapse data-id="i" data-binding={[{ label: 'Items', property: 'items' }]} items={[{ key: '1' }]} />`;
+
+    it('parses committed source text back into an expression', () => {
+      const result = update(
+        arrayCode,
+        'i',
+        'Items',
+        "[{ key: '1' }, { key: '2' }]",
+        'items',
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('items={[{');
+      expect(result.code).toContain("key: '2'");
+      expect(result.code).not.toContain('items="');
+    });
+
+    it('keeps the result parseable when the items hold JSX', () => {
+      const items = `[{ key: '1', label: <p data-id="j">A</p> }]`;
+      const result = update(arrayCode, 'i', 'Items', items, 'items');
+
+      expect(result.success).toBe(true);
+      expect(() => extract(result.code)).not.toThrow();
+      expect(extract(result.code).length).toBeGreaterThan(0);
+    });
+
+    // The narrow gate: only a value that is itself an array/object literal
+    // replaces the expression. Plain text parses as an identifier, and
+    // writing `items={nope}` would turn a value into a variable reference.
+    it('still quotes a committed value that is not an array or object', () => {
+      const result = update(arrayCode, 'i', 'Items', 'nope', 'items');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('items="nope"');
+    });
+
+    // The #238 guarantee is unchanged for attributes that were never
+    // structural: a string committed against a plain text attribute stays a
+    // string literal even when it happens to parse as an array.
+    it('leaves a non-structural attribute quoted', () => {
+      const code = `<Input data-id="k" data-binding={[{ label: 'P', property: 'placeholder' }]} placeholder="x" />`;
+      const result = update(code, 'k', 'P', '[1, 2]', 'placeholder');
+
+      expect(result.success).toBe(true);
+      expect(result.code).toContain('placeholder="[1, 2]"');
+    });
   });
 
   it('returns success: false and the original code when the data-id is not found', () => {
@@ -577,6 +638,50 @@ describe('bulkUpdate', () => {
     expect(batched.code).toBe(sequential.code);
     expect(batched.code).toBe(
       code.replace('title="t"', 'title="t2"').replace('alt="a"', 'alt="a2"'),
+    );
+  });
+});
+
+// The reported break, end to end on the shipped sections: the panel's array
+// editors (built-in `Items`, or a consumer's own markup over
+// `useItemsEditor`) re-serialize the whole array and commit it as source
+// text, so a single "+ Add" has to survive the round trip through `update`.
+// Neither shipped `items` binding declares a `type`, which is exactly the
+// case #238's gate missed.
+describe('adding an item to a shipped section', () => {
+  const flatten = (nodes: DataAttrNode[]): DataAttrNode[] =>
+    nodes.flatMap(node => [node, ...flatten(node.children ?? [])]);
+
+  it.each([
+    ['FAQ', 'FAQ Items'],
+    ['Stats', 'Stats Items'],
+  ])('keeps the %s section parseable', (name, label) => {
+    const section = DRAGGABLE_ITEMS.find(item => item.name === name)!;
+    const node = flatten(extract(section.code)).find(candidate =>
+      candidate.bindings?.some(binding => binding.property === 'items'),
+    )!;
+    const dataId =
+      node.dataAttributes.find(attr => attr.name === 'data-id')?.value ?? '';
+
+    const before = parseItems(getCurrentValue(node, 'items'))!;
+    const appended = appendArrayItem(
+      getCurrentValue(node, 'items'),
+      'object',
+      () => 'fixed',
+    );
+    const result = update(section.code, dataId, label, appended, 'items');
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('items={[');
+    expect(result.code).not.toMatch(/items="/);
+
+    // The document still parses, and the panel reads one more item back.
+    const reparsed = flatten(extract(result.code)).find(candidate =>
+      candidate.bindings?.some(binding => binding.property === 'items'),
+    )!;
+
+    expect(parseItems(getCurrentValue(reparsed, 'items'))).toHaveLength(
+      before.length + 1,
     );
   });
 });

--- a/src/utils/ast/update.ts
+++ b/src/utils/ast/update.ts
@@ -2,7 +2,7 @@ import { parse, parseExpression } from '@babel/parser';
 import * as t from '@babel/types';
 
 import { BINDING_PROP, DATA_ATTR } from '../../constants';
-import { parseBinding } from './binding';
+import { STRING_VALUED_TYPES, parseBinding } from './binding';
 import { traverse } from './document';
 import { nodeToJSX } from './extract';
 import { generateCode, unwrap, wrap } from './helpers';
@@ -258,13 +258,48 @@ const editJsxAttribute = (
   return [{ start: insertAt, end: insertAt, content: `=${content}` }];
 };
 
+// Whether the attribute being replaced was authored as an array or object
+// literal inside a JSX expression container. Narrower than "is an
+// expression" on purpose: `className={cn(...)}` and `items={rows}` are
+// expressions too, but their value doesn't round-trip through the panel as
+// source text, so a string committed against them stays a string.
+const holdsStructuralExpression = (value?: t.JSXAttribute['value']): boolean =>
+  t.isJSXExpressionContainer(value) &&
+  (t.isArrayExpression(value.expression) ||
+    t.isObjectExpression(value.expression));
+
+// Parses committed text back into the array/object literal it claims to be.
+// Requiring that exact shape is what keeps a plain string from silently
+// becoming something else: `"hello"` parses fine as an identifier, and
+// writing `items={hello}` would turn a value into a variable reference.
+const structuralSource = (value: string): t.Expression | null => {
+  try {
+    const expression = parseExpression(value.trim(), {
+      plugins: ['jsx', 'typescript'],
+    });
+
+    return t.isArrayExpression(expression) || t.isObjectExpression(expression)
+      ? expression
+      : null;
+  } catch {
+    return null;
+  }
+};
+
 // Serialize a structured value into a JSX attribute value, once, at the AST
 // boundary — the single point where the declared `type` is known. Replaces
 // the old first-character heuristic (`startsWith('{')` ...) that guessed
 // string-vs-expression and then let `attrValue` guess again. See #238.
+//
+// `current` is the attribute value being replaced. The declared `type` is
+// authoritative when there is one, but most shipped `items` bindings declare
+// none (`{ label: 'FAQ Items', property: 'items' }`), so the source is the
+// only remaining evidence of what the attribute holds — the same evidence
+// `getStructuredValue` reads on the way out via `attr.isStringLiteral`.
 const buildAttributeValue = (
   value: unknown,
   type?: BindingType,
+  current?: t.JSXAttribute['value'],
 ): t.JSXAttribute['value'] => {
   // Declared object/array bindings: an expression container. A string here
   // is already-serialized source text (from the built-in Items/flatten
@@ -289,6 +324,23 @@ const buildAttributeValue = (
   // string stays a string literal whatever it contains, so a genuine
   // `"{not an expression}"` no longer becomes a JSX expression container.
   if (typeof value === 'string') {
+    // ...except when the attribute being replaced is itself an array/object
+    // literal expression. Those hand the panel their *source text* as
+    // `rawValue`, and the array editors commit that same source text back,
+    // so quoting it would rewrite `items={[...]}` into an `items="[{\n ..."`
+    // string literal and leave the document unparseable. Undeclared-type
+    // `items`/`data` bindings only reach here, which is why they broke.
+    if (
+      holdsStructuralExpression(current) &&
+      !(type && STRING_VALUED_TYPES.has(type))
+    ) {
+      const structural = structuralSource(value);
+
+      if (structural) {
+        return t.jsxExpressionContainer(structural);
+      }
+    }
+
     return t.stringLiteral(value);
   }
 
@@ -314,7 +366,10 @@ const editAttribute = (
   // regenerated. Reuses the parsed name node instead of building a fresh
   // identifier so namespaced/dashed names survive untouched.
   const content = generateCode(
-    t.jsxAttribute(attribute.name, buildAttributeValue(value, type)),
+    t.jsxAttribute(
+      attribute.name,
+      buildAttributeValue(value, type, attribute.value),
+    ),
   );
 
   return [


### PR DESCRIPTION
## Summary

Editing an array in the panel corrupted the section source when the binding declared no `type`, which is the case for both shipped `items` bindings. A single "+ Add" left the document unparseable, so the panel emptied and the preview stopped updating.

## Changes

- `buildAttributeValue` (`src/utils/ast/update.ts`) now also reads the attribute it is replacing. An attribute authored as an array/object literal keeps its expression form when the committed value is itself an array/object literal
- gate the recovery on both sides being literals, so `className={cn(...)}`, `items={rows}` and ordinary string commits are untouched
- export `STRING_VALUED_TYPES` from `binding.ts` so a declared text type still wins over the source-shape evidence
- add 6 regression tests, including an end-to-end one over the shipped `FAQ`/`Stats` sections

## What was wrong

The panel's array editors re-serialize the whole array and commit it back as **source text**. `buildAttributeValue` decided string-vs-expression from the declared `type` alone:

```ts
if (type === 'array' || type === 'object') { /* parsed back to an expression */ }
if (typeof value === 'string') { return t.stringLiteral(value); }  // ← untyped items landed here
```

Neither shipped binding declares a type:

```tsx
data-binding={[{ label: 'FAQ Items',   property: 'items' }]}   // src/constants/index.ts:1132
data-binding={[{ label: 'Stats Items', property: 'items' }]}   // src/constants/index.ts:927
```

So `items={[...]}` was rewritten into a quoted string literal:

```
items="[{\n  key: '1',\n  label: <ui.Typography.Text data-id=\"\" ...>"
```

which no longer parses as JSX:

```
⚠️ Failed to parse document SyntaxError: Expecting Unicode escape sequence \uXXXX. (35:82)
    at TypeScriptParserMixin.jsxParseAttribute
```

With the document unparseable there are no bindings left to render, which is why the fields disappear.

## Scope of the break

Not limited to one panel mode. The built-in `Items` control, a wrapped `Live.Dnd.Panel`, and custom markup over `useItemsEditor` all commit through the same `binding.onChange`, and `bulkUpdate` delegates to `update`. Add, remove and reorder were all affected.

The existing array tests missed it because every one of them spells out `type: 'array'`.

Introduced in e9afcbe (#238): the previous `attrValue` decided from the existing attribute's `isStringLiteral` — structural evidence — and that input was dropped when serialization moved behind the declared type. This restores the same evidence the read path (`getStructuredValue`) still uses.

## Type of Change

- [x] fix — bug fix

## Scope

- [x] AST transform (`src/utils/ast`)
- [x] DnD / Canvas

## Validation

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`
- [x] Manual verification completed

`pnpm test` — 424 passed. The new tests fail without the fix (4 of them) and pass with it.

Manually reproduced and re-verified in the `custom-palette-panel` demo: before, "+ Add" on the FAQ section emptied the panel with the parse error above; after, the array goes 4 → 5 items and the new entry renders on the canvas with no console error.

## Checklist

- [x] Commit messages follow conventional-commit style (no gitmoji)
- [x] Updated docs when behavior/API changed — n/a, no API change
- [x] Added or updated tests when needed
- [x] No unrelated changes included
