### PR TITLE
refactor: consume @jbpark/ui-kit CodeEditor instead of a local CodeMirror surface

### DIFF
--- a/.changeset/consume-ui-kit-code-editor.md
+++ b/.changeset/consume-ui-kit-code-editor.md
@@ -1,0 +1,19 @@
+---
+'@jbpark/live-editor': patch
+---
+
+Consume `@jbpark/ui-kit`'s `CodeEditor` instead of a local CodeMirror surface
+
+The CodeMirror wiring (editor component, JS/TS + line-wrap extensions, the
+Cmd+S save transaction and the unified diff view) now comes from
+`@jbpark/ui-kit/CodeEditor` (#309, follow-up to ui-kit's #346). live-editor
+keeps its own glue — the debounced preview sync, error context, and the
+`raw`/`fragment`/`prettierOptions` prettier shaping — so the editor's public
+props and behaviour are unchanged.
+
+- `editor/core` is now a thin adapter that maps live-editor's vocabulary onto
+  `CodeEditor` (`onError` → `onFormatError`, `raw` skips the injected
+  formatter).
+- `diff-modal` uses `CodeEditor`'s `diff` prop rather than wiring
+  `unifiedMergeView` by hand.
+- Bumps `@jbpark/ui-kit` to `^9.0.0`.

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@jbpark/ui-kit": "^7.1.0",
+    "@jbpark/ui-kit": "^9.0.0",
     "@jbpark/use-hooks": "^4.0.1",
     "@uiw/codemirror-theme-vscode": "^4.25.11",
     "@uiw/react-codemirror": "^4.25.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.8)
       '@jbpark/ui-kit':
-        specifier: ^7.1.0
-        version: 7.1.0(@floating-ui/dom@1.8.0)(@tiptap/extensions@3.30.1(@tiptap/core@3.31.3(@tiptap/pm@3.30.1))(@tiptap/pm@3.30.1))(@tiptap/pm@3.30.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^9.0.0
+        version: 9.0.0(@codemirror/lang-javascript@6.2.5)(@codemirror/merge@6.12.2)(@floating-ui/dom@1.8.0)(@tiptap/extensions@3.30.1(@tiptap/core@3.31.3(@tiptap/pm@3.30.1))(@tiptap/pm@3.30.1))(@tiptap/pm@3.30.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@uiw/codemirror-theme-vscode@4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8))(@uiw/react-codemirror@4.25.11(@babel/runtime@8.0.0)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.6.0)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.8)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@jbpark/use-hooks':
         specifier: ^4.0.1
         version: 4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -704,11 +704,27 @@ packages:
     resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
-  '@jbpark/ui-kit@7.1.0':
-    resolution: {integrity: sha512-xabGZwN+6NrSyn2WrIRdaZfcQevZGZN0WluuPZWL7l28JeAx6Xi2YvOMQY9zlBNIcZva8eQ5j0ggDjcv5nreCg==}
+  '@jbpark/ui-kit@9.0.0':
+    resolution: {integrity: sha512-iCRKMcLfOtv/BZsOWn0QSots7GFPUQRtIA4n368j0l1Gi2ZxCxZ+EPtotMeDrFFsdzvNJoGL0YcSawS9P5G/Hw==}
     peerDependencies:
+      '@codemirror/lang-javascript': ^6.2.5
+      '@codemirror/merge': ^6.12.2
+      '@uiw/codemirror-theme-vscode': ^4.25.11
+      '@uiw/react-codemirror': ^4.25.11
+      codemirror: ^6.0.0
       react: ^19.0.0
       react-dom: ^19.0.0
+    peerDependenciesMeta:
+      '@codemirror/lang-javascript':
+        optional: true
+      '@codemirror/merge':
+        optional: true
+      '@uiw/codemirror-theme-vscode':
+        optional: true
+      '@uiw/react-codemirror':
+        optional: true
+      codemirror:
+        optional: true
 
   '@jbpark/use-hooks@4.0.1':
     resolution: {integrity: sha512-d+dRZRrwLUaOYiI8LGySqTEyewB+LWO+k0blb70xv0Gg2Ome9x3gxlXg0Dbjyq6mrVKzXOrHnpLY0uof3gZlaQ==}
@@ -4649,7 +4665,7 @@ snapshots:
       '@isaacs/balanced-match': 4.0.1
     optional: true
 
-  '@jbpark/ui-kit@7.1.0(@floating-ui/dom@1.8.0)(@tiptap/extensions@3.30.1(@tiptap/core@3.31.3(@tiptap/pm@3.30.1))(@tiptap/pm@3.30.1))(@tiptap/pm@3.30.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@jbpark/ui-kit@9.0.0(@codemirror/lang-javascript@6.2.5)(@codemirror/merge@6.12.2)(@floating-ui/dom@1.8.0)(@tiptap/extensions@3.30.1(@tiptap/core@3.31.3(@tiptap/pm@3.30.1))(@tiptap/pm@3.30.1))(@tiptap/pm@3.30.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(@uiw/codemirror-theme-vscode@4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8))(@uiw/react-codemirror@4.25.11(@babel/runtime@8.0.0)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.6.0)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.8)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@gsap/react': 2.1.2(gsap@3.15.0)(react@19.2.8)
       '@jbpark/use-hooks': 4.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -4685,6 +4701,12 @@ snapshots:
       swiper: 14.1.0
       tailwind-merge: 3.6.0
       vaul: 1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+    optionalDependencies:
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/merge': 6.12.2
+      '@uiw/codemirror-theme-vscode': 4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)
+      '@uiw/react-codemirror': 4.25.11(@babel/runtime@8.0.0)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.6.0)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.8)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      codemirror: 6.0.2
     transitivePeerDependencies:
       - '@floating-ui/dom'
       - '@tiptap/extensions'

--- a/src/components/editor/core.tsx
+++ b/src/components/editor/core.tsx
@@ -1,12 +1,6 @@
-import { useCallback, useRef } from 'react';
-
-import { javascript } from '@codemirror/lang-javascript';
+import CodeEditor from '@jbpark/ui-kit/CodeEditor';
 import { vscodeLight } from '@uiw/codemirror-theme-vscode';
-import CodeMirror, {
-  type Extension,
-  type ReactCodeMirrorRef,
-} from '@uiw/react-codemirror';
-import { EditorView } from 'codemirror';
+import { type Extension } from '@uiw/react-codemirror';
 
 import { cn } from '~/utils';
 
@@ -25,6 +19,11 @@ export interface Props {
   onError?: (error: string | null) => void;
 }
 
+// The CodeMirror surface, the Cmd+S save transaction and the JS/TS + line-wrap
+// extensions now live in `@jbpark/ui-kit`'s CodeEditor (#346/#309). This stays
+// only to keep live-editor's own vocabulary: `raw`/`fragment`/`prettierOptions`
+// shape the injected prettier formatter, and `onError` maps to the component's
+// `onFormatError`.
 const Core = ({
   value,
   theme,
@@ -34,73 +33,26 @@ const Core = ({
   fragment,
   raw,
   onChange,
-  onSave: _onSave,
+  onSave,
   onError,
   ...props
 }: Props) => {
-  const editorRef = useRef<ReactCodeMirrorRef>(null);
-
   const formatCode = useFormatCode({ fragment, prettierOptions });
 
-  const onSave = useCallback(
-    async (val: string) => {
-      try {
-        const currentView = editorRef.current?.view;
-        if (!currentView) {
-          return;
-        }
-
-        const currentLength = currentView.state.doc.length;
-        const cursorPos = currentView.state.selection.main.head;
-        const formattedCode = raw ? val : await formatCode(val);
-
-        if (currentLength === currentView.state.doc.length) {
-          const newCursorPos = Math.min(cursorPos, formattedCode.length);
-          const transaction = currentView.state.update({
-            changes: { from: 0, to: currentLength, insert: formattedCode },
-            selection: { anchor: newCursorPos },
-          });
-          currentView.dispatch(transaction);
-
-          onChange?.(formattedCode);
-          _onSave?.(formattedCode);
-        }
-
-        onError?.(null);
-      } catch (e) {
-        onError?.(e instanceof Error ? e.message : String(e));
-      }
-    },
-    [raw, formatCode, onChange, _onSave, onError],
-  );
-
-  const onKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-        e.preventDefault();
-        const currentValue =
-          editorRef.current?.view?.state.doc.toString() || value;
-        onSave(currentValue);
-      }
-    },
-    [onSave, value],
-  );
-
   return (
-    <div className={cn(className)} onKeyDown={onKeyDown}>
-      <CodeMirror
-        ref={editorRef}
-        theme={theme || vscodeLight}
-        height={height || '100%'}
-        value={value}
-        extensions={[
-          javascript({ jsx: true, typescript: true }),
-          EditorView.lineWrapping,
-        ]}
-        onChange={onChange}
-        {...props}
-      />
-    </div>
+    <CodeEditor
+      value={value}
+      theme={theme ?? vscodeLight}
+      height={height || '100%'}
+      className={cn(className)}
+      // `raw` (e.g. innerHTML) skips prettier; otherwise reuse the shared
+      // prettier wiring as the Cmd+S formatter rather than reimplementing it.
+      formatCode={raw ? undefined : formatCode}
+      onChange={onChange}
+      onSave={onSave}
+      onFormatError={onError}
+      {...props}
+    />
   );
 };
 

--- a/src/pages/editor/diff-modal.tsx
+++ b/src/pages/editor/diff-modal.tsx
@@ -1,9 +1,6 @@
-import { javascript } from '@codemirror/lang-javascript';
-import { unifiedMergeView } from '@codemirror/merge';
 import { Modal } from '@jbpark/ui-kit';
+import CodeEditor from '@jbpark/ui-kit/CodeEditor';
 import { vscodeLight } from '@uiw/codemirror-theme-vscode';
-import CodeMirror from '@uiw/react-codemirror';
-import { EditorView } from 'codemirror';
 
 interface Props {
   open: boolean;
@@ -14,7 +11,7 @@ interface Props {
 }
 
 // Read-only review step before persisting to localStorage — shows what
-// changed since the last save (unifiedMergeView diffs the editor's own
+// changed since the last save (the unified diff compares the editor's own
 // content against `original`), so the user can confirm the AST-transform
 // pipeline did what they expected before it's saved. Not an editing tool:
 // mergeControls/editable are both off, this is display-only.
@@ -30,16 +27,12 @@ const DiffModal = ({ open, original, current, onConfirm, onCancel }: Props) => {
       style={{ width: 800, maxWidth: '90vw' }}
     >
       <div className="max-h-[60vh] overflow-auto rounded border border-gray-200">
-        <CodeMirror
+        <CodeEditor
           value={current}
           theme={vscodeLight}
           editable={false}
           readOnly
-          extensions={[
-            javascript({ jsx: true, typescript: true }),
-            EditorView.lineWrapping,
-            unifiedMergeView({ original, mergeControls: false }),
-          ]}
+          diff={{ original, mergeControls: false }}
         />
       </div>
     </Modal>


### PR DESCRIPTION
Closes #309. Follow-up to pjb0811/ui-kit#346 (which shipped `@jbpark/ui-kit/CodeEditor`).

## Summary

Switch live-editor's editor to consume `@jbpark/ui-kit`'s `CodeEditor` instead of its own CodeMirror surface. The duplicated CodeMirror wiring — the editor component, the JS/TS + line-wrap extensions, the Cmd+S save transaction and the unified diff view — now lives in ui-kit. live-editor keeps its domain glue, so the editor's public props and behaviour are unchanged.

- **`editor/core`** is now a thin adapter over `CodeEditor`: it maps live-editor's vocabulary onto the component (`onError` → `onFormatError`, `raw` skips the injected prettier formatter) and injects `useFormatCode` as the `formatCode` prop. The `usePreview`/`useError`/debounce/`DEFAULT_TEMPLATE` glue in `editor.tsx` and the `useFormatCode` prettier shaping stay local, as planned in #309.
- **`diff-modal`** uses `CodeEditor`'s `diff` prop instead of hand-wiring `unifiedMergeView`.
- Bumps `@jbpark/ui-kit` to `^9.0.0` (the release that carries `CodeEditor` plus the Tag/Button and deprecated-alias changes).

The `@codemirror/*`, `codemirror` and `@uiw/*` packages stay in `dependencies` — they are now the optional peers `CodeEditor` needs rather than direct imports.

## Test plan
- [x] `check-types`, `lint`, `depcheck` clean
- [x] `test` — 424 passed
- [x] `build` clean
